### PR TITLE
barplot viz: add default label for fullscreen empty plot

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -273,7 +273,10 @@ function BarplotViz(props: Props) {
           barLayout={'group'}
           independentAxisLabel={
             fullscreen
-              ? findVariable(vizConfig.xAxisVariable)?.displayName
+              ? vizConfig.xAxisVariable
+                ? // the case where the x-axis variable is selected or not
+                  findVariable(vizConfig.xAxisVariable)?.displayName
+                : 'Label'
               : undefined
           }
           dependentAxisLabel={fullscreen ? 'Count' : undefined}


### PR DESCRIPTION
missed a case to set default label for fullscreen empty plot as 'Label'