### PR TITLE
Add route and code for layout based on mockups

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,13 +6,15 @@ import reportWebVitals from './reportWebVitals';
 // import { initialize } from '@veupathdb/wdk-client/lib/Core';
 import { initialize } from '@veupathdb/web-common/lib/bootstrap';
 import { RouteEntry } from '@veupathdb/wdk-client/lib/Core/RouteEntry';
-import { Redirect, RouteComponentProps } from 'react-router';
+import { RouteComponentProps } from 'react-router';
 import { EDASessionList, EDAWorkspace } from './lib/workspace';
 
 import '@veupathdb/wdk-client/lib/Core/Style/index.scss';
 import '@veupathdb/web-common/lib/styles/client.scss';
 import Header from './Header';
 import { MapVeuContainer } from './lib/mapveu';
+import { WorkspaceContainer } from './lib/workspace/WorkspaceContainer';
+import { Link } from '@veupathdb/wdk-client/lib/Components';
 
 initialize({
   rootUrl,
@@ -20,7 +22,19 @@ initialize({
   wrapRoutes: (routes: any): RouteEntry[] => [
     {
       path: '/',
-      component: () => <Redirect to="/eda/DS_841a9f5259" />,
+      component: () => (
+        <div>
+          <h1>EDA Links</h1>
+          <ul>
+            <li>
+              <Link to="/eda/DS_841a9f5259">Variables interface</Link>
+            </li>
+            <li>
+              <Link to="/eda-session/DS_841a9f5259">New Layout</Link>
+            </li>
+          </ul>
+        </div>
+      ),
     },
     {
       path: '/eda/:studyId/:sessionId',
@@ -33,6 +47,25 @@ initialize({
     },
     {
       path: '/eda/:studyId',
+      component: (props: RouteComponentProps<{ studyId: string }>) => (
+        <EDASessionList {...props.match.params} edaServiceUrl="/eda-service" />
+      ),
+    },
+    {
+      path: '/eda-session/:studyId/:sessionId',
+      exact: false,
+      component: (
+        props: RouteComponentProps<{ studyId: string; sessionId: string }>
+      ) => (
+        <WorkspaceContainer
+          {...props.match.params}
+          edaServiceUrl="/eda-service"
+        />
+      ),
+    },
+    {
+      path: '/eda-session/:studyId/',
+      exact: false,
       component: (props: RouteComponentProps<{ studyId: string }>) => (
         <EDASessionList {...props.match.params} edaServiceUrl="/eda-service" />
       ),

--- a/src/lib/core/hooks/entityCounts.ts
+++ b/src/lib/core/hooks/entityCounts.ts
@@ -3,7 +3,7 @@ import { Filter } from '../types/filter';
 import { usePromise } from './promise';
 import { useStudyMetadata, useSubsettingClient } from './workspace';
 
-export function useEntityCounts(filters: Filter[]) {
+export function useEntityCounts(filters?: Filter[]) {
   const { id, rootEntity } = useStudyMetadata();
   const subsettingClient = useSubsettingClient();
   return usePromise(async () => {
@@ -12,7 +12,7 @@ export function useEntityCounts(filters: Filter[]) {
       const { count } = await subsettingClient.getEntityCount(
         id,
         entity.id,
-        filters
+        filters ?? []
       );
       counts[entity.id] = count;
     }

--- a/src/lib/workspace/DefaultVariableRedirect.tsx
+++ b/src/lib/workspace/DefaultVariableRedirect.tsx
@@ -1,0 +1,17 @@
+import { useStudyMetadata } from '../core';
+import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
+import { Redirect, useRouteMatch } from 'react-router';
+
+export function DefaultVariableRedirect() {
+  const { url } = useRouteMatch();
+  const studyMetadata = useStudyMetadata();
+  const entities = Array.from(
+    preorder(studyMetadata.rootEntity, (e) => e.children || [])
+  );
+  const entity = entities[0];
+  const variable = entity && entity.variables.find((v) => v.dataShape != null);
+  if (entity == null || variable == null)
+    return <div>Could not find specified variable.</div>;
+  // Prevent <Variables> from rendering multiple times
+  return <Redirect to={`${url}/${entity.id}/${variable.id}`} />;
+}

--- a/src/lib/workspace/EDAWorkspace.scss
+++ b/src/lib/workspace/EDAWorkspace.scss
@@ -133,4 +133,31 @@
       margin-left: 1ex;
     }
   }
+
+  &-Subsetting {
+    padding: 1em 0;
+    display: flex;
+    justify-content: space-between;
+    gap: 1em;
+    > div {
+      flex: 1 auto;
+      &:last-of-type {
+        width: 100%;
+      }
+    }
+    .filter-param .field-detail {
+      margin: 0;
+      padding: 0;
+      width: auto;
+    }
+  }
+
+  &-VariableEntityHeader {
+    display: flex;
+    align-items: center;
+    gap: 1em;
+    > div {
+      font-size: 1.333em;
+    }
+  }
 }

--- a/src/lib/workspace/SessionList.tsx
+++ b/src/lib/workspace/SessionList.tsx
@@ -25,7 +25,7 @@ export function SessionList(props: Props) {
     updateSessionList();
   }, [updateSessionList]);
   const createNewSession = React.useCallback(async () => {
-    const newId = await sessionStore.createSession({
+    const { id } = await sessionStore.createSession({
       name: 'Unnamed Session',
       studyId,
       filters: [],
@@ -39,7 +39,7 @@ export function SessionList(props: Props) {
       pathname:
         history.location.pathname +
         (history.location.pathname.endsWith('/') ? '' : '/') +
-        newId,
+        id,
     };
     history.push(newLocation);
   }, [sessionStore, history, studyId]);

--- a/src/lib/workspace/SessionPanel.tsx
+++ b/src/lib/workspace/SessionPanel.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { cx } from './Utils';
+import { SessionSummary } from './SessionSummary';
+import { useSession } from '../core';
+import WorkspaceNavigation from '@veupathdb/wdk-client/lib/Components/Workspace/WorkspaceNavigation';
+import {
+  Redirect,
+  Route,
+  RouteComponentProps,
+  useRouteMatch,
+} from 'react-router';
+import { SubsettingRoute } from './Subsetting';
+import { DefaultVariableRedirect } from './DefaultVariableRedirect';
+
+interface Props {
+  sessionId: string;
+}
+
+export function SessionPanel(props: Props) {
+  const { sessionId } = props;
+  const {
+    session,
+    setName,
+    copySession,
+    saveSession,
+    deleteSession,
+  } = useSession(sessionId);
+  const { url: routeBase } = useRouteMatch();
+  if (session == null) return null;
+  return (
+    <div className={cx('-Session')}>
+      <WorkspaceNavigation
+        heading={
+          <SessionSummary
+            session={session}
+            setSessionName={setName}
+            copySession={copySession}
+            saveSession={saveSession}
+            deleteSession={deleteSession}
+          />
+        }
+        routeBase={routeBase}
+        items={[
+          {
+            display: 'Browse and subset',
+            route: '/variables',
+            exact: false,
+          },
+          {
+            display: 'Visualize',
+            route: '/visualizations',
+            exact: false,
+          },
+        ]}
+      />
+      <Route
+        path={routeBase}
+        exact
+        render={() => <Redirect to={`${routeBase}/variables`} />}
+      />
+      <Route
+        path={`${routeBase}/variables`}
+        exact
+        render={() => <DefaultVariableRedirect />}
+      />
+      <Route
+        path={`${routeBase}/variables/:entityId/:variableId`}
+        render={(
+          props: RouteComponentProps<{ entityId: string; variableId: string }>
+        ) => <SubsettingRoute sessionId={session.id} {...props.match.params} />}
+      />
+      <Route
+        path={`${routeBase}/visualizations`}
+        component={() => <h3>TODO</h3>}
+      />
+    </div>
+  );
+}

--- a/src/lib/workspace/Subsetting.tsx
+++ b/src/lib/workspace/Subsetting.tsx
@@ -1,0 +1,147 @@
+import {
+  SessionState,
+  StudyEntity,
+  StudyVariable,
+  useSession,
+  useStudyMetadata,
+} from '../core';
+import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
+import React, { useEffect } from 'react';
+import { useHistory } from 'react-router';
+import { cx } from './Utils';
+import { Variable } from './Variable';
+import { useEntityCounts } from '../core/hooks/entityCounts';
+import { VariableLink } from '../core/components/VariableLink';
+
+interface RouteProps {
+  sessionId: string;
+  entityId?: string;
+  variableId?: string;
+}
+
+export function SubsettingRoute(props: RouteProps) {
+  const { variableId, entityId, sessionId } = props;
+  const session = useSession(sessionId);
+  const studyMetadata = useStudyMetadata();
+  const history = useHistory();
+  const entities = Array.from(
+    preorder(studyMetadata.rootEntity, (e) => e.children || [])
+  );
+  const entity = entityId
+    ? entities.find((e) => e.id === entityId)
+    : entities[0];
+  const variable =
+    entity &&
+    ((variableId && entity.variables.find((v) => v.id === variableId)) ||
+      entity.variables.find((v) => v.dataShape != null));
+  useEffect(() => {
+    if (entity != null && variable != null) {
+      if (entityId == null)
+        history.replace(
+          `${history.location.pathname}/${entity.id}/${variable.id}`
+        );
+      else if (variableId == null)
+        history.replace(`${history.location.pathname}/${variable.id}`);
+    }
+  }, [entityId, variableId, entity, variable, history]);
+  if (entity == null || variable == null)
+    return <div>Could not find specified variable.</div>;
+  // Prevent <Variables> from rendering multiple times
+  if (entityId == null || variableId == null) return null;
+  return (
+    <Subsetting
+      sessionState={session}
+      entity={entity}
+      entities={entities}
+      variable={variable}
+    />
+  );
+}
+
+interface Props {
+  sessionState: SessionState;
+  entity: StudyEntity;
+  entities: StudyEntity[];
+  variable: StudyVariable;
+}
+
+export function Subsetting(props: Props) {
+  const { entity, entities, variable, sessionState } = props;
+  const totalCounts = useEntityCounts();
+  const filteredCounts = useEntityCounts(sessionState.session?.filters);
+  const totalEntityCount = totalCounts.value && totalCounts.value[entity.id];
+  const filteredEntityCount =
+    filteredCounts.value && filteredCounts.value[entity.id];
+  return (
+    <div className={cx('-Subsetting')}>
+      <div>
+        <h2>ENTITIES</h2>
+        <ul
+          style={{
+            border: '1px solid',
+            borderRadius: '.25em',
+            height: '80vh',
+            overflow: 'auto',
+            padding: '1em 2em',
+            margin: 0,
+          }}
+        >
+          {entities.map((e) => (
+            <li>
+              <VariableLink
+                replace
+                style={e.id === entity.id ? { fontWeight: 'bold' } : undefined}
+                entityId={e.id}
+                variableId={
+                  e.variables.find((v) => v.displayType != null)?.id ?? ''
+                }
+              >
+                {e.displayName}
+              </VariableLink>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h2>VARIABLES</h2>
+        <ul
+          style={{
+            border: '1px solid',
+            borderRadius: '.25em',
+            height: '80vh',
+            overflow: 'auto',
+            padding: '1em 2em',
+            margin: 0,
+          }}
+        >
+          {entity.variables.map(
+            (v) =>
+              v.dataShape && (
+                <li>
+                  <VariableLink
+                    replace
+                    style={
+                      v.id === variable.id ? { fontWeight: 'bold' } : undefined
+                    }
+                    entityId={entity.id}
+                    variableId={v.id}
+                  >
+                    {v.displayName} ({v.dataShape} {v.type})
+                  </VariableLink>
+                </li>
+              )
+          )}
+        </ul>
+      </div>
+      <div>
+        <Variable
+          entity={entity}
+          variable={variable}
+          sessionState={sessionState}
+          totalEntityCount={totalEntityCount}
+          filteredEntityCount={filteredEntityCount}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/workspace/Variable.tsx
+++ b/src/lib/workspace/Variable.tsx
@@ -1,0 +1,69 @@
+import {
+  Distribution,
+  StudyEntity,
+  StudyVariable,
+  SessionState,
+  useStudyMetadata,
+} from '../core';
+import { cx } from './Utils';
+
+interface Props {
+  entity: StudyEntity;
+  totalEntityCount?: number;
+  filteredEntityCount?: number;
+  variable: StudyVariable;
+  sessionState: SessionState;
+}
+
+export function Variable(props: Props) {
+  const {
+    entity,
+    variable,
+    filteredEntityCount,
+    totalEntityCount,
+    sessionState,
+  } = props;
+  const studyMetadata = useStudyMetadata();
+  const percent =
+    filteredEntityCount &&
+    totalEntityCount &&
+    (filteredEntityCount / totalEntityCount).toLocaleString(undefined, {
+      style: 'percent',
+    });
+  const filters = sessionState.session?.filters ?? [];
+  return (
+    <div>
+      <div className={cx('-VariableEntityHeader')}>
+        <h2>{entity.displayName}</h2>
+        <div>
+          Your subset includes {filteredEntityCount?.toLocaleString()}{' '}
+          {entity.displayName} ({percent}).
+        </div>
+      </div>
+      <div>
+        {sessionState.session?.filters.map((f) => (
+          <div key={`${f.entityId}_${f.variableId}`}>
+            <button
+              type="button"
+              onClick={() =>
+                sessionState.setFilters(filters.filter((_f) => _f !== f))
+              }
+            >
+              remove
+            </button>
+            <code>{JSON.stringify(f)}</code>
+          </div>
+        ))}
+      </div>
+      <div className="filter-param">
+        <Distribution
+          filters={sessionState.session?.filters}
+          onFiltersChange={sessionState.setFilters}
+          studyMetadata={studyMetadata}
+          entity={entity}
+          variable={variable}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/workspace/WorkspaceContainer.tsx
+++ b/src/lib/workspace/WorkspaceContainer.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback, useMemo } from 'react';
+import { useRouteMatch } from 'react-router';
+import { EDAWorkspaceContainer, SubsettingClient } from '../core';
+import { EDAWorkspaceHeading } from './EDAWorkspaceHeading';
+import { mockSessionStore } from './Mocks';
+import { SessionPanel } from './SessionPanel';
+import { cx } from './Utils';
+
+interface Props {
+  studyId: string;
+  sessionId: string;
+  edaServiceUrl: string;
+}
+export function WorkspaceContainer(props: Props) {
+  const { url } = useRouteMatch();
+  const subsettingClient: SubsettingClient = useMemo(
+    () =>
+      new (class extends SubsettingClient {
+        constructor() {
+          super({ baseUrl: props.edaServiceUrl });
+        }
+        async getStudyMetadata() {
+          return super.getStudyMetadata('GEMSCC0002-1');
+        }
+      })(),
+    [props.edaServiceUrl]
+  );
+
+  const makeVariableLink = useCallback(
+    (entityId: string, variableId: string) =>
+      `${url}/variables/${entityId}/${variableId}`,
+    [url]
+  );
+  return (
+    <EDAWorkspaceContainer
+      sessionId={props.sessionId}
+      studyId={props.studyId}
+      className={cx()}
+      sessionClient={mockSessionStore}
+      subsettingClient={subsettingClient}
+      makeVariableLink={makeVariableLink}
+    >
+      <EDAWorkspaceHeading />
+      <SessionPanel sessionId={props.sessionId} />
+    </EDAWorkspaceContainer>
+  );
+}


### PR DESCRIPTION
This PR implements the layout from the **Clinepi Workspace Mockups**. The primary interactive components are stubbed with minimally functional implementations.

**Details**
* Retains the `Variables` functional implementation for use as a stable component for development of other features.
* Adds new routes to make it easier to navigate to the different layouts.
* Entity and variable pickers are simple lists utilizing the `VariableLink` component.
* Filters list shows JSON of the `Fitler` object with a remove button.
* Filter interface is reusing the same as used by the WDK FitlerParam.