### PR TITLE
Remove 'variable' wordage from InputVariables area

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -180,15 +180,15 @@ function BarplotViz(props: Props) {
             inputs={[
               {
                 name: 'xAxisVariable',
-                label: 'Main variable',
+                label: 'Main',
               },
               {
                 name: 'overlayVariable',
-                label: 'Overlay variable (Optional)',
+                label: 'Overlay (optional)',
               },
               {
                 name: 'facetVariable',
-                label: 'Facet Variable',
+                label: 'Facet (optional)',
               },
             ]}
             entities={entities}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -33,6 +33,7 @@ import { HistogramVariable } from '../../filter/types';
 import { InputVariables } from '../InputVariables';
 import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
 import histogram from './selectorIcons/histogram.svg';
+import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
 
 export const histogramVisualization: VisualizationType = {
   gridComponent: GridComponent,
@@ -210,32 +211,34 @@ function HistogramViz(props: Props) {
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       {fullscreen && (
         <div style={{ display: 'flex', alignItems: 'center' }}>
-          <InputVariables
-            inputs={[
-              {
-                name: 'xAxisVariable',
-                label: 'Main variable',
-              },
-              {
-                name: 'overlayVariable',
-                label: 'Overlay variable',
-              },
-              {
-                name: 'facetVariable',
-                label: 'Facet variable',
-              },
-            ]}
-            entities={entities}
-            values={{
-              xAxisVariable: vizConfig.xAxisVariable,
-              overlayVariable: vizConfig.overlayVariable,
-            }}
-            onChange={handleInputVariableChange}
-            constraints={dataElementConstraints}
-            dataElementDependencyOrder={dataElementDependencyOrder}
-            starredVariables={starredVariables}
-            toggleStarredVariable={toggleStarredVariable}
-          />
+          <LabelledGroup label="Variables">
+            <InputVariables
+              inputs={[
+                {
+                  name: 'xAxisVariable',
+                  label: 'Main',
+                },
+                {
+                  name: 'overlayVariable',
+                  label: 'Overlay (optional)',
+                },
+                {
+                  name: 'facetVariable',
+                  label: 'Facet (optional)',
+                },
+              ]}
+              entities={entities}
+              values={{
+                xAxisVariable: vizConfig.xAxisVariable,
+                overlayVariable: vizConfig.overlayVariable,
+              }}
+              onChange={handleInputVariableChange}
+              constraints={dataElementConstraints}
+              dataElementDependencyOrder={dataElementDependencyOrder}
+              starredVariables={starredVariables}
+              toggleStarredVariable={toggleStarredVariable}
+            />
+          </LabelledGroup>
         </div>
       )}
 

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -33,7 +33,6 @@ import { HistogramVariable } from '../../filter/types';
 import { InputVariables } from '../InputVariables';
 import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
 import histogram from './selectorIcons/histogram.svg';
-import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
 
 export const histogramVisualization: VisualizationType = {
   gridComponent: GridComponent,
@@ -211,34 +210,32 @@ function HistogramViz(props: Props) {
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       {fullscreen && (
         <div style={{ display: 'flex', alignItems: 'center' }}>
-          <LabelledGroup label="Variables">
-            <InputVariables
-              inputs={[
-                {
-                  name: 'xAxisVariable',
-                  label: 'Main',
-                },
-                {
-                  name: 'overlayVariable',
-                  label: 'Overlay (optional)',
-                },
-                {
-                  name: 'facetVariable',
-                  label: 'Facet (optional)',
-                },
-              ]}
-              entities={entities}
-              values={{
-                xAxisVariable: vizConfig.xAxisVariable,
-                overlayVariable: vizConfig.overlayVariable,
-              }}
-              onChange={handleInputVariableChange}
-              constraints={dataElementConstraints}
-              dataElementDependencyOrder={dataElementDependencyOrder}
-              starredVariables={starredVariables}
-              toggleStarredVariable={toggleStarredVariable}
-            />
-          </LabelledGroup>
+          <InputVariables
+            inputs={[
+              {
+                name: 'xAxisVariable',
+                label: 'Main',
+              },
+              {
+                name: 'overlayVariable',
+                label: 'Overlay (optional)',
+              },
+              {
+                name: 'facetVariable',
+                label: 'Facet (optional)',
+              },
+            ]}
+            entities={entities}
+            values={{
+              xAxisVariable: vizConfig.xAxisVariable,
+              overlayVariable: vizConfig.overlayVariable,
+            }}
+            onChange={handleInputVariableChange}
+            constraints={dataElementConstraints}
+            dataElementDependencyOrder={dataElementDependencyOrder}
+            starredVariables={starredVariables}
+            toggleStarredVariable={toggleStarredVariable}
+          />
         </div>
       )}
 

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -334,15 +334,15 @@ function MosaicViz(props: Props) {
             inputs={[
               {
                 name: 'xAxisVariable',
-                label: 'X-axis variable',
+                label: 'X-axis',
               },
               {
                 name: 'yAxisVariable',
-                label: 'Y-axis variable',
+                label: 'Y-axis',
               },
               {
                 name: 'facetVariable',
-                label: 'Facet variable',
+                label: 'Facet (optional)',
               },
             ]}
             entities={entities}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -233,19 +233,19 @@ function ScatterplotViz(props: Props) {
             inputs={[
               {
                 name: 'xAxisVariable',
-                label: 'X-axis variable',
+                label: 'X-axis',
               },
               {
                 name: 'yAxisVariable',
-                label: 'Y-axis variable',
+                label: 'Y-axis',
               },
               {
                 name: 'overlayVariable',
-                label: 'Overlay variable (Optional)',
+                label: 'Overlay (optional)',
               },
               {
                 name: 'facetVariable',
-                label: 'Facet variable (Optional)',
+                label: 'Facet (optional)',
               },
             ]}
             entities={entities}


### PR DESCRIPTION
Closes #153 

I have done as requested, but I also suggest we wrap the controls in a LabelledGroup box (currently implemented for Histogram only).

The layout is a bit wrong - InputVariables would need less padding and LabelledGroup doesn't currently work nicely with a `marginTop` provided via `containerStyles` prop.

![image](https://user-images.githubusercontent.com/308639/121198396-015ea300-c86a-11eb-80dc-8eea0e7b5b01.png)
