### PR TITLE
update sideEffects to include scss files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^17.0.1",
     "uuid": "^8.3.2"
   },
-  "sideEffects": false,
+  "sideEffects": ["*.scss"],
   "files": [
     "lib",
     "src/lib"


### PR DESCRIPTION
This impacts how webpack does tree shaking. The change ensures that scss files are always included.