### PR TITLE
Barplot viz bug

### DIFF
--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -134,14 +134,14 @@ export interface BarplotRequestParams {
   //  derivedVariables:  // TO DO
   config: {
     outputEntityId: string;
-    //DKDK add proportion as it seems to be coming
+    // add proportion as it seems to be coming
     valueSpec: 'count' | 'identity' | 'proportion';
     xAxisVariable: {
       // TO DO: refactor repetition with HistogramRequestParams
       entityId: string;
       variableId: string;
     };
-    //DKDK barplot add prop
+    // barplot add prop
     overlayVariable?: {
       entityId: string;
       variableId: string;
@@ -162,9 +162,7 @@ export const BarplotResponse = type({
     data: array(
       intersection([
         type({
-          //DKDK label can be number too?
-          // label: array(string),
-          label: union([array(string), array(number)]),
+          label: array(string),
           value: array(number),
         }),
         partial({
@@ -218,7 +216,7 @@ export interface ScatterplotRequestParams {
 export const ScatterplotResponseData = array(
   partial({
     // valueSpec = smoothedMean only returns smoothedMean data (no series data)
-    //DKDK changed to string array
+    // changed to string array
     seriesX: array(string),
     seriesY: array(string),
     smoothedMeanX: array(string),
@@ -288,7 +286,7 @@ export interface LineplotRequestParams {
 const LineplotResponseData = array(
   intersection([
     type({
-      //DKDK changed to string array
+      // changed to string array
       seriesX: array(string),
       seriesY: array(string),
     }),
@@ -305,7 +303,7 @@ const LineplotResponseData = array(
 
 export type LineplotResponse = TypeOf<typeof LineplotResponse>;
 export const LineplotResponse = type({
-  //DKDK backend issue for lineplot returning scatterplot currently
+  // backend issue for lineplot returning scatterplot currently
   // lineplot: type({
   scatterplot: type({
     data: LineplotResponseData,

--- a/src/lib/core/components/filter/TableFilter.tsx
+++ b/src/lib/core/components/filter/TableFilter.tsx
@@ -93,10 +93,9 @@ export function TableFilter({
           });
         }
       );
-      //DKDK by setting union for label (array number or string), ts error occurs
       const fgValueByLabel = Object.fromEntries(
         distribution.foreground.barplot.data[0].label.map(
-          (label: string | number, index: number) => [
+          (label: string, index: number) => [
             label,
             distribution.foreground.barplot.data[0].value[index] ?? 0,
           ]
@@ -104,7 +103,7 @@ export function TableFilter({
       );
       const bgValueByLabel = Object.fromEntries(
         distribution.background.barplot.data[0].label.map(
-          (label: string | number, index: number) => [
+          (label: string, index: number) => [
             label,
             distribution.background.barplot.data[0].value[index] ?? 0,
           ]

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -225,67 +225,41 @@ function BarplotViz(props: Props) {
             : String(data.error)}
         </div>
       )}
-      {data.value ? (
-        fullscreen ? (
-          <BarplotWithControls
-            // data.value
-            data={data.value}
-            width={'100%'}
-            height={450}
-            orientation={'vertical'}
-            barLayout={'group'}
-            displayLegend={data.value?.series.length > 1}
-            independentAxisLabel={
-              findVariable(vizConfig.xAxisVariable)?.displayName
-            }
-            dependentAxisLabel={'Count'}
-            showSpinner={data.pending}
-          />
-        ) : (
-          // thumbnail/grid view
-          <Barplot
-            data={data.value}
-            width={230}
-            height={165}
-            // check this option (possibly plot control?)
-            orientation={'vertical'}
-            barLayout={'group'}
-            // show/hide independent/dependent axis tick label
-            showIndependentAxisTickLabel={false}
-            showDependentAxisTickLabel={false}
-            // new props for better displaying grid view
-            displayLegend={false}
-            displayLibraryControls={false}
-            staticPlot={true}
-            // set margin for better display at thumbnail/grid view
-            margin={{ l: 30, r: 20, b: 0, t: 20 }}
-            showSpinner={data.pending}
-          />
-        )
-      ) : (
-        // no data case
-        <Barplot
-          data={{ series: [] }}
-          width={fullscreen ? '100%' : 230}
-          height={fullscreen ? 450 : 165}
+      {fullscreen ? (
+        <BarplotWithControls
+          data={data.value && !data.pending ? data.value : { series: [] }}
+          width={'100%'}
+          height={450}
+          // height={'100%'}
           orientation={'vertical'}
           barLayout={'group'}
+          displayLegend={data.value?.series.length > 1}
           independentAxisLabel={
-            fullscreen
-              ? vizConfig.xAxisVariable
-                ? // the case where the x-axis variable is selected or not
-                  findVariable(vizConfig.xAxisVariable)?.displayName
-                : 'Label'
-              : undefined
+            vizConfig.xAxisVariable
+              ? findVariable(vizConfig.xAxisVariable)?.displayName
+              : 'Label'
           }
-          dependentAxisLabel={fullscreen ? 'Count' : undefined}
+          dependentAxisLabel={'Count'}
+          showSpinner={data.pending}
+        />
+      ) : (
+        // thumbnail/grid view
+        <Barplot
+          data={data.value && !data.pending ? data.value : { series: [] }}
+          width={230}
+          height={165}
+          // check this option (possibly plot control?)
+          orientation={'vertical'}
+          barLayout={'group'}
           // show/hide independent/dependent axis tick label
-          showIndependentAxisTickLabel={fullscreen ? undefined : false}
-          showDependentAxisTickLabel={fullscreen ? undefined : false}
-          displayLegend={fullscreen ? true : false}
+          showIndependentAxisTickLabel={false}
+          showDependentAxisTickLabel={false}
+          // new props for better displaying grid view
+          displayLegend={false}
           displayLibraryControls={false}
-          staticPlot={fullscreen ? false : true}
-          margin={fullscreen ? {} : { l: 30, r: 20, b: 0, t: 20 }}
+          staticPlot={true}
+          // set margin for better display at thumbnail/grid view
+          margin={{ l: 30, r: 20, b: 0, t: 20 }}
           showSpinner={data.pending}
         />
       )}


### PR DESCRIPTION
This PR addresses three kinds of issues for barplot viz: a) its label response type to be string: I could see that the backend now reponds with `label: string`, which was string[] or number[] previously, so corresponding changes are made, including at `Tablefilter` component; b) y-axis changes strangely when switching main variable - it was because `data.pending` case was not considered before; c) most cases are working properly, but when a specific variable is selected and cleared, e.g., "floor material", "human waste facilities", etc., an error popup shows up with a message, `Cannot read property '_redrawFromAutoMarginCount' of undefined`. It seemed to me that it was related to plotly issue concerning a redrawing, thus I have examined this by changing several things at barplot component and its viz. But, I have realized that the error disappeared after addressing b) - I don't know well how it happened but anyway it is now addressed. 