### PR TITLE
Show empty plots while loading or upon errors in Subsetting and Visualizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.2.38",
+    "@veupathdb/components": "^0.3.1",
     "@veupathdb/wdk-client": "^0.1.2",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@types/debounce-promise": "^3.1.3",
@@ -15,7 +15,9 @@
     "react-dom": "^17.0.1",
     "uuid": "^8.3.2"
   },
-  "sideEffects": ["*.scss"],
+  "sideEffects": [
+    "*.scss"
+  ],
   "files": [
     "lib",
     "src/lib"

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -217,41 +217,47 @@ export function HistogramFilter(props: Props) {
   return (
     <div style={{ position: 'relative' }}>
       {data.pending && (
-        <Loading style={{ position: 'absolute', top: '-1.5em' }} radius={2} />
+        <Loading
+          radius={16}
+          style={{ position: 'absolute', top: '200px', left: '200px' }}
+        />
       )}
       {data.error && <pre>{String(data.error)}</pre>}
-      {data.value &&
-        data.value.variableId === variable.id &&
-        data.value.entityId === entity.id &&
-        fgSummaryStats && (
-          <div>
-            <div className="histogram-summary-stats">
-              <b>Min:</b> {fgSummaryStats.min} &emsp; <b>Mean:</b>{' '}
-              {fgSummaryStats.mean} &emsp;
-              <b>Median:</b> {fgSummaryStats.median} &emsp; <b>Max:</b>{' '}
-              {fgSummaryStats.max}
-            </div>
-            <HistogramPlotWithControls
-              key={filters?.length ?? 0}
-              filter={filter}
-              data={data.value}
-              getData={getData}
-              width="100%"
-              height={400}
-              spacingOptions={{
-                marginTop: 20,
-                marginBottom: 20,
-              }}
-              orientation={'vertical'}
-              barLayout={'overlay'}
-              updateFilter={updateFilter}
-              uiState={uiState}
-              updateUIState={updateUIState}
-              variableName={variable.displayName}
-              entityName={entity.displayName}
-            />
+      <div>
+        {fgSummaryStats && (
+          <div className="histogram-summary-stats">
+            <b>Min:</b> {fgSummaryStats.min} &emsp; <b>Mean:</b>{' '}
+            {fgSummaryStats.mean} &emsp;
+            <b>Median:</b> {fgSummaryStats.median} &emsp; <b>Max:</b>{' '}
+            {fgSummaryStats.max}
           </div>
         )}
+        <HistogramPlotWithControls
+          key={filters?.length ?? 0}
+          filter={filter}
+          data={
+            data.value &&
+            data.value.variableId === variable.id &&
+            data.value.entityId === entity.id
+              ? data.value
+              : { series: [] }
+          }
+          getData={getData}
+          width="100%"
+          height={400}
+          spacingOptions={{
+            marginTop: 20,
+            marginBottom: 20,
+          }}
+          orientation={'vertical'}
+          barLayout={'overlay'}
+          updateFilter={updateFilter}
+          uiState={uiState}
+          updateUIState={updateUIState}
+          variableName={variable.displayName}
+          entityName={entity.displayName}
+        />
+      </div>
     </div>
   );
 }
@@ -370,8 +376,8 @@ function HistogramPlotWithControls({
   }, [filter]);
 
   const selectedRangeBounds = {
-    min: data.series[0].summary?.min,
-    max: data.series[0].summary?.max,
+    min: data.series[0]?.summary?.min,
+    max: data.series[0]?.summary?.max,
   } as NumberOrDateRange;
 
   return (

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -393,9 +393,6 @@ function HistogramPlotWithControls({
         selectedRange={selectedRange}
         selectedRangeBounds={selectedRangeBounds}
         onSelectedRangeChange={handleSelectedRangeChange}
-        binWidth={data.binWidth!}
-        binWidthRange={data.binWidthRange!}
-        binWidthStep={data.binWidthStep!}
         containerStyles={{ border: 'none' }}
       />
       <Histogram
@@ -414,6 +411,12 @@ function HistogramPlotWithControls({
         isZoomed={uiState.independentAxisRange ? true : false}
         dependentAxisRange={uiState.dependentAxisRange}
         dependentAxisLogScale={uiState.dependentAxisLogScale}
+        legendOptions={{
+          verticalPosition: 'top',
+          horizontalPosition: 'center',
+          orientation: 'horizontal',
+          verticalPaddingAdjustment: 20,
+        }}
       />
       <HistogramControls
         label="Axis controls"
@@ -423,15 +426,15 @@ function HistogramPlotWithControls({
         displayLibraryControls={displayLibraryControls}
         opacity={opacity}
         orientation={histogramProps.orientation}
-        binWidth={data.binWidth!}
+        binWidth={data.binWidth}
         selectedUnit={
           data.binWidth && isTimeDelta(data.binWidth)
             ? data.binWidth.unit
             : undefined
         }
         onBinWidthChange={handleBinWidthChange}
-        binWidthRange={data.binWidthRange!}
-        binWidthStep={data.binWidthStep!}
+        binWidthRange={data.binWidthRange}
+        binWidthStep={data.binWidthStep}
         errorManagement={errorManagement}
         independentAxisRange={uiState.independentAxisRange}
         onIndependentAxisRangeChange={handleIndependentAxisRangeChange}

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -230,114 +230,114 @@ function MosaicViz(props: Props) {
     ])
   );
 
-  let plotComponent: JSX.Element;
+  const xAxisVariableName = findVariable(vizConfig.xAxisVariable)?.displayName;
+  const yAxisVariableName = findVariable(vizConfig.yAxisVariable)?.displayName;
+  let statsTable = undefined;
 
-  if (data.value) {
-    const xAxisVariableName = findVariable(vizConfig.xAxisVariable)
-      ?.displayName;
-    const yAxisVariableName = findVariable(vizConfig.yAxisVariable)
-      ?.displayName;
-    let statsTable = undefined;
+  if (isTwoByTwo) {
+    const twoByTwoData = data.value as TwoByTwoData | undefined;
 
-    if (isTwoByTwo) {
-      const twoByTwoData = data.value as TwoByTwoData;
-
-      statsTable = (
-        <div className="MosaicVisualization-StatsTable">
-          <table>
-            <tbody>
-              <tr>
-                <th></th>
-                <th>Value</th>
-                <th>95% confidence interval</th>
-              </tr>
-              <tr>
-                <td>p-value</td>
-                <td>{twoByTwoData.pValue ?? 'N/A'}</td>
-                <td>N/A</td>
-              </tr>
-              <tr>
-                <td>Odds ratio</td>
-                <td>{twoByTwoData.oddsRatio ?? 'N/A'}</td>
-                <td>{twoByTwoData.orInterval ?? 'N/A'}</td>
-              </tr>
-              <tr>
-                <td>Relative risk</td>
-                <td>{twoByTwoData.relativeRisk ?? 'N/A'}</td>
-                <td>{twoByTwoData.rrInterval ?? 'N/A'}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      );
-    } else {
-      const contTableData = data.value as ContTableData;
-
-      statsTable = (
-        <div className="MosaicVisualization-StatsTable">
-          <table>
-            <tbody>
-              <tr>
-                <td>p-value</td>
-                <td>{contTableData.pValue ?? 'N/A'}</td>
-              </tr>
-              <tr>
-                <td>Degrees of freedom</td>
-                <td>{contTableData.degreesFreedom ?? 'N/A'}</td>
-              </tr>
-              <tr>
-                <td>Chi-squared</td>
-                <td>{contTableData.chisq ?? 'N/A'}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      );
-    }
-
-    plotComponent = fullscreen ? (
-      <div className="MosaicVisualization">
-        <div className="MosaicVisualization-Plot">
-          <MosaicPlotWithControls
-            data={data.value.data}
-            independentValues={data.value.independentValues}
-            dependentValues={data.value.dependentValues}
-            height={450}
-            independentLabel={xAxisVariableName ?? ''}
-            dependentLabel={yAxisVariableName ?? ''}
-            showLegend={true}
-          />
-        </div>
-        {statsTable}
+    statsTable = (
+      <div className="MosaicVisualization-StatsTable">
+        <table>
+          <tbody>
+            <tr>
+              <th></th>
+              <th>Value</th>
+              <th>95% confidence interval</th>
+            </tr>
+            <tr>
+              <td>p-value</td>
+              <td>{twoByTwoData?.pValue ?? 'N/A'}</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Odds ratio</td>
+              <td>{twoByTwoData?.oddsRatio ?? 'N/A'}</td>
+              <td>{twoByTwoData?.orInterval ?? 'N/A'}</td>
+            </tr>
+            <tr>
+              <td>Relative risk</td>
+              <td>{twoByTwoData?.relativeRisk ?? 'N/A'}</td>
+              <td>{twoByTwoData?.rrInterval ?? 'N/A'}</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-    ) : (
-      // thumbnail/grid view
-      <Mosaic
-        data={data.value.data}
-        independentValues={data.value.independentValues}
-        dependentValues={data.value.dependentValues}
-        width={300}
-        height={180}
-        margin={{ t: 40, b: 20, l: 20, r: 10 }}
-        showColumnLabels={false}
-        showModebar={false}
-        showLegend={false}
-        staticPlot={true}
-        independentLabel=""
-        dependentLabel=""
-      />
     );
   } else {
-    plotComponent = (
-      <i
-        className="fa fa-th-large"
-        style={{
-          fontSize: fullscreen ? '34em' : '12em',
-          color: '#aaa',
-        }}
-      ></i>
+    const contTableData = data.value as ContTableData | undefined;
+
+    statsTable = (
+      <div className="MosaicVisualization-StatsTable">
+        <table>
+          <tbody>
+            <tr>
+              <td>p-value</td>
+              <td>{contTableData?.pValue ?? 'N/A'}</td>
+            </tr>
+            <tr>
+              <td>Degrees of freedom</td>
+              <td>{contTableData?.degreesFreedom ?? 'N/A'}</td>
+            </tr>
+            <tr>
+              <td>Chi-squared</td>
+              <td>{contTableData?.chisq ?? 'N/A'}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     );
   }
+
+  const plotComponent = fullscreen ? (
+    <div className="MosaicVisualization">
+      <div className="MosaicVisualization-Plot">
+        <MosaicPlotWithControls
+          data={data.value && !data.pending ? data.value.data : [[]]}
+          independentValues={
+            data.value && !data.pending ? data.value.independentValues : []
+          }
+          dependentValues={
+            data.value && !data.pending ? data.value.dependentValues : []
+          }
+          height={450}
+          independentLabel={
+            data.value && !data.pending && xAxisVariableName
+              ? xAxisVariableName
+              : ''
+          }
+          dependentLabel={
+            data.value && !data.pending && yAxisVariableName
+              ? yAxisVariableName
+              : ''
+          }
+          showLegend={true}
+        />
+      </div>
+      {statsTable}
+    </div>
+  ) : (
+    // thumbnail/grid view
+    <Mosaic
+      data={data.value && !data.pending ? data.value.data : [[]]}
+      independentValues={
+        data.value && !data.pending ? data.value.independentValues : []
+      }
+      dependentValues={
+        data.value && !data.pending ? data.value.dependentValues : []
+      }
+      width={300}
+      height={180}
+      margin={{ t: 40, b: 20, l: 20, r: 10 }}
+      showColumnLabels={false}
+      showModebar={false}
+      showLegend={false}
+      staticPlot={true}
+      independentLabel=""
+      dependentLabel=""
+    />
+  );
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2880,10 +2880,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.2.38":
-  version "0.2.38"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.2.38.tgz#f6324a1adc370aa72c5e1935f8011462f1321a5b"
-  integrity sha512-Z5Z6cXPRXtHBOXO34DmAb18olu2QhrzHA+JMJZ+rcMnpPb//cantkwTZCWnrKZt3Ar1Z0TF2b+M9DsYRX9OXGg==
+"@veupathdb/components@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.1.tgz#4baada292fad7f807b781a09f3264cf4d92543b1"
+  integrity sha512-L7YgBNWvZH76ABOJ2lBdT2hh991A/NgYM8lWma1r802YiB9/ZsNiWslC4AQzZUaGUF7afAiB319H1ox8lheBAg==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Requires `web-components/allow-empty-plots`  https://github.com/VEuPathDB/web-components/pull/131 

Fixes https://github.com/VEuPathDB/web-eda/issues/104 