### PR TITLE
Mouse-selected date range exceeding the right-hand bounds

### DIFF
--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -32,7 +32,6 @@ import { StudyEntity, StudyMetadata } from '../../types/study';
 import { TimeUnit, NumberOrDateRange, NumberRange } from '../../types/general';
 import { gray, red } from './colors';
 import { HistogramVariable } from './types';
-import { padISODateTime } from '../../utils/date-conversion';
 
 type Props = {
   studyMetadata: StudyMetadata;
@@ -182,8 +181,7 @@ export function HistogramFilter(props: Props) {
                   variableId: variable.id,
                   entityId: entity.id,
                   type: 'dateRange',
-                  min: padISODateTime((selectedRange as DateRange).min),
-                  max: padISODateTime((selectedRange as DateRange).max),
+                  ...(selectedRange as DateRange),
                 }
               : {
                   variableId: variable.id,


### PR DESCRIPTION
Quicker to fix than to create a whole new issue.

Since we are now storing and manipulating dates as strings, it doesn't seem necessary to pad everything with T00:00:00Z.  In fact this was creating a bug with mouse-selection.

It also makes the filter-chip mouse-over more concise.