### PR TITLE
Use Material UI tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.3.11",
+    "@veupathdb/components": "^0.3.14",
     "@veupathdb/wdk-client": "^0.1.4",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",
@@ -69,7 +69,7 @@
     "script-loader": "^0.7.2",
     "set-cookie-parser": "^2.4.6",
     "source-map-loader": "1",
-    "typescript": "^4.0.3",
+    "typescript": "^4.3.4",
     "web-vitals": "^0.2.4"
   },
   "husky": {

--- a/src/lib/core/components/FilterChip.tsx
+++ b/src/lib/core/components/FilterChip.tsx
@@ -1,4 +1,5 @@
-import { Chip } from '@material-ui/core';
+import React from 'react';
+import { Chip, Tooltip } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
 interface Props {
@@ -30,13 +31,14 @@ export default function FilterChip(props: Props) {
   const classes = useStyles(props);
 
   return (
-    <Chip
-      className={classes.root}
-      size="small"
-      label={props.children}
-      title={props.tooltipText}
-      clickable={true}
-      onDelete={props.onDelete}
-    />
+    <Tooltip title={props.tooltipText}>
+      <Chip
+        className={classes.root}
+        size="small"
+        label={props.children}
+        clickable={true}
+        onDelete={props.onDelete}
+      />
+    </Tooltip>
   );
 }

--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -37,18 +37,8 @@ import {
   FieldTreeNode,
 } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/Types';
 import { cx } from '../../workspace/Utils';
-import { Theme, Tooltip, withStyles } from '@material-ui/core';
-
-const HtmlTooltip = withStyles((theme: Theme) => ({
-  tooltip: {
-    backgroundColor: '#fffde7',
-    color: 'rgba(0, 0, 0, 0.87)',
-    maxWidth: 320,
-    fontSize: theme.typography.pxToRem(12),
-    border: '1px solid #dadde9',
-    boxShadow: theme.shadows[1],
-  },
-}))(Tooltip);
+import { Tooltip } from '@material-ui/core';
+import { HtmlTooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 
 //defining types - some are not used (need cleanup later)
 interface VariableField {
@@ -316,9 +306,16 @@ export default function VariableList(props: VariableListProps) {
           {disabledFields.size > 0 && (
             <div className={cx('-DisabledVariablesToggle')}>
               <HtmlTooltip
+                css={
+                  {
+                    /*
+                     * This is needed to address a compiler error.
+                     * Not sure why it's complaining, but here we are...
+                     */
+                  }
+                }
                 title={tooltipContent}
                 interactive
-                // hideEvent="click mouseout"
               >
                 <button
                   className="link"

--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -25,7 +25,6 @@ import {
 import CheckboxTree from '@veupathdb/wdk-client/lib/Components/CheckboxTree/CheckboxTree';
 import Icon from '@veupathdb/wdk-client/lib/Components/Icon/IconAlt';
 import Toggle from '@veupathdb/wdk-client/lib/Components/Icon/Toggle';
-import Tooltip from '@veupathdb/wdk-client/lib/Components/Overlays/Tooltip';
 import {
   isFilterField,
   isMulti,
@@ -38,6 +37,18 @@ import {
   FieldTreeNode,
 } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/Types';
 import { cx } from '../../workspace/Utils';
+import { Theme, Tooltip, withStyles } from '@material-ui/core';
+
+const HtmlTooltip = withStyles((theme: Theme) => ({
+  tooltip: {
+    backgroundColor: '#fffde7',
+    color: 'rgba(0, 0, 0, 0.87)',
+    maxWidth: 320,
+    fontSize: theme.typography.pxToRem(12),
+    border: '1px solid #dadde9',
+    boxShadow: theme.shadows[1],
+  },
+}))(Tooltip);
 
 //defining types - some are not used (need cleanup later)
 interface VariableField {
@@ -253,11 +264,10 @@ export default function VariableList(props: VariableListProps) {
   const additionalFilters = useMemo(
     () => [
       <Tooltip
-        content={makeStarredVariablesFilterTooltipContent(
+        title={makeStarredVariablesFilterTooltipContent(
           showOnlyStarredVariables,
           starredVariableToggleDisabled
         )}
-        hideDelay={0}
       >
         <div>
           <button
@@ -305,11 +315,10 @@ export default function VariableList(props: VariableListProps) {
         <>
           {disabledFields.size > 0 && (
             <div className={cx('-DisabledVariablesToggle')}>
-              <Tooltip
-                content={tooltipContent}
-                showDelay={50}
-                hideDelay={50}
-                hideEvent="click mouseout"
+              <HtmlTooltip
+                title={tooltipContent}
+                interactive
+                // hideEvent="click mouseout"
               >
                 <button
                   className="link"
@@ -321,7 +330,7 @@ export default function VariableList(props: VariableListProps) {
                   <Toggle on={hideDisabledFields} /> Only show compatible
                   variables
                 </button>
-              </Tooltip>
+              </HtmlTooltip>
             </div>
           )}
           {treeSection}
@@ -423,57 +432,58 @@ const FieldNode = ({
     return () => clearTimeout(timerId);
   }, [isActive, searchTerm]);
 
-  const fieldContents = (
-    <Tooltip content={node.field.description} hideDelay={0}>
-      {isFilterField(node.field) ? (
-        <a
-          ref={nodeRef}
-          className={
-            'wdk-AttributeFilterFieldItem' +
-            (isActive ? ' wdk-AttributeFilterFieldItem__active' : '') +
-            (isDisabled ? ' wdk-AttributeFilterFieldItem__disabled' : '')
-          }
-          href={'#' + node.field.term}
-          title={
-            isDisabled
-              ? 'This variable cannot be used with this plot and other variable selections.'
-              : 'Select this variable.'
-          }
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            if (!isDisabled) handleFieldSelect(node);
-          }}
-        >
-          <Icon fa={getIcon(node.field)} /> {node.field.display}
-        </a>
-      ) : (
-        //add condition for identifying entity parent and entity parent of activeField
-        <div
-          className={
-            'wdk-Link wdk-AttributeFilterFieldParent' +
-            (node.field.term.includes('entity:')
-              ? ' wdk-AttributeFilterFieldEntityParent'
-              : '') +
-            (activeFieldEntity != null &&
-            node.field.term.split(':')[1] === activeFieldEntity
-              ? ' wdk-AttributeFilterFieldParent__active'
-              : '')
-          }
-        >
-          {node.field.display}
-        </div>
-      )}
+  const fieldContents = isFilterField(node.field) ? (
+    <Tooltip
+      title={
+        isDisabled
+          ? 'This variable cannot be used with this plot and other variable selections.'
+          : 'Select this variable.'
+      }
+    >
+      <a
+        ref={nodeRef}
+        className={
+          'wdk-AttributeFilterFieldItem' +
+          (isActive ? ' wdk-AttributeFilterFieldItem__active' : '') +
+          (isDisabled ? ' wdk-AttributeFilterFieldItem__disabled' : '')
+        }
+        href={'#' + node.field.term}
+        title={
+          isDisabled
+            ? 'This variable cannot be used with this plot and other variable selections.'
+            : 'Select this variable.'
+        }
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (!isDisabled) handleFieldSelect(node);
+        }}
+      >
+        <Icon fa={getIcon(node.field)} /> {node.field.display}
+      </a>
     </Tooltip>
+  ) : (
+    //add condition for identifying entity parent and entity parent of activeField
+    <div
+      className={
+        'wdk-Link wdk-AttributeFilterFieldParent' +
+        (node.field.term.includes('entity:')
+          ? ' wdk-AttributeFilterFieldEntityParent'
+          : '') +
+        (activeFieldEntity != null &&
+        node.field.term.split(':')[1] === activeFieldEntity
+          ? ' wdk-AttributeFilterFieldParent__active'
+          : '')
+      }
+    >
+      {node.field.display}
+    </div>
   );
 
   return (
     <>
       {isFilterField(node.field) && (
-        <Tooltip
-          content={makeStarButtonTooltipContent(node, isStarred)}
-          hideDelay={0}
-        >
+        <Tooltip title={makeStarButtonTooltipContent(node, isStarred)}>
           <button
             className={`${cx('-StarButton')} link`}
             onClick={onClickStar}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -22,6 +22,7 @@ import { VisualizationType } from './VisualizationTypes';
 import './Visualizations.scss';
 import { ContentError } from '@veupathdb/wdk-client/lib/Components/PageStatus/ContentError';
 import PlaceholderIcon from './PlaceholderIcon';
+import { Tooltip } from '@material-ui/core';
 
 const cx = makeClassNameHelper('VisualizationsContainer');
 
@@ -109,37 +110,41 @@ function ConfiguredVisualizations(props: Props) {
               <div key={viz.id} className={cx('-ConfiguredVisualization')}>
                 <div className={cx('-ConfiguredVisualizationActions')}>
                   <div>
-                    <button
-                      title="Delete visualization"
-                      type="button"
-                      className="link"
-                      onClick={() => deleteVisualization(viz.id)}
-                    >
-                      <i className="fa fa-trash"></i>
-                    </button>
+                    <Tooltip title="Delete visualization">
+                      <button
+                        type="button"
+                        className="link"
+                        onClick={() => deleteVisualization(viz.id)}
+                      >
+                        <i className="fa fa-trash"></i>
+                      </button>
+                    </Tooltip>
                   </div>
                   <div>
-                    <button
-                      title="Copy visualization"
-                      type="button"
-                      className="link"
-                      onClick={() =>
-                        addVisualization({
-                          ...viz,
-                          displayName: `Copy of ${
-                            viz.displayName ?? 'visualization'
-                          }`,
-                          id: uuid(),
-                        })
-                      }
-                    >
-                      <i className="fa fa-clone"></i>
-                    </button>
+                    <Tooltip title="Copy visualization">
+                      <button
+                        type="button"
+                        className="link"
+                        onClick={() =>
+                          addVisualization({
+                            ...viz,
+                            displayName: `Copy of ${
+                              viz.displayName ?? 'visualization'
+                            }`,
+                            id: uuid(),
+                          })
+                        }
+                      >
+                        <i className="fa fa-clone"></i>
+                      </button>
+                    </Tooltip>
                   </div>
                   <div>
-                    <Link to={`${url}/${viz.id}`} title="View fullscreen">
-                      <i className="fa fa-arrows-alt"></i>
-                    </Link>
+                    <Tooltip title="View fullscreen">
+                      <Link to={`${url}/${viz.id}`}>
+                        <i className="fa fa-arrows-alt"></i>
+                      </Link>
+                    </Tooltip>
                   </div>
                 </div>
                 {type ? (
@@ -259,44 +264,48 @@ function FullScreenVisualization(props: Props & { id: string }) {
     <div className={cx('-FullScreenContainer')}>
       <div className={cx('-FullScreenActions')}>
         <div>
-          <button
-            title="Delete visualization"
-            type="button"
-            className="link"
-            onClick={() => {
-              if (viz == null) return;
-              deleteVisualization(viz.id);
-              history.replace(Path.resolve(history.location.pathname, '..'));
-            }}
-          >
-            <i className="fa fa-trash"></i>
-          </button>
+          <Tooltip title="Delete visualization">
+            <button
+              type="button"
+              className="link"
+              onClick={() => {
+                if (viz == null) return;
+                deleteVisualization(viz.id);
+                history.replace(Path.resolve(history.location.pathname, '..'));
+              }}
+            >
+              <i className="fa fa-trash"></i>
+            </button>
+          </Tooltip>
         </div>
         <div>
-          <button
-            title="Copy visualization"
-            type="button"
-            className="link"
-            onClick={() => {
-              if (viz == null) return;
-              const id = uuid();
-              addVisualization({
-                ...viz,
-                id,
-                displayName:
-                  'Copy of ' + (viz.displayName || 'unnamed visualization'),
-              });
-              history.replace(
-                Path.resolve(history.location.pathname, '..', id)
-              );
-            }}
-          >
-            <i className="fa fa-clone"></i>
-          </button>
+          <Tooltip title="Copy visualization">
+            <button
+              type="button"
+              className="link"
+              onClick={() => {
+                if (viz == null) return;
+                const id = uuid();
+                addVisualization({
+                  ...viz,
+                  id,
+                  displayName:
+                    'Copy of ' + (viz.displayName || 'unnamed visualization'),
+                });
+                history.replace(
+                  Path.resolve(history.location.pathname, '..', id)
+                );
+              }}
+            >
+              <i className="fa fa-clone"></i>
+            </button>
+          </Tooltip>
         </div>
-        <Link to={`../${computationId}`} title="Minimize visualization">
-          <i className="fa fa-window-restore"></i>
-        </Link>
+        <Tooltip title="Minimize visualization">
+          <Link to={`../${computationId}`}>
+            <i className="fa fa-window-restore"></i>
+          </Link>
+        </Tooltip>
       </div>
       {viz == null ? (
         <ContentError>Visualization not found.</ContentError>

--- a/src/lib/core/components/workspaceTheme.ts
+++ b/src/lib/core/components/workspaceTheme.ts
@@ -42,5 +42,10 @@ export const workspaceTheme: ThemeOptions = {
         border: '1px solid #ccc',
       },
     },
+    MuiTooltip: {
+      tooltip: {
+        fontSize: 12,
+      },
+    },
   },
 };

--- a/src/lib/workspace/ActionIconButton.tsx
+++ b/src/lib/workspace/ActionIconButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { IconAlt } from '@veupathdb/wdk-client/lib/Components';
 import { cx } from './Utils';
+import { Tooltip } from '@material-ui/core';
 
 interface Props {
   iconClassName: string;
@@ -12,9 +13,11 @@ export function ActionIconButton(props: Props) {
   const { action, hoverText, iconClassName } = props;
   return (
     <div className={cx('-ActionIconButton')}>
-      <button type="button" title={hoverText} className="link" onClick={action}>
-        <IconAlt fa={iconClassName} />
-      </button>
+      <Tooltip title={hoverText}>
+        <button type="button" className="link" onClick={action}>
+          <IconAlt fa={iconClassName} />
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/src/lib/workspace/Subsetting.tsx
+++ b/src/lib/workspace/Subsetting.tsx
@@ -9,6 +9,7 @@ import { useEntityCounts } from '../core/hooks/entityCounts';
 import { useToggleStarredVariable } from '../core/hooks/starredVariables';
 import { VariableTree } from '../core/components/VariableTree';
 import FilterChipList from '../core/components/FilterChipList';
+import { Tooltip } from '@material-ui/core';
 
 interface Props {
   analysisState: AnalysisState;
@@ -76,14 +77,15 @@ export function Subsetting(props: Props) {
         />
       </div>
       <div className="TabularDownload">
-        <button
-          type="button"
-          className="link"
-          title={`Download current subset of ${entity.displayName}`}
-          onClick={() => alert('Coming soon')}
-        >
-          <i className="fa fa-table" />
-        </button>
+        <Tooltip title={`Download current subset of ${entity.displayName}`}>
+          <button
+            type="button"
+            className="link"
+            onClick={() => alert('Coming soon')}
+          >
+            <i className="fa fa-table" />
+          </button>
+        </Tooltip>
       </div>
       <div className="Filter">
         <Variable

--- a/yarn.lock
+++ b/yarn.lock
@@ -1576,7 +1576,7 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@material-ui/core@^4.11.2":
+"@material-ui/core@^4.11.2", "@material-ui/core@^4.11.3":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.4.tgz#4fb9fe5dec5dcf780b687e3a40cff78b2b9640a4"
   integrity sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==
@@ -1585,24 +1585,6 @@
     "@material-ui/styles" "^4.11.4"
     "@material-ui/system" "^4.11.3"
     "@material-ui/types" "5.1.0"
-    "@material-ui/utils" "^4.11.2"
-    "@types/react-transition-group" "^4.2.0"
-    clsx "^1.0.4"
-    hoist-non-react-statics "^3.3.2"
-    popper.js "1.16.1-lts"
-    prop-types "^15.7.2"
-    react-is "^16.8.0 || ^17.0.0"
-    react-transition-group "^4.4.0"
-
-"@material-ui/core@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.3.tgz#f22e41775b0bd075e36a7a093d43951bf7f63850"
-  integrity sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@material-ui/styles" "^4.11.3"
-    "@material-ui/system" "^4.11.3"
-    "@material-ui/types" "^5.1.0"
     "@material-ui/utils" "^4.11.2"
     "@types/react-transition-group" "^4.2.0"
     clsx "^1.0.4"
@@ -1630,7 +1612,7 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
-"@material-ui/styles@^4.11.3", "@material-ui/styles@^4.11.4":
+"@material-ui/styles@^4.11.4":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"
   integrity sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==
@@ -1662,7 +1644,7 @@
     csstype "^2.5.2"
     prop-types "^15.7.2"
 
-"@material-ui/types@5.1.0", "@material-ui/types@^5.1.0":
+"@material-ui/types@5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
   integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
@@ -2900,10 +2882,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.3.11":
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.11.tgz#3e944d63528b3c6336939b0e52c0c6a98706105b"
-  integrity sha512-u5wy6pFz1h9RdtE6wntnhT75u4FRj39JHUzdKaeAmJkBSzza6dSc4FmtpHw48leyIHOFAjOMFI5mfLClhzWCag==
+"@veupathdb/components@^0.3.14":
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.14.tgz#5b5df11fe6233e7d93402ea4cb9f57bb870e4fb9"
+  integrity sha512-a3xVpBSVaOl46B/clzrsFovA0Rl2pBg5pnQnLWSxNymbMn/IBmh3muiIfkX76wgjd+gRMAWVaLfqHwkgVSz/Uw==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"
@@ -16029,10 +16011,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+typescript@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
+  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
 unbox-primitive@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR utilizes tooltips from the Material UI library. We may want to use these tooltips in other parts of the EDA workspace, such as places where we are currently relying on system tooltips (via the `title` attributes).