### PR TITLE
Date to string fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.2.24",
+    "@veupathdb/components": "^0.2.30",
     "@veupathdb/wdk-client": "^0.1.1",
     "@veupathdb/web-common": "^0.1.1-alpha.11",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -33,10 +33,7 @@ import { StudyEntity, StudyMetadata } from '../../types/study';
 import { PromiseType } from '../../types/utility';
 import { gray, red } from './colors';
 import { HistogramVariable } from './types';
-import {
-  ISODateStringToZuluDate,
-  parseTimeDelta,
-} from '../../utils/date-conversion';
+import { parseTimeDelta, padISODateTime } from '../../utils/date-conversion';
 import { isTimeDelta } from '@veupathdb/components/lib/types/guards';
 
 type Props = {
@@ -171,12 +168,8 @@ export function HistogramFilter(props: Props) {
                   variableId: variable.id,
                   entityId: entity.id,
                   type: 'dateRange',
-                  min: (selectedRange as DateRange).min
-                    .toISOString()
-                    .slice(0, 19),
-                  max: (selectedRange as DateRange).max
-                    .toISOString()
-                    .slice(0, 19),
+                  min: padISODateTime((selectedRange as DateRange).min),
+                  max: padISODateTime((selectedRange as DateRange).max),
                 }
               : {
                   variableId: variable.id,
@@ -296,12 +289,7 @@ function HistogramPlotWithControls({
 
   const selectedRange = useMemo((): NumberOrDateRange | undefined => {
     if (filter == null) return;
-    return filter.type === 'numberRange'
-      ? { min: filter.min, max: filter.max }
-      : {
-          min: ISODateStringToZuluDate(filter.min),
-          max: ISODateStringToZuluDate(filter.max),
-        };
+    return { min: filter.min, max: filter.max } as NumberOrDateRange;
   }, [filter]);
 
   return (
@@ -362,21 +350,18 @@ function histogramResponseToDataSeries(
       `Expected a single data series, but got ${response.data.length}`
     );
   const data = response.data[0];
-  const bins = data.value
-    // FIXME Handle Dates properly
-    .map((_, index) => ({
-      binStart:
-        type === 'number'
-          ? Number(data.binStart[index])
-          : ISODateStringToZuluDate(data.binStart[index]),
-      binEnd:
-        type === 'number'
-          ? Number(data.binEnd[index])
-          : ISODateStringToZuluDate(data.binEnd[index]),
-      binLabel: data.binLabel[index],
-      count: data.value[index],
-    }))
-    .sort((a, b) => a.binStart.valueOf() - b.binStart.valueOf()); // TO DO: review necessity of sort if back end (or plot component) does sorting?
+  const bins = data.value.map((_, index) => ({
+    binStart:
+      type === 'number'
+        ? Number(data.binStart[index])
+        : String(data.binStart[index]),
+    binEnd:
+      type === 'number'
+        ? Number(data.binEnd[index])
+        : String(data.binEnd[index]),
+    binLabel: data.binLabel[index],
+    count: data.value[index],
+  }));
   return {
     name,
     color,

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -28,10 +28,7 @@ import { Filter } from '../../../types/filter';
 import { PromiseType } from '../../../types/utility';
 import { Variable } from '../../../types/variable';
 import { DataElementConstraint } from '../../../types/visualization';
-import {
-  ISODateStringToZuluDate,
-  parseTimeDelta,
-} from '../../../utils/date-conversion';
+import { parseTimeDelta } from '../../../utils/date-conversion';
 import { isHistogramVariable } from '../../filter/guards';
 import { HistogramVariable } from '../../filter/types';
 import { InputVariables } from '../InputVariables';
@@ -412,21 +409,18 @@ export function histogramResponseToData(
     series: response.data.map((data, index) => ({
       name: data.overlayVariableDetails?.value ?? `series ${index}`,
       // color: TO DO
-      bins: data.value
-        .map((_, index) => ({
-          binStart:
-            type === 'number'
-              ? Number(data.binStart[index])
-              : ISODateStringToZuluDate(data.binStart[index]),
-          binEnd:
-            type === 'number'
-              ? Number(data.binEnd[index])
-              : ISODateStringToZuluDate(data.binEnd[index]),
-          binLabel: data.binLabel[index],
-          count: data.value[index],
-        }))
-        .sort((a, b) => a.binStart.valueOf() - b.binStart.valueOf()),
-      // TO DO: review necessity of sort if back end (or plot component) does sorting?
+      bins: data.value.map((_, index) => ({
+        binStart:
+          type === 'number'
+            ? Number(data.binStart[index])
+            : String(data.binStart[index]),
+        binEnd:
+          type === 'number'
+            ? Number(data.binEnd[index])
+            : String(data.binEnd[index]),
+        binLabel: data.binLabel[index],
+        count: data.value[index],
+      })),
     })),
     valueType: type,
     binWidth,

--- a/src/lib/core/utils/date-conversion.ts
+++ b/src/lib/core/utils/date-conversion.ts
@@ -2,26 +2,26 @@ import { TimeDelta } from '@veupathdb/components/lib/types/general';
 import { isTimeUnit } from '@veupathdb/components/lib/types/guards';
 
 /**
- * Convenience function to get around issue with Firefox new Date() not being able to convert
- * 2001Z or 2001-01-01Z
+ * Convenience function to pad an incomplete date to Jan-01 as required
+ * and to add the time component (as midnight UTC/Zulu)
  */
-export function ISODateStringToZuluDate(ISODate: string): Date {
+export function padISODateTime(ISODate: string): string {
   // extend 2001 or 2001-02 to 2001-01-01 and 2001-02-01 respectively
-  let fixedISODate = ISODate;
-  while (fixedISODate.length === 4 || fixedISODate.length === 7) {
-    fixedISODate = fixedISODate + '-01';
+  let fixedISODateTime = ISODate;
+  while (fixedISODateTime.length === 4 || fixedISODateTime.length === 7) {
+    fixedISODateTime = fixedISODateTime + '-01';
   }
 
   // add the time as T00:00.000 if needed
-  if (fixedISODate.indexOf('T') < 0) {
-    fixedISODate = fixedISODate + 'T00:00';
+  if (fixedISODateTime.indexOf('T') < 0) {
+    fixedISODateTime = fixedISODateTime + 'T00:00';
   }
 
   // add the Z for Zulu time zone
-  if (!fixedISODate.endsWith('Z')) {
-    fixedISODate = fixedISODate + 'Z';
+  if (!fixedISODateTime.endsWith('Z')) {
+    fixedISODateTime = fixedISODateTime + 'Z';
   }
-  return new Date(fixedISODate);
+  return fixedISODateTime;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2880,10 +2880,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.2.24":
-  version "0.2.24"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.2.24.tgz#37050e4e87705a46a68244873cd98ebfc1494b5c"
-  integrity sha512-D2qmeh9t0ylca3XSqZcnjkdJ6mPTg1z8ABOUKRbvXVuPi1VKujoVVxKLuLBhipq8kf3/A6uiXZnxRuGzrbdruw==
+"@veupathdb/components@^0.2.30":
+  version "0.2.30"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.2.30.tgz#e0d3ea6646cdd79e2cfd572e72c66b8eef7e528f"
+  integrity sha512-0q9J09Uiw0NhT4qK1ijtxfRGxaWGkNf0AWAZS0zybey3W3oXrVxupXhTvkdo34l+dt5s9XFFdPAcBH6u2QuIlA==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Dates are now represented as strings.

Dates used in filters must be padded Zulu date-times, so padISODateTime() function modified from previous ISODateStringToZuluDate().

Requires https://github.com/VEuPathDB/web-components/pull/106 to compile/pass checks

Two bin sorts (on binStart) were removed from HistogramFilter and HistogramVisualization because Histogram itself now does a full sort of all bins (mainly to determine the min and max range for the x-axis).

Ready to merge if approved.