### PR TITLE
adding and styling viz title and subtitle

### DIFF
--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -315,7 +315,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
             <SaveableTextEditor
               value={
                 viz.displayName ??
-                'Unnamed ' + overview?.displayName ??
+                'unnamed ' + overview?.displayName ??
                 'visualization'
               }
               onSave={(value) =>

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -311,11 +311,11 @@ function FullScreenVisualization(props: Props & { id: string }) {
         </ContentError>
       ) : (
         <div>
-          <h3>
+          <h3 style={{ fontStyle: 'normal', fontWeight: 'bold' }}>
             <SaveableTextEditor
               value={
                 viz.displayName ??
-                'unnamed ' + overview?.displayName ??
+                'DKDKDK ' + overview?.displayName ??
                 'visualization'
               }
               onSave={(value) =>
@@ -323,6 +323,18 @@ function FullScreenVisualization(props: Props & { id: string }) {
               }
             />
           </h3>
+          <div
+            style={{
+              fontStyle: 'italic',
+              fontSize: '1.3em',
+              color: '#333333',
+              margin: 0,
+              paddingLeft: '0.3em',
+            }}
+          >
+            {' '}
+            {overview?.displayName}{' '}
+          </div>
           <vizType.fullscreenComponent
             dataElementConstraints={constraints}
             dataElementDependencyOrder={dataElementDependencyOrder}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -311,7 +311,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
         </ContentError>
       ) : (
         <div>
-          <h3 style={{ fontStyle: 'normal', fontWeight: 'bold' }}>
+          <h3>
             <SaveableTextEditor
               value={
                 viz.displayName ??
@@ -325,7 +325,6 @@ function FullScreenVisualization(props: Props & { id: string }) {
           </h3>
           <div
             style={{
-              fontStyle: 'italic',
               fontSize: '1.3em',
               color: '#333333',
               margin: 0,

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -332,8 +332,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
               paddingLeft: '0.3em',
             }}
           >
-            {' '}
-            {overview?.displayName}{' '}
+            {overview?.displayName}
           </div>
           <vizType.fullscreenComponent
             dataElementConstraints={constraints}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -315,7 +315,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
             <SaveableTextEditor
               value={
                 viz.displayName ??
-                'DKDKDK ' + overview?.displayName ??
+                'Unnamed ' + overview?.displayName ??
                 'visualization'
               }
               onSave={(value) =>


### PR DESCRIPTION
viz subtitle indicating plot, e.g., Scatter plot, is added and title and subtitle are styled according to the example shown by @dmfalke [here](https://github.com/VEuPathDB/web-eda/issues/154)

Here is a screenshot: text color for subtitle is #333333

![scatter-subtitle-333333](https://user-images.githubusercontent.com/12802305/121228846-3fa09600-c85b-11eb-9596-7499bd3b6084.png)
