### PR TITLE
handling date string for scatter plot viz

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.3.15",
+    "@veupathdb/components": "^0.3.17",
     "@veupathdb/wdk-client": "^0.1.4",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,10 +2889,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.3.15":
-  version "0.3.15"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.15.tgz#3e6f60beb6d11de2cc660b25583ba5c6e6f2080f"
-  integrity sha512-z52+V5fP6ohKnu46hag0sgkVgLjdJcFsVJQKMsAu2EXDjwJbRRRbR/EoJnAGcTVe5C8O3zVrsdzzS5eG8lDM3g==
+"@veupathdb/components@^0.3.17":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.17.tgz#4415224554c2cf5ab3ccc6dd76f8536af2db024a"
+  integrity sha512-8iTgjT2MPT2xAZ9k0M4O+lfaPm+ETcrIaqlQh3d8qaj7EOQHAsGN/nvKoI1ZoRpXRNOIFHFhVgV1gPbH2ZmcIw==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
This PR involves several works concerning scatter plot and its viz. Since its plot component is changed, [the work at web-components](https://github.com/VEuPathDB/web-components/pull/161) needs to be merged as well.

Changes are:
a) handled date string for scatter plot (see the first screenshot)
  : simplified the function to make plotly friendly data
  : changed to use lodash for min/max and math operations
b) addressed David's suggestion to place lines on top of markers: owing to Dave's suggestion (refer to the first screenshot)
c) added overlay variable's value to legend for smoothed mean, confidence interval, and best fit line cases for better distinction
  : by addressing b), above cases are always shown after all markers (refer to the first screenshot)
d) dynamic plot control for its viz: only show Raw option when y-axis variable is date (refer to the second screenshot)
e) bug fix for y-axis range

![scatter-date1](https://user-images.githubusercontent.com/12802305/123681946-67f73100-d818-11eb-910b-3c73cd36b070.png)

![scatter-date2](https://user-images.githubusercontent.com/12802305/123681994-73e2f300-d818-11eb-8053-8b527522872e.png)
