### PR TITLE
Don't "jump" to the active field when starring/unstarring certain variables 

### DIFF
--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -2,7 +2,7 @@
  * This is based on FieldList.jsx for typing
  */
 
-import { difference, uniq } from 'lodash';
+import { uniq } from 'lodash';
 import React, {
   useCallback,
   useEffect,
@@ -18,7 +18,6 @@ import {
   makeSearchHelpText,
 } from '@veupathdb/wdk-client/lib/Utils/SearchUtils';
 import {
-  getLeaves,
   preorderSeq,
   pruneDescendantNodes,
 } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';

--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -37,7 +37,11 @@ export function VariableTree(props: Props) {
     variableId,
     onChange,
   } = props;
-  const entities = Array.from(preorder(rootEntity, (e) => e.children ?? []));
+  const entities = useMemo(
+    () => Array.from(preorder(rootEntity, (e) => e.children ?? [])),
+    [rootEntity]
+  );
+
   const fields = useMemo(() => {
     return entities.flatMap((entity) => {
       // Create a Set of variableId so we can lookup parentIds


### PR DESCRIPTION
This PR resolves #135 by memoizing the derivation of `entities`. This stops the chain of events described in that issue from occurring.