### PR TITLE
add X-axis offset for scatter plot viz

### DIFF
--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -972,6 +972,11 @@ function processInputData<T extends number | Date>(
       });
     }
 
+    // make some margin for x-axis range (2% of range for now)
+    if (typeof xMin == 'number' && typeof xMax == 'number') {
+      xMin = xMin - (xMax - xMin) * 0.02;
+      xMax = xMax + (xMax - xMin) * 0.02;
+    }
     // make some margin for y-axis range (5% of range for now)
     if (typeof yMin == 'number' && typeof yMax == 'number') {
       yMin = yMin - (yMax - yMin) * 0.05;


### PR DESCRIPTION
added X-axis offset for scatter plot viz. Discussed with 5% offset but it seems to be a bit large for some cases, thus I have set it to 2%. Two screenshots, which are based on Steve's screenshot at Slack (GEMS1 Case Control), are attached, without and with offset.

![scatter-xaxis-without-offset](https://user-images.githubusercontent.com/12802305/122264312-68e9a380-cea5-11eb-8afb-c46ba1180a97.png)

![scatter-xaxis-offset](https://user-images.githubusercontent.com/12802305/122264375-7868ec80-cea5-11eb-84d9-5fa77cc63f9f.png)
