### PR TITLE
Subsetting date fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.17",
   "dependencies": {
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.2.10",
+    "@veupathdb/components": "^0.2.13",
     "@veupathdb/wdk-client": "^0.1.1-alpha.14",
     "@veupathdb/web-common": "^0.1.1-alpha.11",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -406,12 +406,11 @@ export function histogramResponseToData(
       ? parseFloat(response.config.binWidth as string) || 1
       : parseTimeDelta(response.config.binWidth as string);
   const { min, max, step } = response.config.binSlider;
-  // FIXME - remove max/100 when sorted
   const binWidthRange = (type === 'number'
     ? { min, max }
     : {
         min,
-        max: Math.floor(max / 100),
+        max,
         unit: (binWidth as TimeDelta)[1],
       }) as NumberOrTimeDeltaRange;
   const binWidthStep = step || 0.1;

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -358,27 +358,29 @@ function HistogramPlotWithControls({
         showBarValues={false}
         barLayout={barLayout}
       />
-      <HistogramControls
-        label="Histogram Controls"
-        valueType={data.valueType}
-        barLayout={barLayout}
-        displayLegend={false /* should not be a required prop */}
-        displayLibraryControls={displayLibraryControls}
-        opacity={opacity}
-        orientation={histogramProps.orientation}
-        binWidth={data.binWidth!}
-        selectedUnit={
-          data.binWidth && isTimeDelta(data.binWidth)
-            ? data.binWidth[1]
-            : undefined
-        }
-        onBinWidthChange={({ binWidth: newBinWidth }) => {
-          onBinWidthChange({ binWidth: newBinWidth });
-        }}
-        binWidthRange={data.binWidthRange!}
-        binWidthStep={data.binWidthStep!}
-        errorManagement={errorManagement}
-      />
+      {data.binWidth && data.binWidthRange && data.binWidthStep && (
+        <HistogramControls
+          label="Histogram Controls"
+          valueType={data.valueType}
+          barLayout={barLayout}
+          displayLegend={false /* should not be a required prop */}
+          displayLibraryControls={displayLibraryControls}
+          opacity={opacity}
+          orientation={histogramProps.orientation}
+          binWidth={data.binWidth}
+          selectedUnit={
+            data.binWidth && isTimeDelta(data.binWidth)
+              ? data.binWidth[1]
+              : undefined
+          }
+          onBinWidthChange={({ binWidth: newBinWidth }) => {
+            onBinWidthChange({ binWidth: newBinWidth });
+          }}
+          binWidthRange={data.binWidthRange}
+          binWidthStep={data.binWidthStep}
+          errorManagement={errorManagement}
+        />
+      )}
     </div>
   );
 }
@@ -401,7 +403,7 @@ export function histogramResponseToData(
 
   const binWidth =
     type === 'number'
-      ? parseInt(String(response.config.binWidth), 10) || 1
+      ? parseFloat(response.config.binWidth as string) || 1
       : parseTimeDelta(response.config.binWidth as string);
   const { min, max, step } = response.config.binSlider;
   // FIXME - remove max/100 when sorted
@@ -409,7 +411,7 @@ export function histogramResponseToData(
     ? { min, max }
     : {
         min,
-        max: max / 100,
+        max: Math.floor(max / 100),
         unit: (binWidth as TimeDelta)[1],
       }) as NumberOrTimeDeltaRange;
   const binWidthStep = step || 0.1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2880,10 +2880,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.2.10.tgz#b0a45a194ab6b2ae3fe2e4b44c7603b1d8e33995"
-  integrity sha512-KA4HOG7k/PPf9SHIXRYI2tlqoBXB+Tugi3f8fJtFIRApKDsMw8dsTjTql/mYNe1T84L8lrsBufzfHcHEzKLIww==
+"@veupathdb/components@^0.2.13":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.2.13.tgz#db1633f0915b8c54254022fcea19797f99808964"
+  integrity sha512-OgsCpLZeKRqxWMnw7u1LnnStV8YzImjxDpy38GKgn/Wi+9jy3f0eQI5mX8wtUIk5kCXR+d66dGxOA65HLvup8w==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
There are a few small fixes for HistogramVisualization too.

The binWidth slider works nicely now for all variables.  (The only issue is a back-end 500 when date binWidth is >= 10 months.)

All the date variables in GEMS bin to month resolution, so it hasn't been tested very hard for days/weeks/years etc.  When we do the zooming https://github.com/VEuPathDB/web-components/issues/70 we should get other date resolutions.

This PR depends on https://github.com/VEuPathDB/web-components/pull/91 

I acknowledge there's a fair bit of duplication between HistogramFilter and HistogramVisualisation - so that might be good to refactor some time.