### PR TITLE
handled all four histogram requests but not tested yet

### DIFF
--- a/src/lib/core/api/data-service.ts
+++ b/src/lib/core/api/data-service.ts
@@ -10,6 +10,7 @@ import {
   array,
   type,
   tuple,
+  union,
   intersection,
   partial,
 } from 'io-ts';
@@ -76,7 +77,10 @@ const HistogramResponseData = array(
     }),
     partial({
       overlayVariableDetails: StringVariableValue,
-      facetVariableDetails: StringVariableValue,
+      facetVariableDetails: union([
+        tuple([StringVariableValue]),
+        tuple([StringVariableValue, StringVariableValue]),
+      ]),
     }),
   ])
 );

--- a/src/lib/core/api/data-service.ts
+++ b/src/lib/core/api/data-service.ts
@@ -3,49 +3,128 @@ import {
   createJsonRequest,
   FetchClient,
 } from '@veupathdb/web-common/lib/util/api';
-import { TypeOf, string, number, array, type, tuple } from 'io-ts';
+import {
+  TypeOf,
+  string,
+  number,
+  array,
+  type,
+  tuple,
+  intersection,
+  union,
+  undefined,
+} from 'io-ts';
 import { Filter } from '../types/filter';
+import { Variable, StringVariableValue } from '../types/variable';
 import { ioTransformer } from './ioTransformer';
 
-// TO DO: handle other three histogram queries and their responses
-export interface HistogramRequestParams {
+type NumBinsOrNumericWidth =
+  | {
+      numBins: number;
+      binWidth?: never;
+    }
+  | {
+      numBins?: undefined;
+      binWidth: number;
+    };
+
+export interface NumericHistogramRequestParams {
   studyId: string;
   filters: Filter[];
   //  derivedVariables:  // TO DO
   config: {
-    numBins: number;
     entityId: string;
     valueSpec: 'count' | 'proportion';
-    xAxisVariable: {
-      entityId: string;
-      variableId: string;
-    };
-  };
+    xAxisVariable: Variable;
+    overlayVariable?: Variable;
+    facetVariable?: Variable;
+    viewportMin?: number; // do we want some fancy both-or-none
+    viewportMax?: number; // constraint here?
+  } & NumBinsOrNumericWidth;
 }
 
-export type HistogramResponse = TypeOf<typeof HistogramResponse>;
-export const HistogramResponse = tuple([
-  array(
-    type({
-      binLabel: array(string),
-      binStart: array(string),
-      value: array(number),
-    })
-  ),
+type NumBinsOrDateWidth =
+  | {
+      numBins: number;
+      binWidth?: never;
+    }
+  | {
+      numBins?: undefined;
+      binWidth: string; // Dates widths are strings
+    };
+
+export interface DateHistogramRequestParams {
+  studyId: string;
+  filters: Filter[];
+  //  derivedVariables:  // TO DO
+  config: {
+    entityId: string;
+    valueSpec: 'count' | 'proportion';
+    xAxisVariable: Variable;
+    overlayVariable?: Variable;
+    facetVariable?: Variable;
+    viewportMin?: string;
+    viewportMax?: string;
+  } & NumBinsOrDateWidth;
+}
+
+const HistogramResponseData = array(
   type({
-    incompleteCases: array(number),
-    binSlider: type({
-      min: array(number),
-      max: array(number),
-      step: array(number),
-    }),
-    numBins: array(number),
-    xVariableDetails: type({
-      variableId: array(string),
-      entityId: array(string),
-    }),
+    binLabel: array(string),
+    binStart: array(string),
+    value: array(number),
+    overlayVariableDetails: StringVariableValue, // these may need to be optional
+    facetVariableDetails: StringVariableValue, // (which is tricky with io-ts...?)
+  })
+);
+
+const HistogramResponseBaseConfig = type({
+  incompleteCases: number,
+  binSlider: type({
+    min: number,
+    max: number,
+    step: number,
   }),
-]);
+  xVariableDetails: Variable,
+});
+
+// works for date or numeric 'num-bins' responses
+export type HistogramNumBinsResponse = TypeOf<typeof HistogramNumBinsResponse>;
+export const HistogramNumBinsResponse = type({
+  data: HistogramResponseData,
+  config: intersection([
+    HistogramResponseBaseConfig,
+    type({
+      numBins: number,
+    }),
+  ]),
+});
+
+export type NumericHistogramBinWidthResponse = TypeOf<
+  typeof NumericHistogramBinWidthResponse
+>;
+export const NumericHistogramBinWidthResponse = type({
+  data: HistogramResponseData,
+  config: intersection([
+    HistogramResponseBaseConfig,
+    type({
+      binWidth: number,
+    }),
+  ]),
+});
+
+export type DateHistogramBinWidthResponse = TypeOf<
+  typeof DateHistogramBinWidthResponse
+>;
+export const DateHistogramBinWidthResponse = type({
+  data: HistogramResponseData,
+  config: intersection([
+    HistogramResponseBaseConfig,
+    type({
+      binWidth: string,
+    }),
+  ]),
+});
 
 export interface BarplotRequestParams {
   studyId: string;
@@ -80,19 +159,60 @@ export const BarplotResponse = tuple([
 ]);
 
 export class DataClient extends FetchClient {
+  // Histogram
   getNumericHistogramNumBins(
-    params: HistogramRequestParams
-  ): Promise<HistogramResponse> {
+    params: NumericHistogramRequestParams
+  ): Promise<HistogramNumBinsResponse> {
     return this.fetch(
       createJsonRequest({
         method: 'POST',
         path: '/analyses/numeric-histogram-num-bins',
         body: params,
-        transformResponse: ioTransformer(HistogramResponse),
+        transformResponse: ioTransformer(HistogramNumBinsResponse),
       })
     );
   }
 
+  getNumericHistogramBinWidth(
+    params: NumericHistogramRequestParams
+  ): Promise<NumericHistogramBinWidthResponse> {
+    return this.fetch(
+      createJsonRequest({
+        method: 'POST',
+        path: '/analyses/numeric-histogram-bin-width',
+        body: params,
+        transformResponse: ioTransformer(NumericHistogramBinWidthResponse),
+      })
+    );
+  }
+
+  getDateHistogramNumBins(
+    params: DateHistogramRequestParams
+  ): Promise<HistogramNumBinsResponse> {
+    return this.fetch(
+      createJsonRequest({
+        method: 'POST',
+        path: '/analyses/date-histogram-num-bins',
+        body: params,
+        transformResponse: ioTransformer(HistogramNumBinsResponse),
+      })
+    );
+  }
+
+  getDateHistogramBinWidth(
+    params: DateHistogramRequestParams
+  ): Promise<DateHistogramBinWidthResponse> {
+    return this.fetch(
+      createJsonRequest({
+        method: 'POST',
+        path: '/analyses/date-histogram-bin-width',
+        body: params,
+        transformResponse: ioTransformer(DateHistogramBinWidthResponse),
+      })
+    );
+  }
+
+  // Barplot
   getBarplot(params: BarplotRequestParams): Promise<BarplotResponse> {
     return this.fetch(
       createJsonRequest({

--- a/src/lib/core/api/data-service.ts
+++ b/src/lib/core/api/data-service.ts
@@ -11,8 +11,7 @@ import {
   type,
   tuple,
   intersection,
-  union,
-  undefined,
+  partial,
 } from 'io-ts';
 import { Filter } from '../types/filter';
 import { Variable, StringVariableValue } from '../types/variable';
@@ -69,13 +68,17 @@ export interface DateHistogramRequestParams {
 }
 
 const HistogramResponseData = array(
-  type({
-    binLabel: array(string),
-    binStart: array(string),
-    value: array(number),
-    overlayVariableDetails: StringVariableValue, // these may need to be optional
-    facetVariableDetails: StringVariableValue, // (which is tricky with io-ts...?)
-  })
+  intersection([
+    type({
+      binLabel: array(string),
+      binStart: array(string),
+      value: array(number),
+    }),
+    partial({
+      overlayVariableDetails: StringVariableValue,
+      facetVariableDetails: StringVariableValue,
+    }),
+  ])
 );
 
 const HistogramResponseBaseConfig = type({

--- a/src/lib/core/components/Distribution.tsx
+++ b/src/lib/core/components/Distribution.tsx
@@ -13,7 +13,6 @@ import {
 import { useDataClient } from '../hooks/workspace';
 import { Filter as EdaFilter } from '../types/filter';
 import { Filter as WdkFilter } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/Types';
-import { HistogramResponse, BarplotResponse } from '../api/data-service';
 
 interface Props {
   studyMetadata: StudyMetadata;

--- a/src/lib/core/types/variable.ts
+++ b/src/lib/core/types/variable.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-redeclare */
+import * as t from 'io-ts';
+
+const _VariableBase = t.type({
+  entityId: t.string,
+  variableId: t.string,
+});
+
+export type Variable = t.TypeOf<typeof Variable>;
+export const Variable = _VariableBase;
+
+export type StringVariableValue = t.TypeOf<typeof StringVariableValue>;
+export const StringVariableValue = t.intersection([
+  _VariableBase,
+  t.type({
+    value: t.string,
+  }),
+]);


### PR DESCRIPTION
NOTE: merges into `add-data-adapter` not main!

Following the newly updated API specs here: https://veupathdb.github.io/EdaDataService/api.html

I made adapter methods for all four histogram endpoints.

I don't think it's going to work in practice because the responses will not always have 
`data[].overlayVariableDetails` or `data[].facetVariableDetails` in them, so the io-ts validator needs to be aware of that.

(and I just saw that the latter is an array - will fix this ASAP)