### PR TITLE
updates on scatter plot viz and InputVariables component

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.2.38",
+    "@veupathdb/components": "^0.3.0",
     "@veupathdb/wdk-client": "^0.1.2",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -167,18 +167,17 @@ export interface ScatterplotRequestParams {
 }
 
 // unlike API doc, data (response) shows seriesX, seriesY, smoothedMeanX, smoothedMeanY, smoothedMeanSE
-const ScatterplotResponseData = array(
+export const ScatterplotResponseData = array(
   partial({
     // valueSpec = smoothedMean only returns smoothedMean data (no series data)
     //DKDK changed to string array
     seriesX: array(string),
     seriesY: array(string),
-    // smoothedMeanX: array(string),
-    smoothedMeanX: array(number),
+    smoothedMeanX: array(string),
     smoothedMeanY: array(number),
     smoothedMeanSE: array(number),
     // add bestFitLineWithRaw
-    bestFitLineX: array(number),
+    bestFitLineX: array(string),
     bestFitLineY: array(number),
     r2: number,
     // need to make sure if below is correct (untested)

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -170,8 +170,10 @@ export interface ScatterplotRequestParams {
 const ScatterplotResponseData = array(
   partial({
     // valueSpec = smoothedMean only returns smoothedMean data (no series data)
-    seriesX: array(number),
-    seriesY: array(number),
+    //DKDK changed to string array
+    seriesX: array(string),
+    seriesY: array(string),
+    // smoothedMeanX: array(string),
     smoothedMeanX: array(number),
     smoothedMeanY: array(number),
     smoothedMeanSE: array(number),
@@ -204,6 +206,19 @@ const sampleSizeTableArray = array(
     }),
   })
 );
+
+// define completeCasesTableArray
+const completeCasesTableArray = array(
+  partial({
+    // set union for size as it depends on the presence of overlay variable
+    completeCases: union([number, array(number)]),
+    variableDetails: type({
+      entityId: string,
+      variableId: string,
+    }),
+  })
+);
+
 export type ScatterplotResponse = TypeOf<typeof ScatterplotResponse>;
 export const ScatterplotResponse = type({
   scatterplot: type({
@@ -221,6 +236,7 @@ export const ScatterplotResponse = type({
     }),
   }),
   sampleSizeTable: sampleSizeTableArray,
+  completeCasesTable: completeCasesTableArray,
 });
 
 // lineplot
@@ -250,8 +266,9 @@ export interface LineplotRequestParams {
 const LineplotResponseData = array(
   intersection([
     type({
-      seriesX: array(number),
-      seriesY: array(number),
+      //DKDK changed to string array
+      seriesX: array(string),
+      seriesY: array(string),
     }),
     partial({
       // need to make sure if below is correct (untested)
@@ -283,6 +300,7 @@ export const LineplotResponse = type({
     }),
   }),
   sampleSizeTable: sampleSizeTableArray,
+  completeCasesTable: completeCasesTableArray,
 });
 
 export interface MosaicRequestParams {

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -49,7 +49,8 @@ export interface Props {
 const useStyles = makeStyles(
   {
     root: {
-      border: '2px solid rgb(240, 240, 240)',
+      // border: '2px solid rgb(240, 240, 240)',
+      border: 0,
       padding: '1.5em',
       borderRadius: '10px',
       color: 'rgb(150, 150, 150)',
@@ -109,7 +110,7 @@ export function InputVariables(props: Props) {
           </div>
         ))}
       </div>
-      <div className={`${classes.label} ${classes.dataLabel}`}>Data inputs</div>
+      {/* <div className={`${classes.label} ${classes.dataLabel}`}>Data inputs</div> */}
     </div>
   );
 }

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1,5 +1,5 @@
 // load scatter plot component
-import ScatterAndLinePlotGeneral from '@veupathdb/components/lib/plots/ScatterAndLinePlotGeneral';
+import XYPlot from '@veupathdb/components/lib/plots/XYPlot';
 import { ErrorManagement } from '@veupathdb/components/lib/types/general';
 
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
@@ -343,7 +343,7 @@ function ScatterplotViz(props: Props) {
           />
         ) : (
           // thumbnail/grid view
-          <ScatterAndLinePlotGeneral
+          <XYPlot
             data={[...data.value.dataSetProcess]}
             width={230}
             height={150}
@@ -360,7 +360,7 @@ function ScatterplotViz(props: Props) {
       ) : (
         //DKDK no data or data error case: with control
         <>
-          <ScatterAndLinePlotGeneral
+          <XYPlot
             data={[]}
             width={fullscreen ? 1000 : 230}
             height={fullscreen ? 600 : 150}
@@ -420,7 +420,7 @@ any) {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <ScatterAndLinePlotGeneral
+      <XYPlot
         {...ScatterplotProps}
         data={data}
         // add controls

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -26,8 +26,8 @@ import { Variable } from '../../../types/variable';
 import { InputVariables } from '../InputVariables';
 import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
 
-// ScatterplotControls
-import ScatterplotControls from '@veupathdb/components/lib/components/plotControls/ScatterplotControls';
+// XYPlotControls
+import XYPlotControls from '@veupathdb/components/lib/components/plotControls/XYPlotControls';
 
 export const scatterplotVisualization: VisualizationType = {
   gridComponent: GridComponent,
@@ -193,7 +193,7 @@ function ScatterplotViz(props: Props) {
     [entities]
   );
 
-  // ScatterplotControls: add valueSpec option
+  // XYPlotControls: add valueSpec option
   const onValueSpecChange = useCallback(
     (value: string) => {
       updateVizConfig({
@@ -233,7 +233,7 @@ function ScatterplotViz(props: Props) {
         vizConfig.enableOverlay ? vizConfig.overlayVariable : undefined,
         // add visualization.type
         visualization.type,
-        //DKDK ScatterplotControls
+        //DKDK XYPlotControls
         vizConfig.valueSpecConfig ? vizConfig.valueSpecConfig : 'Raw'
       );
 
@@ -334,7 +334,7 @@ function ScatterplotViz(props: Props) {
             independentAxisRange={[data.value.xMin, data.value.xMax]}
             // block this for now
             dependentAxisRange={[data.value.yMin, data.value.yMax]}
-            //DKDK ScatterplotControls valueSpecInitial
+            //DKDK XYPlotControls valueSpecInitial
             valueSpec={vizConfig.valueSpecConfig}
             // valueSpec={valueSpecInitial}
             onValueSpecChange={onValueSpecChange}
@@ -380,7 +380,7 @@ function ScatterplotViz(props: Props) {
             margin={fullscreen ? {} : { l: 30, r: 20, b: 15, t: 20 }}
           />
           {visualization.type === 'scatterplot' && fullscreen && (
-            <ScatterplotControls
+            <XYPlotControls
               // label="Scatter Plot Controls"
               valueSpec={vizConfig.valueSpecConfig}
               onValueSpecChange={onValueSpecChange}
@@ -400,7 +400,7 @@ function ScatterplotViz(props: Props) {
 
 function ScatterplotWithControls({
   data,
-  //DKDK ScatterplotControls: set initial value as 'raw' ('Raw')
+  //DKDK XYPlotControls: set initial value as 'raw' ('Raw')
   valueSpec = 'Raw',
   onValueSpecChange,
   vizType,
@@ -427,9 +427,9 @@ any) {
         displayLegend={data.length > 1}
         displayLibraryControls={false}
       />
-      {/* DKDK ScatterplotControls: check vizType (only for scatterplot for now) */}
+      {/* DKDK XYPlotControls: check vizType (only for scatterplot for now) */}
       {vizType === 'scatterplot' && (
-        <ScatterplotControls
+        <XYPlotControls
           // label="Scatter Plot Controls"
           valueSpec={valueSpec}
           onValueSpecChange={onValueSpecChange}
@@ -483,7 +483,7 @@ function getRequestParams(
   overlayVariable?: Variable,
   // add visualization.type
   vizType?: string,
-  //DKDK ScatterplotControls
+  //DKDK XYPlotControls
   valueSpecConfig?: string
 ): getRequestParamsProps {
   //DKDK valueSpec
@@ -516,7 +516,7 @@ function getRequestParams(
       config: {
         // is outputEntityId correct?
         outputEntityId: xAxisVariable.entityId,
-        //DKDK ScatterplotControls
+        //DKDK XYPlotControls
         valueSpec: valueSpecValue,
         xAxisVariable: xAxisVariable,
         yAxisVariable: yAxisVariable,

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -325,11 +325,15 @@ function ScatterplotViz(props: Props) {
             width={1000}
             height={600}
             // title={'Scatter plot'}
-            xLabel={findVariable(vizConfig.xAxisVariable)?.displayName}
-            yLabel={findVariable(vizConfig.yAxisVariable)?.displayName}
-            xRange={[data.value.xMin, data.value.xMax]}
+            independentAxisLabel={
+              findVariable(vizConfig.xAxisVariable)?.displayName
+            }
+            dependentAxisLabel={
+              findVariable(vizConfig.yAxisVariable)?.displayName
+            }
+            independentAxisRange={[data.value.xMin, data.value.xMax]}
             // block this for now
-            yRange={[data.value.yMin, data.value.yMax]}
+            dependentAxisRange={[data.value.yMin, data.value.yMax]}
             //DKDK ScatterplotControls valueSpecInitial
             valueSpec={vizConfig.valueSpecConfig}
             // valueSpec={valueSpecInitial}
@@ -343,9 +347,9 @@ function ScatterplotViz(props: Props) {
             data={[...data.value.dataSetProcess]}
             width={230}
             height={150}
-            xRange={[data.value.xMin, data.value.xMax]}
+            independentAxisRange={[data.value.xMin, data.value.xMax]}
             // block this for now
-            yRange={[data.value.yMin, data.value.yMax]}
+            dependentAxisRange={[data.value.yMin, data.value.yMax]}
             // new props for better displaying grid view
             displayLegend={false}
             displayLibraryControls={false}
@@ -360,12 +364,12 @@ function ScatterplotViz(props: Props) {
             data={[]}
             width={fullscreen ? 1000 : 230}
             height={fullscreen ? 600 : 150}
-            xLabel={
+            independentAxisLabel={
               fullscreen
                 ? findVariable(vizConfig.xAxisVariable)?.displayName
                 : undefined
             }
-            yLabel={
+            dependentAxisLabel={
               fullscreen
                 ? findVariable(vizConfig.yAxisVariable)?.displayName
                 : undefined

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -182,8 +182,6 @@ function ScatterplotViz(props: Props) {
     [updateVizConfig, vizConfig]
   );
 
-  console.log('valueSpec at ScatterViz =', vizConfig.valueSpecConfig);
-
   const data = usePromise(
     // set any for now
     // useCallback(async (): Promise<ScatterplotData> => {
@@ -268,8 +266,6 @@ function ScatterplotViz(props: Props) {
     ])
   );
 
-  // console.log('const data = ', data);
-
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       {/*  change title at viz page */}
@@ -347,7 +343,7 @@ function ScatterplotViz(props: Props) {
             yLabel={findVariable(vizConfig.yAxisVariable)?.displayName}
             xRange={[data.value.xMin, data.value.xMax]}
             // block this for now
-            // yRange={[data.value.yMin, data.value.yMax]}
+            yRange={[data.value.yMin, data.value.yMax]}
             //DKDK ScatterplotControls valueSpecInitial
             valueSpec={vizConfig.valueSpecConfig}
             // valueSpec={valueSpecInitial}
@@ -363,7 +359,7 @@ function ScatterplotViz(props: Props) {
             height={150}
             xRange={[data.value.xMin, data.value.xMax]}
             // block this for now
-            // yRange={[data.value.yMin, data.value.yMax]}
+            yRange={[data.value.yMin, data.value.yMax]}
             // new props for better displaying grid view
             displayLegend={false}
             displayLibraryControls={false}
@@ -404,8 +400,6 @@ any) {
     };
   }, []);
 
-  // console.log('ScatterplotWithControls.data = ', data);
-
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <ScatterAndLinePlotGeneral
@@ -440,9 +434,6 @@ export function scatterplotResponseToData(
   // vizType may be used for handling other plots in this component like line and density
   vizType: string
 ): any {
-  // console.log('visualization type at scatterplotResponseToData = ', vizType);
-  // console.log('response.data =', response);
-
   const modeValue = vizType === 'lineplot' ? 'lines' : 'markers'; // for scatterplot
 
   const { dataSetProcess, xMin, xMax, yMin, yMax } = processInputData(
@@ -450,8 +441,6 @@ export function scatterplotResponseToData(
     vizType,
     modeValue
   );
-
-  console.log('dataSet Process = ', dataSetProcess);
 
   return {
     dataSetProcess: dataSetProcess,
@@ -534,8 +523,6 @@ function processInputData<T extends number | Date>(
   // line, marker,
   modeValue: string
 ) {
-  // console.log('dataSet =', dataSet)
-
   // set fillAreaValue for densityplot
   const fillAreaValue = '';
 
@@ -552,6 +539,12 @@ function processInputData<T extends number | Date>(
   let xMax: number | Date = 0;
   let yMin: number | Date = 0;
   let yMax: number | Date = 0;
+
+  // // set variables for x- and yaxis ranges
+  // let xMin: number | Date;
+  // let xMax: number | Date;
+  // let yMin: number | Date;
+  // let yMax: number | Date;
 
   //DKDK coloring: using plotly.js default colors
   const markerColors = [
@@ -587,12 +580,6 @@ function processInputData<T extends number | Date>(
     if (el.seriesX && el.seriesY) {
       // check the number of x = number of y
       if (el.seriesX.length !== el.seriesY.length) {
-        console.log(
-          'x length=',
-          el.seriesX.length,
-          '  y length=',
-          el.seriesY.length
-        );
         // alert('The number of X data is not equal to the number of Y data');
         throw new Error(
           'The number of X data is not equal to the number of Y data'
@@ -668,10 +655,15 @@ function processInputData<T extends number | Date>(
 
       // check if this Y array consists of numbers & add type assertion
       if (isArrayOfNumbers(ySeriesValue)) {
-        yMin =
-          yMin < Math.min(...ySeriesValue) ? yMin : Math.min(...ySeriesValue);
-        yMax =
-          yMax > Math.max(...ySeriesValue) ? yMax : Math.max(...ySeriesValue);
+        if (index == 0) {
+          yMin = Math.min(...ySeriesValue);
+          yMax = Math.max(...ySeriesValue);
+        } else {
+          yMin =
+            yMin < Math.min(...ySeriesValue) ? yMin : Math.min(...ySeriesValue);
+          yMax =
+            yMax > Math.max(...ySeriesValue) ? yMax : Math.max(...ySeriesValue);
+        }
       } else {
         if (index === 0) {
           // to set initial Date value for Date[]
@@ -822,8 +814,6 @@ function processInputData<T extends number | Date>(
         xIntervalLineValue.map((element: any) => element).reverse()
       );
 
-      // console.log('xMin xMax =', xMin, xMax);
-
       // need to compare xMin/xMax
       xMin =
         xMin < Math.min(...xIntervalBounds.map(Number))
@@ -967,10 +957,10 @@ function processInputData<T extends number | Date>(
       });
     }
 
-    // determine y-axis range for numbers only: x-axis should be in the range of [xMin,xMax] due to CI plot
+    // make some margin for y-axis range (5% of range for now)
     if (typeof yMin == 'number' && typeof yMax == 'number') {
-      yMin = yMin < 0 ? Math.floor(yMin) : Math.ceil(yMin);
-      yMax = yMax < 0 ? Math.floor(yMax) : Math.ceil(yMax);
+      yMin = yMin - (yMax - yMin) * 0.05;
+      yMax = yMax + (yMax - yMin) * 0.05;
     }
   });
 

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -451,7 +451,7 @@ export function scatterplotResponseToData(
     modeValue
   );
 
-  // console.log('dataSet Process = ', dataSetProcess)  ;
+  console.log('dataSet Process = ', dataSetProcess);
 
   return {
     dataSetProcess: dataSetProcess,
@@ -699,7 +699,13 @@ function processInputData<T extends number | Date>(
           : 'Data',
         mode: modeValue,
         // type: 'scattergl',
-        type: 'scatter',
+        // type: 'scatter',
+        type:
+          vizType === 'lineplot'
+            ? 'scatter'
+            : vizType === 'densityplot'
+            ? 'scatter'
+            : 'scattergl', // for the raw data of the scatterplot
         fill: fillAreaValue,
         marker: {
           //DKDK coloring
@@ -807,6 +813,7 @@ function processInputData<T extends number | Date>(
           shape: 'spline',
           width: 2,
         },
+        type: 'scatter',
       });
 
       // make Confidence Interval (CI) or Bounds (filled area)
@@ -956,6 +963,7 @@ function processInputData<T extends number | Date>(
           shape: 'spline',
           width: 2,
         },
+        type: 'scatter',
       });
     }
 

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -81,7 +81,7 @@ function createDefaultConfig(): ScatterplotConfig {
   return {
     enableOverlay: true,
     //DKDK ScatterplotControls
-    valueSpecConfig: 'raw',
+    valueSpecConfig: 'Raw',
   };
 }
 
@@ -194,36 +194,13 @@ function ScatterplotViz(props: Props) {
       if (vizConfig.xAxisVariable == null || xAxisVariable == null)
         return Promise.reject(new Error('Please choose a X-axis variable'));
       // isHistogramVariable may be used instead
-      else if (!isScatterplotVariable(xAxisVariable))
-        return Promise.reject(
-          new Error(
-            `'${xAxisVariable.displayName}' is not suitable for this plot`
-          )
-        );
       else if (vizConfig.yAxisVariable == null || yAxisVariable == null)
         return Promise.reject(new Error('Please choose a Y-axis variable'));
-      else if (!isScatterplotVariable(yAxisVariable))
-        return Promise.reject(
-          new Error(
-            `'${yAxisVariable.displayName}' is not suitable for this plot`
-          )
-        );
       // add a condition to check whether xAxisVariable == yxAxisVariable
       else if (xAxisVariable === yAxisVariable)
         return Promise.reject(
           new Error(
             'Please choose different variables between X- and Y-axis variable'
-          )
-        );
-      // overlay
-      else if (
-        vizConfig.overlayVariable != null &&
-        overlayVariable != null &&
-        !isTableVariable(overlayVariable)
-      )
-        return Promise.reject(
-          new Error(
-            `'${overlayVariable.displayName}' is not suitable for this plot. Only categorical, binary, or ordinal type is allowed for the Overlay variable.`
           )
         );
 
@@ -237,7 +214,7 @@ function ScatterplotViz(props: Props) {
         // add visualization.type
         visualization.type,
         //DKDK ScatterplotControls
-        vizConfig.valueSpecConfig ? vizConfig.valueSpecConfig : 'raw'
+        vizConfig.valueSpecConfig ? vizConfig.valueSpecConfig : 'Raw'
       );
 
       // scatterplot, lineplot
@@ -383,7 +360,7 @@ function ScatterplotViz(props: Props) {
 function ScatterplotWithControls({
   data,
   //DKDK ScatterplotControls: set initial value as 'raw'
-  valueSpec = 'raw',
+  valueSpec = 'Raw',
   onValueSpecChange,
   vizType,
   ...ScatterplotProps
@@ -498,12 +475,6 @@ function getRequestParams(
       config: {
         // is outputEntityId correct?
         outputEntityId: xAxisVariable.entityId,
-        // valueSpect will be handled by a plot control in the near future
-        // valueSpec: 'raw',
-        // valueSpec: 'smoothedMean',
-        // valueSpec: 'smoothedMeanWithRaw',
-        // test bestFitLineWithRaw
-        // valueSpec: 'bestFitLineWithRaw',
         //DKDK ScatterplotControls
         valueSpec: valueSpecValue,
         xAxisVariable: xAxisVariable,
@@ -576,6 +547,10 @@ function processInputData<T extends number | Date>(
     let xIntervalBounds: T[] = [];
     let yIntervalBounds: T[] = [];
 
+    //DKDK initialize seriesX/Y
+    let seriesX = [];
+    let seriesY = [];
+
     // series is for scatter plot
     if (el.seriesX && el.seriesY) {
       // check the number of x = number of y
@@ -586,13 +561,19 @@ function processInputData<T extends number | Date>(
         );
       }
 
+      //DKDK change string array to number array for numeric data
+      // think of date data later
+      seriesX = el.seriesX.map(Number);
+      seriesY = el.seriesY.map(Number);
+
       // probably no need to have this for series data, though
       //1) combine the arrays:
       let combinedArray = [];
-      for (let j = 0; j < el.seriesX.length; j++) {
+      for (let j = 0; j < seriesX.length; j++) {
         combinedArray.push({
-          xValue: el.seriesX[j],
-          yValue: el.seriesY[j],
+          //DKDK use seriesX/Y instead of el.seriesX/Y
+          xValue: seriesX[j],
+          yValue: seriesY[j],
         });
       }
       //2) sort:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2880,10 +2880,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.2.38":
-  version "0.2.38"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.2.38.tgz#f6324a1adc370aa72c5e1935f8011462f1321a5b"
-  integrity sha512-Z5Z6cXPRXtHBOXO34DmAb18olu2QhrzHA+JMJZ+rcMnpPb//cantkwTZCWnrKZt3Ar1Z0TF2b+M9DsYRX9OXGg==
+"@veupathdb/components@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.0.tgz#f7df4f3215a1e6679a38fe993888be7842808b7c"
+  integrity sha512-uCglSXGeCN5JclPNF0UuG4Pw1a0TOBwpBl61KSlZo/zqZk0e3XldadIzSX09gMv41mWvzFiMLjSUqKA4BHw7hw==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
For InputVariables component: removed border and text (Data Inputs)

Note that this requires the merge of [the corresponding PR at web-components](https://github.com/VEuPathDB/web-components/pull/125) 

For scatter plot viz:
a) adjusted plot control to the button text with spaces
b) made colors up to 10: previously only two colors were manually set, which caused some issue with overlay variable more than 2 stratifications. Those colors are taken from plotly's default colors - screenshot attached
c) some minor changes

![scatterplotviz1](https://user-images.githubusercontent.com/12802305/118906702-45eec280-b8ec-11eb-8691-53e7f26ef4b6.png)

