### PR TITLE
Scatterplot viz: remove SmoothedMean option and update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.3.6",
+    "@veupathdb/components": "^0.3.8",
     "@veupathdb/wdk-client": "^0.1.2",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -363,7 +363,6 @@ function ScatterplotViz(props: Props) {
               labelPlacement={'end'}
               // minWidth is used to set equivalent space per item
               minWidth={210}
-              // minWidth={75}
               buttonColor={'primary'}
               margins={['0', '0', '0', '5em']}
             />

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -363,6 +363,7 @@ function ScatterplotViz(props: Props) {
               labelPlacement={'end'}
               // minWidth is used to set equivalent space per item
               minWidth={210}
+              // minWidth={75}
               buttonColor={'primary'}
               margins={['0', '0', '0', '5em']}
             />
@@ -474,9 +475,7 @@ function getRequestParams(
 ): getRequestParamsProps {
   // valueSpec
   let valueSpecValue = 'raw';
-  if (valueSpecConfig === 'Smoothed mean') {
-    valueSpecValue = 'smoothedMean';
-  } else if (valueSpecConfig === 'Smoothed mean with raw') {
+  if (valueSpecConfig === 'Smoothed mean with raw') {
     valueSpecValue = 'smoothedMeanWithRaw';
   } else if (valueSpecConfig === 'Best fit line with raw') {
     valueSpecValue = 'bestFitLineWithRaw';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2900,10 +2900,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.6.tgz#b5bdf0fca270f3b22214234a279ed49a42f22395"
-  integrity sha512-JEmy+BzQ3tw3rX8fZyprsdcKVQxY0jJlZrfAV+N+cMM4HPlNkkSVFeF2mNedNFCp8wBomK+dWvMCJYIjXHTvMA==
+"@veupathdb/components@^0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.8.tgz#ba5407e4c1664b7b4d03f2ba114e5146d4725eba"
+  integrity sha512-IMEZ2LyPpT853smP8UjtDL3lTdSViHvzDVRH5XUdNOUwGacSPUimuXxv+LlvmkCecqZFZzuuZ9vBf7lM8X7r3Q==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
SmoothedMean option is removed from scatter plot, thus corresponding changes are made. Corresponding update at XYPlotControls are already approved and [merged](https://github.com/VEuPathDB/web-components/pull/147), thus package.json is also updated with the new web-components version. It looks like this at viz: backend seems down now so just captured empty plot with control

![scatter-control2](https://user-images.githubusercontent.com/12802305/121240789-b98b4c00-c868-11eb-84b6-f7348d6571d5.png)
