### PR TITLE
radio button spacing for scatterplot viz

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.3.9",
+    "@veupathdb/components": "^0.3.10",
     "@veupathdb/wdk-client": "^0.1.2",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -371,6 +371,7 @@ function ScatterplotViz(props: Props) {
               minWidth={210}
               buttonColor={'primary'}
               margins={['0', '0', '0', '5em']}
+              itemMarginRight={50}
             />
           )}
         </>
@@ -426,6 +427,7 @@ function ScatterplotWithControls({
           minWidth={210}
           buttonColor={'primary'}
           margins={['0', '0', '0', '5em']}
+          itemMarginRight={50}
         />
       )}
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2900,10 +2900,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.9.tgz#536ede7a5d4cd5cf6c45933e6425502d5176c889"
-  integrity sha512-DngR6in036DN8ytCDYWuZWVVoWmpJpCCd+5pNldsDBzsNT0tYJ1a4okZOi3Ygk4Hngbe3qI6nhzfV+GoP8IKXw==
+"@veupathdb/components@^0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.10.tgz#a794003df6dc512521d5de530cfaa73fc1accd11"
+  integrity sha512-Z3Ll6zLZsaup4LjSpQtJ2bnpZJyYwUahiJFULXzxImC4WE053kKUOvbY2QVxs+uhGI37VXoDIlHa5V22wtnlsw==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
After approving/merging [a new spacing method at web-components](https://github.com/VEuPathDB/web-components/pull/148), corresponding changes are made at scatterplot viz. This will be required for Gates demo: I believe this would be a quick review :) 

A screenshot is attached:

![scatter-radio2](https://user-images.githubusercontent.com/12802305/121416134-74355000-c936-11eb-845d-b377064604e9.png)
