### PR TITLE
Variable constraints UI update

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@types/debounce-promise": "^3.1.3",
     "@veupathdb/components": "^0.3.11",
-    "@veupathdb/wdk-client": "^0.1.2",
+    "@veupathdb/wdk-client": "^0.1.4",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -432,6 +432,11 @@ const FieldNode = ({
             (isDisabled ? ' wdk-AttributeFilterFieldItem__disabled' : '')
           }
           href={'#' + node.field.term}
+          title={
+            isDisabled
+              ? 'This variable cannot be used with this plot and other variable selections.'
+              : 'Select this variable.'
+          }
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();

--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -79,6 +79,8 @@ interface VariableListProps {
   starredVariables?: string[];
   toggleStarredVariable: (targetVariableId: string) => void;
   disabledFieldIds?: string[];
+  hideDisabledFields: boolean;
+  setHideDisabledFields: (hide: boolean) => void;
 }
 
 interface getNodeSearchStringType {
@@ -100,6 +102,8 @@ export default function VariableList(props: VariableListProps) {
     autoFocus,
     starredVariables,
     toggleStarredVariable,
+    hideDisabledFields,
+    setHideDisabledFields,
   } = props;
   const [searchTerm, setSearchTerm] = useState<string>('');
   const getPathToField = useCallback(
@@ -240,8 +244,6 @@ export default function VariableList(props: VariableListProps) {
 
   const starredVariableToggleDisabled = starredVariablesSet.size === 0;
 
-  const [disabledVariablesHidden, setDisabledVariablesHidden] = useState(false);
-
   useEffect(() => {
     if (starredVariableToggleDisabled) {
       setShowOnlyStarredVariables(false);
@@ -312,11 +314,11 @@ export default function VariableList(props: VariableListProps) {
                 <button
                   className="link"
                   type="button"
-                  onClick={() =>
-                    setDisabledVariablesHidden((hidden) => !hidden)
-                  }
+                  onClick={() => {
+                    setHideDisabledFields(!hideDisabledFields);
+                  }}
                 >
-                  <Toggle on={disabledVariablesHidden} /> Only show compatible
+                  <Toggle on={hideDisabledFields} /> Only show compatible
                   variables
                 </button>
               </Tooltip>
@@ -326,7 +328,7 @@ export default function VariableList(props: VariableListProps) {
         </>
       );
     },
-    [disabledFields.size, disabledVariablesHidden]
+    [disabledFields.size, hideDisabledFields, setHideDisabledFields]
   );
 
   const isAdditionalFilterApplied = showOnlyStarredVariables;
@@ -341,7 +343,7 @@ export default function VariableList(props: VariableListProps) {
               starredVariablesSet.has(node.field.term.split('/')[1]),
             fieldTree
           );
-    return disabledVariablesHidden
+    return hideDisabledFields
       ? pruneDescendantNodes((node) => {
           if (disabledFields.size === 0) return true;
           if (node.field.type == null) return node.children.length > 0;
@@ -352,7 +354,7 @@ export default function VariableList(props: VariableListProps) {
     showOnlyStarredVariables,
     starredVariableToggleDisabled,
     fieldTree,
-    disabledVariablesHidden,
+    hideDisabledFields,
     starredVariablesSet,
     disabledFields,
   ]);

--- a/src/lib/core/components/VariableTree.scss
+++ b/src/lib/core/components/VariableTree.scss
@@ -16,15 +16,25 @@
   }
 
   /* All entities */
-  .wdk-CheckboxTree .wdk-Link.wdk-AttributeFilterFieldEntityParent {
+  .wdk-AttributeFilterFieldEntityParent {
     font-weight: bold;
     font-size: 1.05em;
   }
 
   /* Active variable */
-  .wdk-AttributeFilterFieldItem__active {
-    background: #e6e6e6;
-    outline: none;
+  .wdk-AttributeFilterFieldItem {
+    &__active {
+      background: #e6e6e6;
+      outline: none;
+    }
+    &__disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+  }
+
+  .wdk-CheckboxTreeAdditionalFilters {
+    display: flex;
   }
 
   /* height of CheckboxTree - use vh */
@@ -35,7 +45,7 @@
   /* configuring scrolling for CheckboxTree list only: anchoring search bar */
   .wdk-CheckboxTree > .wdk-CheckboxTreeList {
     position: relative;
-    height: 100%;
+    height: calc(100% - 3em);
     overflow: auto;
     padding: 0 1em;
   }
@@ -96,5 +106,30 @@
 
   .wdk-CheckboxTreeFilters {
     gap: 0.5em;
+  }
+
+  .EDAWorkspace-DisabledVariablesToggle {
+    margin: 0 1em 0.75em;
+    button {
+      color: #666;
+    }
+  }
+}
+
+.EDAWorkspace-VariableTreeDropdown {
+  position: relative;
+
+  &TreeContainer {
+    // border: 1px solid;
+    border-radius: 0.25em;
+    padding: 0.5em;
+    height: 60vh;
+    width: 30em;
+    position: relative;
+
+    .wdk-AttributeFilterFieldItem,
+    .wdk-AttributeFilterFieldParent {
+      color: #2f2f2f;
+    }
   }
 }

--- a/src/lib/core/components/VariableTree.scss
+++ b/src/lib/core/components/VariableTree.scss
@@ -29,7 +29,7 @@
     }
     &__disabled {
       opacity: 0.5;
-      pointer-events: none;
+      cursor: not-allowed;
     }
   }
 

--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -3,7 +3,7 @@ import { Button } from '@material-ui/core';
 import { getTree } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/AttributeFilterUtils';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { keyBy } from 'lodash';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { cx } from '../../workspace/Utils';
 import { StudyEntity } from '../types/study';
 import { Variable } from '../types/variable';
@@ -27,6 +27,8 @@ export interface Props {
   disabledVariables?: Variable[];
   /** term string is of format "entityId/variableId"  e.g. "PCO_0000024/EUPATH_0000714" */
   onChange: (variable?: Variable) => void;
+  hideDisabledFields?: boolean;
+  setHideDisabledFields?: (hide: boolean) => void;
 }
 export function VariableTree(props: Props) {
   const {
@@ -37,6 +39,8 @@ export function VariableTree(props: Props) {
     entityId,
     variableId,
     onChange,
+    hideDisabledFields = false,
+    setHideDisabledFields = () => {},
   } = props;
   const entities = useMemo(
     () =>
@@ -130,12 +134,15 @@ export function VariableTree(props: Props) {
       autoFocus={false}
       starredVariables={starredVariables}
       toggleStarredVariable={toggleStarredVariable}
+      hideDisabledFields={hideDisabledFields}
+      setHideDisabledFields={setHideDisabledFields}
     />
   );
 }
 
 export function VariableTreeDropdown(props: Props) {
   const { rootEntity, entityId, variableId, onChange } = props;
+  const [hideDisabledFields, setHideDisabledFields] = useState(false);
   const entities = Array.from(preorder(rootEntity, (e) => e.children ?? []));
   const variable = entities
     .find((e) => e.id === entityId)
@@ -159,7 +166,11 @@ export function VariableTreeDropdown(props: Props) {
           </div>
         )}
         <div className={cx('-VariableTreeDropdownTreeContainer')}>
-          <VariableTree {...props} />
+          <VariableTree
+            {...props}
+            hideDisabledFields={hideDisabledFields}
+            setHideDisabledFields={setHideDisabledFields}
+          />
         </div>
       </PopoverButton>
     </div>

--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -145,10 +145,10 @@ export function VariableTreeDropdown(props: Props) {
     <div className={cx('-VariableTreeDropdown')}>
       <PopoverButton label={label} key={`${entityId}/${variableId}`}>
         {variable && (
-          <div style={{ textAlign: 'center', padding: '0.25em' }}>
+          <div style={{ textAlign: 'center', padding: '.75em 0.25em 0.25em' }}>
             <Button
               type="button"
-              style={{ width: '100%' }}
+              style={{ width: '90%' }}
               variant="contained"
               color="default"
               size="small"

--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -1,11 +1,10 @@
 import PopoverButton from '@veupathdb/components/lib/components/widgets/PopoverButton';
+import { Button } from '@material-ui/core';
 import { getTree } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/AttributeFilterUtils';
-import {
-  preorder,
-  pruneDescendantNodes,
-} from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
+import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { keyBy } from 'lodash';
 import { useCallback, useMemo } from 'react';
+import { cx } from '../../workspace/Utils';
 import { StudyEntity } from '../types/study';
 import { Variable } from '../types/variable';
 import { edaVariableToWdkField } from '../utils/wdk-filter-param-adapter';
@@ -25,12 +24,14 @@ export interface Props {
   toggleStarredVariable: (targetVariableId: string) => void;
   entityId?: string;
   variableId?: string;
+  disabledVariables?: Variable[];
   /** term string is of format "entityId/variableId"  e.g. "PCO_0000024/EUPATH_0000714" */
   onChange: (variable?: Variable) => void;
 }
 export function VariableTree(props: Props) {
   const {
     rootEntity,
+    disabledVariables,
     starredVariables,
     toggleStarredVariable,
     entityId,
@@ -89,15 +90,14 @@ export function VariableTree(props: Props) {
   }, [entities]);
 
   // Construct the fieldTree using the fields defined above.
-  const fieldTree = useMemo(() => {
-    const fieldTree = getTree(fields, { hideSingleRoot: false });
-    // Remove non-variable branches with no children.
-    // This can happen if variables are filtered out due to constraints.
-    return pruneDescendantNodes(
-      (node) => node.field.type != null || node.children.length > 0,
-      fieldTree
-    );
-  }, [fields]);
+  const fieldTree = useMemo(() => getTree(fields, { hideSingleRoot: false }), [
+    fields,
+  ]);
+
+  const disabledFields = useMemo(
+    () => disabledVariables?.map((v) => `${v.entityId}/${v.variableId}`),
+    [disabledVariables]
+  );
 
   // Used to lookup a field by entityId and variableId.
   const fieldsByTerm = useMemo(() => keyBy(fields, (f) => f.term), [fields]);
@@ -123,6 +123,7 @@ export function VariableTree(props: Props) {
   return (
     <VariableList
       activeField={activeField}
+      disabledFieldIds={disabledFields}
       onActiveFieldChange={onActiveFieldChange}
       valuesMap={valuesMap}
       fieldTree={fieldTree}
@@ -141,35 +142,26 @@ export function VariableTreeDropdown(props: Props) {
     ?.variables.find((v) => v.id === variableId);
   const label = variable?.displayName ?? 'Select a variable';
   return (
-    <div
-      style={{
-        position: 'relative',
-      }}
-    >
+    <div className={cx('-VariableTreeDropdown')}>
       <PopoverButton label={label} key={`${entityId}/${variableId}`}>
-        <div
-          style={{
-            border: '1px solid',
-            borderRadius: ' 0.25em',
-            padding: '0.5em',
-            height: '60vh',
-            width: '30em',
-            position: 'relative',
-          }}
-        >
+        {variable && (
+          <div style={{ textAlign: 'center', padding: '0.25em' }}>
+            <Button
+              type="button"
+              style={{ width: '100%' }}
+              variant="contained"
+              color="default"
+              size="small"
+              onClick={() => onChange()}
+            >
+              Clear selection
+            </Button>
+          </div>
+        )}
+        <div className={cx('-VariableTreeDropdownTreeContainer')}>
           <VariableTree {...props} />
         </div>
       </PopoverButton>
-      {variable && (
-        <button
-          type="button"
-          style={{ position: 'absolute', bottom: '-1.5em', right: 0 }}
-          className="link"
-          onClick={() => onChange()}
-        >
-          clear
-        </button>
-      )}
     </div>
   );
 }

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -1,15 +1,18 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { makeStyles } from '@material-ui/core';
 import { StudyEntity } from '../../types/study';
 import { Variable } from '../../types/variable';
 import {
   DataElementConstraintRecord,
-  filterVariablesByConstraint,
+  excludedVariables,
   flattenConstraints,
   ValueByInputName,
 } from '../../utils/data-element-constraints';
 import { VariableTreeDropdown } from '../VariableTree';
-import { mapStructure } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
+import {
+  mapStructure,
+  preorder,
+} from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 
 interface InputSpec {
   name: string;
@@ -102,46 +105,76 @@ export function InputVariables(props: Props) {
   const flattenedConstraints =
     constraints && flattenConstraints(values, entities, constraints);
 
-  // Steps
-  // 1. Get closest prev and next values
-  // 2. If next defined, root is next's entity, otherwise default root entity
-  // 3. If prev is defined, remove prev's entity's children
-  // 4. Return tree.
-  const rootEntities = inputs.map((input) => {
-    if (dataElementDependencyOrder == null) return entities[0];
-
-    // 1
-    const index = dataElementDependencyOrder.indexOf(input.name);
-    // return root entity if dependencyOrder is not declared
-    if (index === -1) return entities[0];
-
-    const prevValue = dataElementDependencyOrder
-      .slice(0, index)
-      .map((n) => values[n])
-      .reverse()
-      .find((v) => v != null);
-    const nextValue = dataElementDependencyOrder
-      .slice(index + 1)
-      .map((n) => values[n])
-      .find((v) => v != null);
-
-    // 2
-    const rootEntityId = nextValue?.entityId ?? entities[0].id;
-    const rootEntity =
-      entities.find((entity) => entity.id === rootEntityId) ?? entities[0];
-
-    // 3
-    return prevValue == null
-      ? rootEntity
-      : mapStructure(
-          (entity) =>
-            entity.id === prevValue.entityId
-              ? { ...entity, children: [] }
-              : entity,
-          (entity) => entity.children ?? [],
-          rootEntity
+  // Find entities that are excluded for each variable, and union their variables
+  // with the disabled variables.
+  const disabledVariablesByInputIndex = useMemo(
+    () =>
+      inputs.map((input) => {
+        const disabledVariables = excludedVariables(
+          entities[0],
+          flattenedConstraints && flattenedConstraints[input.name]
         );
-  });
+        if (dataElementDependencyOrder == null) return disabledVariables;
+
+        const index = dataElementDependencyOrder.indexOf(input.name);
+        // no change if dependencyOrder is not declared
+        if (index === -1) return disabledVariables;
+
+        const prevValue = dataElementDependencyOrder
+          .slice(0, index)
+          .map((n) => values[n])
+          .reverse()
+          .find((v) => v != null);
+        const nextValue = dataElementDependencyOrder
+          .slice(index + 1)
+          .map((n) => values[n])
+          .find((v) => v != null);
+
+        // Remove descendants of next input's entity
+        if (prevValue) {
+          const entity = entities.find(
+            (entity) => entity.id === prevValue.entityId
+          );
+          if (entity == null) throw new Error('Unknown entity used.');
+          const childVariables = Array.from(
+            preorder(entity, (e) => e.children ?? [])
+          )
+            .slice(1)
+            .flatMap((e) =>
+              e.variables.map(
+                (variable): Variable => ({
+                  variableId: variable.id,
+                  entityId: e.id,
+                })
+              )
+            );
+          disabledVariables.push(...childVariables);
+        }
+
+        // remove ancestors of previous input's entity
+        if (nextValue == null || nextValue.entityId === entities[0].id)
+          return disabledVariables;
+        const ancestorTree = mapStructure<StudyEntity, StudyEntity>(
+          (entity, children) => ({
+            ...entity,
+            children: children.filter((e) => e.id !== nextValue.entityId),
+          }),
+          (entity) => entity.children ?? [],
+          entities[0]
+        );
+        const ancestorVariables = Array.from(
+          preorder(ancestorTree, (e) => e.children ?? [])
+        ).flatMap((e) =>
+          e.variables.map((variable) => ({
+            variableId: variable.id,
+            entityId: e.id,
+          }))
+        );
+        disabledVariables.push(...ancestorVariables);
+        return disabledVariables;
+      }),
+    [dataElementDependencyOrder, entities, flattenedConstraints, inputs, values]
+  );
 
   return (
     <div>
@@ -150,10 +183,8 @@ export function InputVariables(props: Props) {
           <div key={input.name} className={classes.input}>
             <div className={classes.label}>{input.label}</div>
             <VariableTreeDropdown
-              rootEntity={filterVariablesByConstraint(
-                rootEntities[index],
-                flattenedConstraints && flattenedConstraints[input.name]
-              )}
+              rootEntity={entities[0]}
+              disabledVariables={disabledVariablesByInputIndex[index]}
               starredVariables={starredVariables}
               toggleStarredVariable={toggleStarredVariable}
               entityId={values[input.name]?.entityId}

--- a/src/lib/core/components/workspaceTheme.ts
+++ b/src/lib/core/components/workspaceTheme.ts
@@ -33,7 +33,7 @@ export const workspaceTheme: ThemeOptions = {
         lineHeight: 1.25,
         textTransform: 'none',
       },
-      containedSizeSmall: {
+      sizeSmall: {
         padding: '4px 8px',
       },
     },

--- a/src/lib/core/components/workspaceTheme.ts
+++ b/src/lib/core/components/workspaceTheme.ts
@@ -13,6 +13,12 @@ export const workspaceTheme: ThemeOptions = {
       dark: '#084e71',
       contrastText: '#fff',
     },
+    secondary: {
+      light: '#FB7087',
+      main: '#DD314E',
+      dark: '#A00D25',
+      contrastText: '#fff',
+    },
   },
   props: {
     MuiButton: {
@@ -25,12 +31,15 @@ export const workspaceTheme: ThemeOptions = {
     MuiButton: {
       root: {
         lineHeight: 1.25,
-      },
-      contained: {
         textTransform: 'none',
       },
       containedSizeSmall: {
         padding: '4px 8px',
+      },
+    },
+    MuiPopover: {
+      root: {
+        border: '1px solid #ccc',
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2961,10 +2961,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/tsconfig/-/tsconfig-1.0.1.tgz#a2b748b46838af1337ca9f23d969993fb952def4"
   integrity sha512-i6gq7mgnyEN8/xW5EaI9RiWCwS1oB8cgWqx9h5w4vZtnb10oiyyepD640l9x/gZf6IWecjynRs7weDgSRs7l0Q==
 
-"@veupathdb/wdk-client@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.1.2.tgz#3b8b466e9ca72d8af6c07fc1dad21fd9b22e6059"
-  integrity sha512-PlUD6O0ihUfPWrcfLpi3Qgau4ew+V3lPfBq4YerxFS1Cn8fEskRRjtffpJqDNPzqDsWOrBblsBYaB9kpB1I2Dg==
+"@veupathdb/wdk-client@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.1.4.tgz#415b839a2c6efbd59c34d5bb7cd536b074f0ae0a"
+  integrity sha512-oEyAt3CtAzy4ZcL4Ja2kGhUg9AC3dyxUNIOCSGNDbj/6L49wcB7Gu7jLgM1uxJkN+dqsO9KreLxSg0r774rCiw==
   dependencies:
     "@types/datatables.net" "^1.10.5"
     "@types/flot" "^0.0.31"


### PR DESCRIPTION
This PR introduces changes to the variable picker used in visualizations. The changes are detailed in the list below.

- Shows incompatible variables as disabled.
- Adds a toggle to hide or show disabled variables, with some help text about variable compatibility. More verbiage is needed.
- Moves the "clear" button from outside the popover button to inside the variable tree dialogue. This de-clutters the primary user interface, and moves it to a more expected place.
- Changes the text color in the variable tree to black. This disambiguates the text from links.

Possible discussion points:
- Is the new location for the clear button ideal?
- What is the best scope for the state of the show/hide toggle? E.g., "component" vs "visualization" vs "analysis".

closes #177