### PR TITLE
Scatter plot viz update

### DIFF
--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
-import { unknown } from '@veupathdb/wdk-client/lib/Utils/Json';
 import {
   createJsonRequest,
   FetchClient,

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -200,7 +200,12 @@ export interface ScatterplotRequestParams {
   filters: Filter[];
   config: {
     outputEntityId: string;
-    valueSpec: 'raw' | 'smoothedMean' | 'smoothedMeanWithRaw';
+    //DKDK add bestFitLineWithRaw
+    valueSpec:
+      | 'raw'
+      | 'smoothedMean'
+      | 'smoothedMeanWithRaw'
+      | 'bestFitLineWithRaw';
     // not quite sure of overlayVariable and facetVariable yet
     // facetVariable?: ZeroToTwoVariables;
     xAxisVariable: {
@@ -218,15 +223,19 @@ export interface ScatterplotRequestParams {
   };
 }
 
-// unlike API doc, data (response) shows seriesX, seriesY, intervalX, intervalY, intervalSE
+// unlike API doc, data (response) shows seriesX, seriesY, smoothedMeanX, smoothedMeanY, smoothedMeanSE
 const ScatterplotResponseData = array(
   partial({
-    // valueSpec = smoothedMean only returns interval data (no series data)
+    // valueSpec = smoothedMean only returns smoothedMean data (no series data)
     seriesX: array(number),
     seriesY: array(number),
-    intervalX: array(number),
-    intervalY: array(number),
-    intervalSE: array(number),
+    smoothedMeanX: array(number),
+    smoothedMeanY: array(number),
+    smoothedMeanSE: array(number),
+    //DKDK add bestFitLineWithRaw
+    bestFitLineX: array(number),
+    bestFitLineY: array(number),
+    r2: number,
     // need to make sure if below is correct (untested)
     overlayVariableDetails: type({
       entityId: string,

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -15,7 +15,6 @@ import {
   intersection,
   partial,
   Decoder,
-  Any,
 } from 'io-ts';
 import { Filter } from '../types/filter';
 import { Variable, StringVariableValue } from '../types/variable';

--- a/src/lib/core/components/computations/PassThroughComputation.tsx
+++ b/src/lib/core/components/computations/PassThroughComputation.tsx
@@ -24,7 +24,7 @@ const visualizationTypes: Record<string, VisualizationType> = {
   'numeric-histogram-bin-width': histogramVisualization,
   scatterplot: scatterplotVisualization,
   lineplot: scatterplotVisualization,
-  //DKDK placeholder for densityplot
+  // placeholder for densityplot
   // densityplot: scatterplotVisualization,
 };
 

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -671,10 +671,9 @@ function processInputData<T extends number | Date>(
         // set name as a string
         // name: 'Data' + (index + 1),
         // distinguish X/Y Data from Overlay
-        name:
-          el.overlayVariableDetails && el.overlayVariableDetails.value === 'Yes'
-            ? 'Overlay Data'
-            : 'X-Y Data',
+        name: el.overlayVariableDetails
+          ? el.overlayVariableDetails.value
+          : 'Data',
         // mode: 'markers',
         // mode: 'lines+markers',
         mode: modeValue,

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1,32 +1,17 @@
-//DKDK this may not be needed if import ScatterplotProps from Scatter plot component
-import PlotlyPlot, {
-  PlotProps,
-  ModebarDefault,
-} from '@veupathdb/components/lib/plots//PlotlyPlot';
-// need to export Scatterplot or add @types/plotly.js
-// import { Layout, PlotData } from 'plotly.js';
-
-//DKDK load src for changing, esp. props
+// load scatter plot component
 import ScatterAndLinePlotGeneral from '@veupathdb/components/lib/plots/ScatterAndLinePlotGeneral';
-// import ScatterAndLinePlotGeneral from '@veupathdb/components/src/plots/ScatterAndLinePlotGeneral';
-
 import { ErrorManagement } from '@veupathdb/components/lib/types/general';
-
-//DKDK import it from scatter plot component or may need to make a new ScatterplotData ts
-// import { HistogramData } from '@veupathdb/components/lib/types/plots';
 
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { getOrElse } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/function';
 import * as t from 'io-ts';
-import { isEqual } from 'lodash';
 import React, { useCallback, useMemo } from 'react';
 
-//DKDK need to set for Scatterplot
+// need to set for Scatterplot
 import {
   DataClient,
-  // ScatterplotResponse,
   ScatterplotRequestParams,
   LineplotRequestParams,
 } from '../../../api/data-api';
@@ -37,13 +22,9 @@ import { Filter } from '../../../types/filter';
 import { PromiseType } from '../../../types/utility';
 import { Variable } from '../../../types/variable';
 import { DataElementConstraint } from '../../../types/visualization';
-// import {
-//   ISODateStringToZuluDate,
-//   parseTimeDelta,
-// } from '../../../utils/date-conversion';
 
-//DKDK need to make ts for Scatterplot? need to know dataShape and type
-import { isScatterplotVariable } from '../../filter/guards';
+// tableVariable/isTableVariable fit to the condition of overlayVariable
+import { isScatterplotVariable, isTableVariable } from '../../filter/guards';
 import { ScatterplotVariable } from '../../filter/types';
 
 import { InputVariables } from '../InputVariables';
@@ -55,47 +36,6 @@ export const scatterplotVisualization: VisualizationType = {
   fullscreenComponent: FullscreenComponent,
   createDefaultConfig: createDefaultConfig,
 };
-
-//DKDK copy Scatter Plot props here for now instead of import
-
-// interface ScatterplotProps<T extends keyof PlotData> extends PlotProps {
-interface ScatterplotProps<T extends keyof any> extends PlotProps {
-  //DKDK temporarily set any before resolving @types/plotly.js
-  // data: Pick<PlotData, T>[];
-  data: any;
-  xLabel: string;
-  yLabel: string;
-  plotTitle: string;
-  //DKDK involving CI, x & y range may need to be set
-  xRange?: number[] | Date[];
-  yRange?: number[] | Date[];
-  showLegend?: boolean;
-}
-
-//DKDK from ScatterAndLinePlotGeneral component
-interface ScatterPlotData<T extends number | Date> {
-  data: Array<{
-    series: {
-      x: T[]; //DKDK perhaps string[] is better despite Date format, e.g., ISO format?
-      y: T[]; //DKDK will y data have a Date?
-      // popupContent?: string;
-    };
-    interval?: {
-      x: T[]; //DKDK perhaps string[] is better despite Date format, e.g., ISO format?
-      y: T[]; //DKDK will y data have a Date?
-      // orientation: string;
-      standardError: number[];
-    };
-    // color?: string;
-    // label: string;
-    // //DKDK for general scatter component
-    // showLines?: boolean;
-    // showMarkers?: boolean;
-    // fillArea?: boolean;
-    // useSpline?: boolean;
-  }>;
-  // opacity?: number;
-}
 
 function GridComponent(props: VisualizationProps) {
   const { visualization, computation, filters } = props;
@@ -109,7 +49,7 @@ function GridComponent(props: VisualizationProps) {
   );
 }
 
-//DKDK this needs a handling of text for scatter, line, and density plots
+// this needs a handling of text/image for scatter, line, and density plots
 function SelectorComponent() {
   return <div>Pick me, I'm a Scatter Plot!</div>;
 }
@@ -136,8 +76,7 @@ function FullscreenComponent(props: VisualizationProps) {
 
 function createDefaultConfig(): ScatterplotConfig {
   return {
-    //DKDK default is true but changed to false for scatterplot
-    enableOverlay: false,
+    enableOverlay: true,
   };
 }
 
@@ -149,11 +88,8 @@ const ScatterplotConfig = t.intersection([
   }),
   t.partial({
     xAxisVariable: Variable,
-    //DKDK yAxisVariable
     yAxisVariable: Variable,
     overlayVariable: Variable,
-    // binWidth: t.number,
-    // binWidthTimeUnit: t.string, // TO DO: constrain to weeks, months etc like Unit from date-arithmetic and/or R
   }),
 ]);
 
@@ -209,11 +145,9 @@ function ScatterplotViz(props: Props) {
         { entityId: string; variableId: string } | undefined
       >
     ) => {
-      //DKDK yAxisVariable
       const { xAxisVariable, yAxisVariable, overlayVariable } = values;
       updateVizConfig({
         xAxisVariable,
-        //DKDK yAxisVariable
         yAxisVariable,
         overlayVariable,
       });
@@ -232,15 +166,17 @@ function ScatterplotViz(props: Props) {
   );
 
   const data = usePromise(
-    //DKDK set any for now
+    // set any for now
     // useCallback(async (): Promise<ScatterplotData> => {
     useCallback(async (): Promise<any> => {
       const xAxisVariable = findVariable(vizConfig.xAxisVariable);
-      //DKDK yAxisVariable
       const yAxisVariable = findVariable(vizConfig.yAxisVariable);
-      //DKDK yAxisVariable
+      const overlayVariable = findVariable(vizConfig.overlayVariable);
+
+      // check variable inputs
       if (vizConfig.xAxisVariable == null || xAxisVariable == null)
         return Promise.reject(new Error('Please choose a X-axis variable'));
+      // isHistogramVariable may be used instead
       else if (!isScatterplotVariable(xAxisVariable))
         return Promise.reject(
           new Error(
@@ -255,45 +191,42 @@ function ScatterplotViz(props: Props) {
             `'${yAxisVariable.displayName}' is not suitable for this plot`
           )
         );
-
-      //DKDK add visualization.type here
+      // overlay
+      else if (
+        vizConfig.overlayVariable != null &&
+        overlayVariable != null &&
+        !isTableVariable(overlayVariable)
+      )
+        return Promise.reject(
+          new Error(
+            `'${overlayVariable.displayName}' is not suitable for this plot. Only categorical, binary, or ordinal type is allowed for the Overlay variable.`
+          )
+        );
+      // add visualization.type here. valueSpec too?
       const params = getRequestParams(
         studyId,
         filters ?? [],
         vizConfig.xAxisVariable,
-        //DKDK yAxisVariable
         vizConfig.yAxisVariable,
-        //DKDK overlay...
         vizConfig.enableOverlay ? vizConfig.overlayVariable : undefined,
-        //DKDK add visualization.type
+        // add visualization.type
         visualization.type
       );
 
-      // //DKDK
-      // console.log('params = ', params)
-      // console.log('computation = ', computation)
-
-      // const response = dataClient.getScatterplot(
-      //   computation.type,
-      //   params as ScatterplotRequestParams
-      // );
-
-      //DKDK scatterplot, lineplot
+      // scatterplot, lineplot
       const response =
         visualization.type === 'lineplot'
           ? dataClient.getLineplot(
               computation.type,
               params as LineplotRequestParams
             )
-          : //DKDK set default as scatterplot/getScatterplot
+          : // set default as scatterplot/getScatterplot
             dataClient.getScatterplot(
               computation.type,
               params as ScatterplotRequestParams
             );
 
-      // console.log('dataClient->response = ', response)
-
-      //DKDK send visualization.type as well
+      // send visualization.type as well
       return scatterplotResponseToData(await response, visualization.type);
     }, [
       studyId,
@@ -305,12 +238,12 @@ function ScatterplotViz(props: Props) {
     ])
   );
 
-  //DKDK
+  //
   console.log('const data = ', data);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      {/* DKDK change page title */}
+      {/*  change title at viz page */}
       {fullscreen &&
         (visualization.type === 'scatterplot' ? (
           <h1>Scatter Plot</h1>
@@ -331,12 +264,16 @@ function ScatterplotViz(props: Props) {
                 name: 'yAxisVariable',
                 label: 'y-axis variable',
               },
+              {
+                name: 'overlayVariable',
+                label: 'Overlay variable (Optional)',
+              },
             ]}
             entities={entities}
             values={{
               xAxisVariable: vizConfig.xAxisVariable,
-              //DKDK yAxisVariable
               yAxisVariable: vizConfig.yAxisVariable,
+              overlayVariable: vizConfig.overlayVariable,
             }}
             onChange={handleInputVariableChange}
             constraints={constraints}
@@ -369,28 +306,28 @@ function ScatterplotViz(props: Props) {
       {data.value ? (
         fullscreen ? (
           <ScatterplotWithControls
-            //DKDK data.value
+            // data.value
             data={[...data.value.dataSetProcess]}
             width={1000}
             height={600}
             xLabel={findVariable(vizConfig.xAxisVariable)?.displayName}
             yLabel={findVariable(vizConfig.yAxisVariable)?.displayName}
-            plotTitle={''}
             xRange={[data.value.xMin, data.value.xMax]}
             yRange={[data.value.yMin, data.value.yMax]}
           />
         ) : (
           // thumbnail/grid view
           <ScatterAndLinePlotGeneral
-            //DKDK data.value
             data={[...data.value.dataSetProcess]}
-            width={350}
-            height={280}
-            xLabel={'xLabel'}
-            yLabel={'yLabel'}
-            plotTitle={'plotTitle'}
+            width={230}
+            height={150}
             xRange={[data.value.xMin, data.value.xMax]}
             yRange={[data.value.yMin, data.value.yMax]}
+            // new props for better displaying grid view
+            displayLegend={false}
+            displayLibraryControls={false}
+            staticPlot={true}
+            margin={{ l: 40, r: 20, b: 20, t: 10 }}
           />
         )
       ) : (
@@ -406,17 +343,13 @@ function ScatterplotViz(props: Props) {
   );
 }
 
-// //DKDK block for now
-// type ScatterplotWithControlsProps = ScatterplotProps
-
 function ScatterplotWithControls({
   data,
   ...ScatterplotProps
-}: //DKDK
+}: //
 // }: ScatterplotWithControlsProps) {
 any) {
   // TODO Use UIState
-  const displayLibraryControls = false;
   const errorManagement = useMemo((): ErrorManagement => {
     return {
       errors: [],
@@ -426,24 +359,22 @@ any) {
     };
   }, []);
 
-  //DKDK
-  console.log('ScatterplotWithControls.data = ', data);
+  // console.log('ScatterplotWithControls.data = ', data);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <ScatterAndLinePlotGeneral
         {...ScatterplotProps}
         data={data}
-        displayLibraryControls={displayLibraryControls}
+        // add controls
+        displayLegend={true}
+        displayLibraryControls={false}
       />
     </div>
   );
-  //DKDK making a control later
+  // making a control later
   // <ScatterplotControls
-  //   label="Scatter Plot Controls"
-  //   valueType={data.valueType}
-  //   displayLegend={false /* should not be a required prop */}
-  //   displayLibraryControls={displayLibraryControls}
+  //   label="Scatter plot control"
   //   errorManagement={errorManagement}
   // />
 }
@@ -454,22 +385,23 @@ any) {
  * @returns ScatterplotData
  */
 export function scatterplotResponseToData(
-  //DKDK getScatterplot may also need to be changed in the future for hosting other plots
-  // response: PromiseType<ReturnType<DataClient['getScatterplot']>> | PromiseType<ReturnType<DataClient['getLineplot']>>,
   response: PromiseType<
     ReturnType<DataClient['getScatterplot'] | DataClient['getLineplot']>
   >,
-  //DKDK vizType is visualization.type. This may be used for handling other plots in this component like line and density
+  // vizType may be used for handling other plots in this component like line and density
   vizType: string
 ): any {
   // if (response.data.length === 0)
   //   throw Error(`Expected one or more data series, but got zero`);
   // else console.log('Im at scatterplotResponseToData');
 
-  console.log('visualization type at scatterplotResponseToData = ', vizType);
-  console.log('response.data =', response);
+  // if ((vizType === 'scatterplot' && response.scatterplot.data.length === 0) || (vizType === 'lineplot' && response.lineplot.data.length === 0))
+  //   throw Error(`Expected one or more data series, but got zero`);
 
-  const modeValue = vizType === 'lineplot' ? 'lines' : 'markers'; //DKDK for scatter plot
+  // console.log('visualization type at scatterplotResponseToData = ', vizType);
+  // console.log('response.data =', response);
+
+  const modeValue = vizType === 'lineplot' ? 'lines' : 'markers'; // for scatter plot
 
   const { dataSetProcess, xMin, xMax, yMin, yMax } = processInputData(
     response,
@@ -477,8 +409,7 @@ export function scatterplotResponseToData(
     modeValue
   );
 
-  console.log('dataSetProcess =', dataSetProcess);
-  console.log('xMin, xMax, yMin, yMax =', xMin, xMax, yMin, yMax);
+  // console.log('dataSet Process = ', dataSetProcess)  ;
 
   return {
     dataSetProcess: dataSetProcess,
@@ -489,7 +420,7 @@ export function scatterplotResponseToData(
   };
 }
 
-//DKDK add an extended type
+// add an extended type
 type getRequestParamsProps =
   | (ScatterplotRequestParams & { vizType?: string })
   | (LineplotRequestParams & { vizType?: string });
@@ -500,7 +431,7 @@ function getRequestParams(
   xAxisVariable: Variable,
   yAxisVariable?: Variable,
   overlayVariable?: Variable,
-  //DKDK add visualization.type
+  // add visualization.type
   vizType?: string
 ): getRequestParamsProps {
   if (vizType === 'lineplot') {
@@ -508,94 +439,103 @@ function getRequestParams(
       studyId,
       filters,
       config: {
-        //DKDK is outputEntityId correct?
+        // is outputEntityId correct?
         outputEntityId: xAxisVariable.entityId,
         xAxisVariable: xAxisVariable,
         yAxisVariable: yAxisVariable,
+        overlayVariable: overlayVariable,
       },
     } as LineplotRequestParams;
   } else {
-    //DKDK scatterplot
+    // scatterplot
     return {
       studyId,
       filters,
       config: {
-        //DKDK is outputEntityId correct?
+        // is outputEntityId correct?
         outputEntityId: xAxisVariable.entityId,
-        //DKDK valueSpect may be used in the future
+        // valueSpect may be used in the future
         // valueSpec: 'raw',
         // valueSpec: 'smoothedMean',
         valueSpec: 'smoothedMeanWithRaw',
-        // smoothedMean: true,
         xAxisVariable: xAxisVariable,
         yAxisVariable: yAxisVariable,
+        overlayVariable: overlayVariable,
       },
     } as ScatterplotRequestParams;
   }
 }
 
-//DKDK making plotly input data
+// making plotly input data
 function processInputData<T extends number | Date>(
-  //DKDK any
+  // any
   // dataSet: VEuPathDBScatterPlotData<T>
   dataSet: any,
-  //DKDK use vizType or perhaps use different argument when calling processInputData?
   vizType: string,
-  //DKDK line, marker,
+  // line, marker,
   modeValue: string
 ) {
-  console.log('dataSet =', dataSet);
+  // console.log('dataSet =', dataSet)
 
-  //DKDK set fillAreaValue
+  // set fillAreaValue
   const fillAreaValue = '';
 
-  //DKDK distinguish data per Viztype
+  // distinguish data per Viztype
   const plotDataSet =
     vizType === 'lineplot'
-      ? //DKDK lineplot
-        dataSet.lineplot
+      ? //DKDK backend issue for lineplot returning scatterplot currently
+        // dataSet.lineplot
+        dataSet.scatterplot
       : dataSet.scatterplot;
 
-  //DKDK set a default color
+  // set a default color
   const defaultColor: string = '#00b0f6';
-  //DKDK set global Opacity value
+  // set global Opacity value
   const globalOpacity = 1;
-  // //DKDK an example data: data are assumed to be number type only
+  // // an example data: data are assumed to be number type only
   // const orientationValue = 'y';
 
-  //DKDK set variables for x- and yaxis ranges
+  // set variables for x- and yaxis ranges
   let xMin: number | Date = 0;
   let xMax: number | Date = 0;
   let yMin: number | Date = 0;
   let yMax: number | Date = 0;
 
+  // set marker colors: rgb values
+  const markerColors = [
+    '26, 190, 255', // #1abeff
+    '255, 153, 51', // #ff9966
+  ];
+
+  // set fitted line and CI colors: rgb values
+  const boundColors = [
+    '0, 128, 179', // #0080b3
+    '204, 102, 0', // #cc6600
+  ];
+
   let dataSetProcess: Array<{}> = [];
   // dataSet.data.forEach(function (el: any, index: number) {
   plotDataSet.data.forEach(function (el: any, index: number) {
-    //DKDK initialize variables: setting with union type for future, but this causes typescript issue in the current version
+    // initialize variables: setting with union type for future, but this causes typescript issue in the current version
     let xSeriesValue: T[] = [];
     let ySeriesValue: T[] = [];
     let xIntervalLineValue: T[] = [];
     let yIntervalLineValue: T[] = [];
-    let standardErrorValue: T[] = []; //DKDK this is for standardError
+    let standardErrorValue: T[] = []; // this is for standardError
     let xIntervalBounds: T[] = [];
     let yIntervalBounds: T[] = [];
 
-    //DKDK set rgbValue here per dataset with a default color
+    // set rgbValue here per dataset with a default color
     let rgbValue: number[] = el.color
       ? hexToRgb(el.color)
       : hexToRgb(defaultColor);
     let scatterPointColor: string = '';
     let fittingLineColor: string = '';
     let intervalColor: string = '';
-    //DKDK set line and marker variable - get these as args
-    // let modeValue: string = '';
-    // let splineValue: string = '';
-    // let fillAreaValue: string = '';
 
-    //DKDK series is for scatter plot
+    // series is for scatter plot
     if (el.seriesX && el.seriesY) {
-      //DKDK check the number of x = number of y
+      // check the number of x = number of y
       if (el.seriesX.length !== el.seriesY.length) {
         console.log(
           'x length=',
@@ -603,13 +543,13 @@ function processInputData<T extends number | Date>(
           '  y length=',
           el.seriesY.length
         );
-        alert('The number of X data is not equal to the number of Y data');
+        // alert('The number of X data is not equal to the number of Y data');
         throw new Error(
           'The number of X data is not equal to the number of Y data'
         );
       }
 
-      //DKDK probably no need to have this for series data, though
+      // probably no need to have this for series data, though
       //1) combine the arrays:
       let combinedArray = [];
       for (let j = 0; j < el.seriesX.length; j++) {
@@ -629,13 +569,13 @@ function processInputData<T extends number | Date>(
       }
 
       /*
-       * DKDK set variables for x-/y-axes ranges including x,y data points: considering Date data for X as well
+       * Set variables for x-/y-axes ranges including x,y data points: considering Date data for X as well
        * This is for finding global min/max values among data arrays for better display of the plot(s)
        */
-      //DKDK check if this X array consists of numbers & add type assertion
+      // check if this X array consists of numbers & add type assertion
       if (isArrayOfNumbers(xSeriesValue)) {
         if (index == 0) {
-          //DKDK need to set initial xMin/xMax
+          // need to set initial xMin/xMax
           xMin = xSeriesValue[0];
           xMax = xSeriesValue[xSeriesValue.length - 1];
         } else {
@@ -649,9 +589,9 @@ function processInputData<T extends number | Date>(
               : Math.max(...(xSeriesValue as number[]));
         }
       } else {
-        //DKDK this array consists of Dates
+        // this array consists of Dates
         if (index == 0) {
-          //DKDK to set initial min/max Date values for Date[]
+          // to set initial min/max Date values for Date[]
           xMin = getMinDate(xSeriesValue as Date[]);
           xMax = getMaxDate(xSeriesValue as Date[]);
         } else {
@@ -676,7 +616,7 @@ function processInputData<T extends number | Date>(
         }
       }
 
-      //DKDK check if this Y array consists of numbers & add type assertion
+      // check if this Y array consists of numbers & add type assertion
       if (isArrayOfNumbers(ySeriesValue)) {
         yMin =
           yMin < Math.min(...ySeriesValue) ? yMin : Math.min(...ySeriesValue);
@@ -684,7 +624,7 @@ function processInputData<T extends number | Date>(
           yMax > Math.max(...ySeriesValue) ? yMax : Math.max(...ySeriesValue);
       } else {
         if (index == 0) {
-          //DKDK to set initial Date value for Date[]
+          // to set initial Date value for Date[]
           yMin = getMinDate(ySeriesValue as Date[]);
           yMax = getMaxDate(ySeriesValue as Date[]);
         } else {
@@ -699,7 +639,7 @@ function processInputData<T extends number | Date>(
         }
       }
 
-      //DKDK use global opacity for coloring
+      // use global opacity for coloring
       scatterPointColor =
         'rgba(' +
         rgbValue[0] +
@@ -708,36 +648,63 @@ function processInputData<T extends number | Date>(
         ',' +
         rgbValue[2] +
         ',' +
-        globalOpacity +
-        ')'; //DKDK set alpha/opacity as 0.2 for CI
+        // globalOpacity +
+        '0' +
+        ')'; // set alpha/opacity as 0.2 for CI
 
-      //DKDK add scatter data considering input options
+      const scatterPointColor1 =
+        'rgba(' +
+        rgbValue[0] +
+        ',' +
+        rgbValue[1] +
+        ',' +
+        rgbValue[2] +
+        ',' +
+        // globalOpacity +
+        '1' +
+        ')'; // set alpha/opacity as 0.2 for CI
+
+      // add scatter data considering input options
       dataSetProcess.push({
         x: xSeriesValue,
         y: ySeriesValue,
-        //DKDK set name as a string
-        name: 'data',
+        // set name as a string
+        // name: 'Data' + (index + 1),
+        // distinguish X/Y Data from Overlay
+        name:
+          el.overlayVariableDetails && el.overlayVariableDetails.value === 'Yes'
+            ? 'Overlay Data'
+            : 'X-Y Data',
         // mode: 'markers',
         // mode: 'lines+markers',
         mode: modeValue,
         // type: 'scattergl',
         type: 'scatter',
         fill: fillAreaValue,
-        marker: { color: scatterPointColor, size: 12 },
-        //DKDK always use spline
-        line: { color: scatterPointColor, shape: 'spline' },
+        // marker border only
+        // marker: { color: scatterPointColor, size: 12 },
+        // marker: { color: scatterPointColor, size: 12,
+        //   line: {color: scatterPointColor1, width: 2} },
+        marker: {
+          color: 'rgba(' + markerColors[index] + ',0)',
+          size: 12,
+          line: { color: 'rgba(' + markerColors[index] + ',1)', width: 2 },
+        },
+        // this needs to be here for the case of markers with line or lineplot.
+        // always use spline?
+        line: { color: 'rgba(' + markerColors[index] + ',1)', shape: 'spline' },
       });
     }
 
-    //DKDK check if interval prop exists
+    // check if interval prop exists
     if (el.intervalX && el.intervalY && el.intervalSE) {
-      //DKDK check the number of x = number of y or standardError
+      // check the number of x = number of y or standardError
       if (el.intervalX.length !== el.intervalY.length) {
         throw new Error(
           'The number of X data is not equal to the number of Y data or standardError data'
         );
       }
-      //DKDK sorting function
+      // sorting function
       //1) combine the arrays: including standardError
       let combinedArrayInterval = [];
       for (let j = 0; j < el.intervalX.length; j++) {
@@ -758,9 +725,9 @@ function processInputData<T extends number | Date>(
         standardErrorValue[k] = combinedArrayInterval[k].zValue;
       }
 
-      //DKDK set variables for x-/y-axes ranges including fitting line
+      // set variables for x-/y-axes ranges including fitting line
       if (isArrayOfNumbers(xIntervalLineValue)) {
-        //DKDK add additional condition for the case of smoothedMean (without series data)
+        // add additional condition for the case of smoothedMean (without series data)
         xMin = el.seriesX
           ? xMin < Math.min(...xIntervalLineValue)
             ? xMin
@@ -785,7 +752,7 @@ function processInputData<T extends number | Date>(
       }
 
       if (isArrayOfNumbers(yIntervalLineValue)) {
-        //DKDK add additional condition for the case of smoothedMean (without series data)
+        // add additional condition for the case of smoothedMean (without series data)
         yMin = el.seriesY
           ? yMin < Math.min(...yIntervalLineValue)
             ? yMin
@@ -815,9 +782,9 @@ function processInputData<T extends number | Date>(
       const xMaxCheck = isArrayOfNumbers(xIntervalLineValue)
         ? Math.max(...xIntervalLineValue)
         : null;
-      console.log('xMin xMax at process function =', xMinCheck, xMinCheck);
+      console.log('xMin xMax at process function =', xMinCheck, xMaxCheck);
 
-      //DKDK use global opacity for coloring
+      // use global opacity for coloring
       // fittingLineColor =
       //   'rgba(' +
       //   rgbValue[0] +
@@ -830,21 +797,29 @@ function processInputData<T extends number | Date>(
       //   ')';
       fittingLineColor = 'rgba(144,12,63,' + globalOpacity + ')';
 
-      //DKDK store data for fitting line: this is not affected by plot options (e.g., showLine etc.)
+      // store data for fitting line: this is not affected by plot options (e.g., showLine etc.)
       dataSetProcess.push({
         x: xIntervalLineValue,
         y: yIntervalLineValue,
-        name: 'fitted line',
+        // name: 'Data' +  + (index + 1) + ' Fitted line',
+        name: 'Smoothed line',
+        // name: (el.overlayVariableDetails && el.overlayVariableDetails.value === 'Yes') ?
+        //   'Overlay fitted line'
+        //   : 'X-Y Data fitted line',
         // mode: 'lines+markers',
-        mode: 'lines', //DKDK no data point is displayed: only line
+        mode: 'lines', // no data point is displayed: only line
         // type: 'line',
         // line: {color: el.color, shape: 'spline',  width: 5 },
-        //DKDK line width
-        line: { color: fittingLineColor, shape: 'spline', width: 2 },
-        // line: { shape: 'spline', width: 2 },
+        // line width
+        // line: { color: fittingLineColor, shape: 'spline', width: 2 },
+        line: {
+          color: 'rgba(' + boundColors[index] + ',1)',
+          shape: 'spline',
+          width: 2,
+        },
       });
 
-      //DKDK make Confidence Interval (CI) or Bounds (filled area)
+      // make Confidence Interval (CI) or Bounds (filled area)
       xIntervalBounds = xIntervalLineValue;
       xIntervalBounds = xIntervalBounds.concat(
         xIntervalLineValue.map((element: any) => element).reverse()
@@ -852,7 +827,7 @@ function processInputData<T extends number | Date>(
 
       console.log('xMin xMax =', xMin, xMax);
 
-      //DKDK need to compare xMin/xMax
+      // need to compare xMin/xMax
       xMin =
         xMin < Math.min(...xIntervalBounds.map(Number))
           ? xMin
@@ -862,9 +837,9 @@ function processInputData<T extends number | Date>(
           ? xMax
           : Math.max(...xIntervalBounds.map(Number));
 
-      //DKDK finding upper and lower bound values.
+      // finding upper and lower bound values.
       const { yUpperValues, yLowerValues } = getBounds(
-        //DKDK scatterplot - use yIntervalLineValue
+        // scatterplot - use yIntervalLineValue
         // el.interval.orientation === 'x'
         // ? xIntervalLineValue
         // : yIntervalLineValue,
@@ -872,18 +847,18 @@ function processInputData<T extends number | Date>(
         standardErrorValue
       );
 
-      //DKDK make upper and lower bounds plotly format
+      // make upper and lower bounds plotly format
       yIntervalBounds = yUpperValues;
       yIntervalBounds = yIntervalBounds.concat(
         yLowerValues.map((element: any) => element).reverse()
       );
 
-      //DKDK set alpha/opacity as 0.2 for CI
+      // set alpha/opacity as 0.2 for CI
       // intervalColor =
       //   'rgba(' + rgbValue[0] + ',' + rgbValue[1] + ',' + rgbValue[2] + ',0.2)';
       intervalColor = 'rgba(144,12,63,0.2)';
 
-      //DKDK set variables for x-/y-axes ranges including CI/bounds: no need for x data as it was compared before
+      // set variables for x-/y-axes ranges including CI/bounds: no need for x data as it was compared before
       yMin =
         yMin < Math.min(...yLowerValues.map(Number))
           ? yMin
@@ -893,20 +868,25 @@ function processInputData<T extends number | Date>(
           ? yMax
           : Math.max(...yUpperValues.map(Number));
 
-      //DKDK store data for CI/bounds
+      // store data for CI/bounds
       dataSetProcess.push({
         x: xIntervalBounds,
         y: yIntervalBounds,
+        // name: 'Data' +  (index + 1) + ' Confidence interval',
         name: 'Confidence interval',
+        // name: (el.overlayVariableDetails && el.overlayVariableDetails.value === 'Yes') ?
+        //   'Overlay confidence interval'
+        //   : 'X-Y Data confidence interval',
         fill: 'tozerox',
-        fillcolor: intervalColor,
-        // opacity: 0.4,  //DKDK this works
+        // fillcolor: intervalColor,
+        fillcolor: 'rgba(' + boundColors[index] + ',0.2)',
+        // opacity: 0.4,  // this works
         type: 'line',
-        line: { color: 'transparent', shape: 'spline' }, //DKDK here, line means upper and lower bounds
+        line: { color: 'transparent', shape: 'spline' }, // here, line means upper and lower bounds
       });
     }
 
-    //DKDK determine y-axis range for numbers only: x-axis should be in the range of [xMin,xMax] due to CI plot
+    // determine y-axis range for numbers only: x-axis should be in the range of [xMin,xMax] due to CI plot
     if (typeof yMin == 'number' && typeof yMax == 'number') {
       yMin = yMin < 0 ? Math.floor(yMin) : Math.ceil(yMin);
       yMax = yMax < 0 ? Math.floor(yMax) : Math.ceil(yMax);
@@ -916,8 +896,8 @@ function processInputData<T extends number | Date>(
   return { dataSetProcess, xMin, xMax, yMin, yMax };
 }
 
-//DKDK util functions for processInputData()
-//DKDK change HTML hex code to rgb array
+// util functions for processInputData()
+// change HTML hex code to rgb array
 const hexToRgb = (hex?: string): [number, number, number] => {
   if (!hex) return [0, 0, 0];
   const fullHex = hex.replace(
@@ -935,9 +915,9 @@ const hexToRgb = (hex?: string): [number, number, number] => {
   ];
 };
 
-//DKDK check number array and if empty
+// check number array and if empty
 function isArrayOfNumbers(value: any): value is number[] {
-  //DKDK value.length !==0
+  // value.length !==0
   return (
     Array.isArray(value) &&
     value.length !== 0 &&

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -458,6 +458,8 @@ function getRequestParams(
         // valueSpec: 'raw',
         // valueSpec: 'smoothedMean',
         valueSpec: 'smoothedMeanWithRaw',
+        //DKDK add bestFitLineWithRaw
+        // valueSpec: 'bestFitLineWithRaw',
         xAxisVariable: xAxisVariable,
         yAxisVariable: yAxisVariable,
         overlayVariable: overlayVariable,
@@ -695,10 +697,10 @@ function processInputData<T extends number | Date>(
       });
     }
 
-    // check if interval prop exists
-    if (el.intervalX && el.intervalY && el.intervalSE) {
+    // check if smoothedMean prop exists
+    if (el.smoothedMeanX && el.smoothedMeanY && el.smoothedMeanSE) {
       // check the number of x = number of y or standardError
-      if (el.intervalX.length !== el.intervalY.length) {
+      if (el.smoothedMeanX.length !== el.smoothedMeanY.length) {
         throw new Error(
           'The number of X data is not equal to the number of Y data or standardError data'
         );
@@ -706,11 +708,11 @@ function processInputData<T extends number | Date>(
       // sorting function
       //1) combine the arrays: including standardError
       let combinedArrayInterval = [];
-      for (let j = 0; j < el.intervalX.length; j++) {
+      for (let j = 0; j < el.smoothedMeanX.length; j++) {
         combinedArrayInterval.push({
-          xValue: el.intervalX[j],
-          yValue: el.intervalY[j],
-          zValue: el.intervalSE[j],
+          xValue: el.smoothedMeanX[j],
+          yValue: el.smoothedMeanY[j],
+          zValue: el.smoothedMeanSE[j],
         });
       }
       //2) sort:
@@ -801,7 +803,7 @@ function processInputData<T extends number | Date>(
         x: xIntervalLineValue,
         y: yIntervalLineValue,
         // name: 'Data' +  + (index + 1) + ' Fitted line',
-        name: 'Smoothed line',
+        name: 'Smoothed mean',
         // name: (el.overlayVariableDetails && el.overlayVariableDetails.value === 'Yes') ?
         //   'Overlay fitted line'
         //   : 'X-Y Data fitted line',


### PR DESCRIPTION
Several updates are made:

a) with the update of props for the scatter plot component (see this [approved and merged PR](https://github.com/VEuPathDB/web-components/pull/115)), some props are added for better displaying grid view of scatter and line plot vizs. (screenshot added)

b) added overlay variable to scatter and line plot viz and changed minor ones (screenshot added)

c) I have decided to use incorrect response for line plot viz for now: lineplot post should return lineplot.data response but currently it returns scatterplot.data. Danielle will need to change it in the backend, but I have changed line plot viz to use the name of scatterplot.data for now so that one can play with the line plot viz. After she will fix the issue, then I will change my frontend code again

d) changed plot legend texts for handling overlay variable data: they are now based on the response of overlayVariableDetails.value so that the plots are more clearly identified: thanks to Danielle for explaining to me about the response when using overlay variable

e) changed parameter names for data API changes: with a new data response, best fit, Danielle decided to change intervalX/Y/SE responses to smoothedMeanX/Y/SE ones for better meaning. Accordingly, scatter plot viz is also changed to accept new names.

f) some clean-up


![scatter-overlay1](https://user-images.githubusercontent.com/12802305/117228999-2e8de080-ade8-11eb-804f-8eb9c6872c23.png)
![sample-grid-view](https://user-images.githubusercontent.com/12802305/117229018-351c5800-ade8-11eb-9157-2ed6c1a877df.png)
