### PR TITLE
Fix EDA to work with refactored plot components and controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.3.14",
+    "@veupathdb/components": "^0.3.15",
     "@veupathdb/wdk-client": "^0.1.4",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -1,4 +1,5 @@
 import HistogramControls from '@veupathdb/components/lib/components/plotControls/HistogramControls';
+import SelectedRangeControl from '@veupathdb/components/lib/components/plotControls/SelectedRangeControl';
 import Histogram, {
   HistogramProps,
 } from '@veupathdb/components/lib/plots/Histogram';
@@ -275,11 +276,13 @@ export function HistogramFilter(props: Props) {
             data.value.variableId === variable.id &&
             data.value.entityId === entity.id
               ? data.value
-              : { series: [] }
+              : undefined
           }
           getData={getData}
-          width="100%"
-          height={400}
+          containerStyles={{
+            width: '100%',
+            height: '400px',
+          }}
           spacingOptions={{
             marginTop: 20,
             marginBottom: 20,
@@ -333,7 +336,7 @@ function HistogramPlotWithControls({
   );
 
   const handleBinWidthChange = useCallback(
-    ({ binWidth: newBinWidth }: { binWidth: NumberOrTimeDelta }) => {
+    (newBinWidth: NumberOrTimeDelta) => {
       updateUIState({
         binWidth: isTimeDelta(newBinWidth) ? newBinWidth.value : newBinWidth,
         binWidthTimeUnit: isTimeDelta(newBinWidth)
@@ -412,28 +415,23 @@ function HistogramPlotWithControls({
   }, [filter]);
 
   const selectedRangeBounds = {
-    min: data.series[0]?.summary?.min,
-    max: data.series[0]?.summary?.max,
+    min: data?.series[0]?.summary?.min,
+    max: data?.series[0]?.summary?.max,
   } as NumberOrDateRange;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <HistogramControls
-        valueType={data.valueType}
-        barLayout={barLayout}
-        displayLegend={displayLegend}
-        displayLibraryControls={displayLibraryControls}
-        opacity={opacity}
-        orientation={histogramProps.orientation}
-        errorManagement={errorManagement}
+      <SelectedRangeControl
+        label={`Subset on ${variableName}`}
+        valueType={data?.valueType}
         selectedRange={selectedRange}
         selectedRangeBounds={selectedRangeBounds}
         onSelectedRangeChange={handleSelectedRangeChange}
-        containerStyles={{ border: 'none' }}
       />
       <Histogram
         {...histogramProps}
         data={data}
+        interactive={true}
         selectedRange={selectedRange}
         selectedRangeBounds={selectedRangeBounds}
         opacity={opacity}
@@ -456,21 +454,16 @@ function HistogramPlotWithControls({
       />
       <HistogramControls
         label="Axis controls"
-        valueType={data.valueType}
+        valueType={data?.valueType}
         barLayout={barLayout}
         displayLegend={displayLegend}
         displayLibraryControls={displayLibraryControls}
         opacity={opacity}
         orientation={histogramProps.orientation}
-        binWidth={data.binWidth}
-        selectedUnit={
-          data.binWidth && isTimeDelta(data.binWidth)
-            ? data.binWidth.unit
-            : undefined
-        }
+        binWidth={data?.binWidth}
         onBinWidthChange={handleBinWidthChange}
-        binWidthRange={data.binWidthRange}
-        binWidthStep={data.binWidthStep}
+        binWidthRange={data?.binWidthRange}
+        binWidthStep={data?.binWidthStep}
         errorManagement={errorManagement}
         independentAxisRange={uiState.independentAxisRange}
         onIndependentAxisRangeChange={handleIndependentAxisRangeChange}

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -453,7 +453,7 @@ function HistogramPlotWithControls({
         }}
       />
       <HistogramControls
-        label="Axis controls"
+        label={undefined}
         valueType={data?.valueType}
         barLayout={barLayout}
         displayLegend={displayLegend}

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -248,7 +248,7 @@ function BarplotViz(props: Props) {
           data={data.value && !data.pending ? data.value : { series: [] }}
           containerStyles={{
             width: '230px',
-            height: '165px',
+            height: '150px',
           }}
           // check this option (possibly plot control?)
           orientation={'vertical'}

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -2,7 +2,6 @@
 import Barplot, { BarplotProps } from '@veupathdb/components/lib/plots/Barplot';
 import { ErrorManagement } from '@veupathdb/components/lib/types/general';
 
-import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { getOrElse } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/function';
@@ -228,9 +227,10 @@ function BarplotViz(props: Props) {
       {fullscreen ? (
         <BarplotWithControls
           data={data.value && !data.pending ? data.value : { series: [] }}
-          width={'100%'}
-          height={450}
-          // height={'100%'}
+          containerStyles={{
+            width: '100%',
+            height: '450px',
+          }}
           orientation={'vertical'}
           barLayout={'group'}
           displayLegend={data.value?.series.length > 1}
@@ -246,8 +246,10 @@ function BarplotViz(props: Props) {
         // thumbnail/grid view
         <Barplot
           data={data.value && !data.pending ? data.value : { series: [] }}
-          width={230}
-          height={165}
+          containerStyles={{
+            width: '230px',
+            height: '165px',
+          }}
           // check this option (possibly plot control?)
           orientation={'vertical'}
           barLayout={'group'}
@@ -257,9 +259,14 @@ function BarplotViz(props: Props) {
           // new props for better displaying grid view
           displayLegend={false}
           displayLibraryControls={false}
-          staticPlot={true}
+          interactive={false}
           // set margin for better display at thumbnail/grid view
-          margin={{ l: 30, r: 20, b: 0, t: 20 }}
+          spacingOptions={{
+            marginLeft: 30,
+            marginRight: 20,
+            marginBottom: 0,
+            marginTop: 20,
+          }}
           showSpinner={data.pending}
         />
       )}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -2,6 +2,9 @@ import HistogramControls from '@veupathdb/components/lib/components/plotControls
 import Histogram, {
   HistogramProps,
 } from '@veupathdb/components/lib/plots/Histogram';
+import BinWidthControl from '@veupathdb/components/lib/components/plotControls/BinWidthControl';
+import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
+import Switch from '@veupathdb/components/lib/components/widgets/Switch';
 import {
   ErrorManagement,
   NumberOrTimeDelta,
@@ -341,21 +344,23 @@ function HistogramPlotWithControls({
         showValues={false}
         barLayout={barLayout}
       />
-      <HistogramControls
-        valueType={data?.valueType}
-        barLayout={barLayout}
-        displayLegend={false /* should not be a required prop */}
-        displayLibraryControls={displayLibraryControls}
-        opacity={opacity}
-        orientation={histogramProps.orientation}
-        binWidth={data?.binWidth}
-        onBinWidthChange={onBinWidthChange}
-        binWidthRange={data?.binWidthRange}
-        binWidthStep={data?.binWidthStep}
-        errorManagement={errorManagement}
-        dependentAxisLogScale={histogramProps.dependentAxisLogScale}
-        toggleDependentAxisLogScale={handleDependentAxisLogScale}
-      />
+      <div style={{ display: 'flex', flexDirection: 'row' }}>
+        <LabelledGroup label="Y-axis">
+          <Switch
+            label="Log Scale:"
+            state={histogramProps.dependentAxisLogScale}
+            onStateChange={handleDependentAxisLogScale}
+          />
+        </LabelledGroup>
+        <LabelledGroup label="X-axis">
+          <BinWidthControl
+            binWidth={data?.binWidth}
+            onBinWidthChange={onBinWidthChange}
+            binWidthRange={data?.binWidthRange}
+            binWidthStep={data?.binWidthStep}
+          />
+        </LabelledGroup>
+      </div>
     </div>
   );
 }

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -10,7 +10,6 @@ import {
 } from '@veupathdb/components/lib/types/general';
 import { isTimeDelta } from '@veupathdb/components/lib/types/guards';
 import { HistogramData } from '@veupathdb/components/lib/types/plots';
-import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { getOrElse } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/function';
@@ -150,7 +149,7 @@ function HistogramViz(props: Props) {
   );
 
   const onBinWidthChange = useCallback(
-    ({ binWidth: newBinWidth }: { binWidth: NumberOrTimeDelta }) => {
+    (newBinWidth: NumberOrTimeDelta) => {
       if (newBinWidth) {
         updateVizConfig({
           binWidth: isTimeDelta(newBinWidth) ? newBinWidth.value : newBinWidth,
@@ -265,12 +264,14 @@ function HistogramViz(props: Props) {
       )}
       {fullscreen ? (
         <HistogramPlotWithControls
-          data={data.value && !data.pending ? data.value : { series: [] }}
+          data={data.value && !data.pending ? data.value : undefined}
           onBinWidthChange={onBinWidthChange}
           dependentAxisLogScale={vizConfig.dependentAxisLogScale}
           handleDependentAxisLogScale={handleDependentAxisLogScale}
-          width="100%"
-          height={400}
+          containerStyles={{
+            width: '100%',
+            height: '400px',
+          }}
           orientation={'vertical'}
           barLayout={'stack'}
           displayLegend={
@@ -286,9 +287,11 @@ function HistogramViz(props: Props) {
       ) : (
         // thumbnail/grid view
         <Histogram
-          data={data.value && !data.pending ? data.value : { series: [] }}
-          width={350}
-          height={280}
+          data={data.value && !data.pending ? data.value : undefined}
+          containerStyles={{
+            width: '350px',
+            height: '280px',
+          }}
           orientation={'vertical'}
           barLayout={'stack'}
           displayLibraryControls={false}
@@ -305,11 +308,7 @@ function HistogramViz(props: Props) {
 }
 
 type HistogramPlotWithControlsProps = HistogramProps & {
-  onBinWidthChange: ({
-    binWidth: newBinWidth,
-  }: {
-    binWidth: NumberOrTimeDelta;
-  }) => void;
+  onBinWidthChange: (newBinWidth: NumberOrTimeDelta) => void;
   handleDependentAxisLogScale: (newState?: boolean) => void;
 };
 
@@ -339,27 +338,20 @@ function HistogramPlotWithControls({
         data={data}
         opacity={opacity}
         displayLibraryControls={displayLibraryControls}
-        showBarValues={false}
+        showValues={false}
         barLayout={barLayout}
       />
       <HistogramControls
-        valueType={data.valueType}
+        valueType={data?.valueType}
         barLayout={barLayout}
         displayLegend={false /* should not be a required prop */}
         displayLibraryControls={displayLibraryControls}
         opacity={opacity}
         orientation={histogramProps.orientation}
-        binWidth={data.binWidth}
-        selectedUnit={
-          data.binWidth && isTimeDelta(data.binWidth)
-            ? data.binWidth.unit
-            : undefined
-        }
-        onBinWidthChange={({ binWidth: newBinWidth }) => {
-          onBinWidthChange({ binWidth: newBinWidth });
-        }}
-        binWidthRange={data.binWidthRange}
-        binWidthStep={data.binWidthStep}
+        binWidth={data?.binWidth}
+        onBinWidthChange={onBinWidthChange}
+        binWidthRange={data?.binWidthRange}
+        binWidthStep={data?.binWidthStep}
         errorManagement={errorManagement}
         dependentAxisLogScale={histogramProps.dependentAxisLogScale}
         toggleDependentAxisLogScale={handleDependentAxisLogScale}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -364,6 +364,7 @@ function HistogramPlotWithControls({
             onBinWidthChange={onBinWidthChange}
             binWidthRange={data?.binWidthRange}
             binWidthStep={data?.binWidthStep}
+            valueType={data?.valueType}
           />
         </LabelledGroup>
       </div>

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -292,8 +292,14 @@ function HistogramViz(props: Props) {
         <Histogram
           data={data.value && !data.pending ? data.value : undefined}
           containerStyles={{
-            width: '350px',
-            height: '280px',
+            width: '250px',
+            height: '180px',
+          }}
+          spacingOptions={{
+            marginLeft: 0,
+            marginRight: 30,
+            marginTop: 30,
+            marginBottom: 0,
           }}
           orientation={'vertical'}
           barLayout={'stack'}

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -1,9 +1,9 @@
 // import MosaicControls from '@veupathdb/components/lib/components/plotControls/MosaicControls';
 import Mosaic, {
-  Props as MosaicProps,
+  MosaicPlotProps as MosaicProps,
 } from '@veupathdb/components/lib/plots/MosaicPlot';
+import { MosaicData } from '@veupathdb/components/lib/types/plots';
 // import { ErrorManagement } from '@veupathdb/components/lib/types/general';
-import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { getOrElse } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/function';
@@ -20,11 +20,6 @@ import { InputVariables } from '../InputVariables';
 import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
 import contingency from './selectorIcons/contingency.svg';
 import mosaic from './selectorIcons/mosaic.svg';
-
-type MosaicData = Pick<
-  MosaicProps,
-  'data' | 'independentValues' | 'dependentValues'
->;
 
 type ContTableData = MosaicData &
   Partial<{
@@ -292,25 +287,21 @@ function MosaicViz(props: Props) {
     <div className="MosaicVisualization">
       <div className="MosaicVisualization-Plot">
         <MosaicPlotWithControls
-          data={data.value && !data.pending ? data.value.data : [[]]}
-          independentValues={
-            data.value && !data.pending ? data.value.independentValues : []
-          }
-          dependentValues={
-            data.value && !data.pending ? data.value.dependentValues : []
-          }
-          height={450}
-          independentLabel={
+          data={data.value && !data.pending ? data.value : undefined}
+          containerStyles={{
+            height: '450px',
+          }}
+          independentAxisLabel={
             data.value && !data.pending && xAxisVariableName
               ? xAxisVariableName
               : ''
           }
-          dependentLabel={
+          dependentAxisLabel={
             data.value && !data.pending && yAxisVariableName
               ? yAxisVariableName
               : ''
           }
-          showLegend={true}
+          displayLegend={true}
           showSpinner={data.pending}
         />
       </div>
@@ -319,22 +310,23 @@ function MosaicViz(props: Props) {
   ) : (
     // thumbnail/grid view
     <Mosaic
-      data={data.value && !data.pending ? data.value.data : [[]]}
-      independentValues={
-        data.value && !data.pending ? data.value.independentValues : []
-      }
-      dependentValues={
-        data.value && !data.pending ? data.value.dependentValues : []
-      }
-      width={300}
-      height={180}
-      margin={{ t: 40, b: 20, l: 20, r: 10 }}
+      data={data.value && !data.pending ? data.value : undefined}
+      containerStyles={{
+        width: '300px',
+        height: '180px',
+      }}
+      spacingOptions={{
+        marginTop: 40,
+        marginBottom: 20,
+        marginLeft: 20,
+        marginRight: 10,
+      }}
       showColumnLabels={false}
-      showModebar={false}
-      showLegend={false}
-      staticPlot={true}
-      independentLabel=""
-      dependentLabel=""
+      displayLibraryControls={false}
+      displayLegend={false}
+      interactive={false}
+      independentAxisLabel={''}
+      dependentAxisLabel={''}
       showSpinner={data.pending}
     />
   );
@@ -418,7 +410,7 @@ function MosaicPlotWithControls({
       <Mosaic
         {...mosaicProps}
         data={data}
-        showModebar={displayLibraryControls}
+        displayLibraryControls={displayLibraryControls}
       />
       {/* <MosaicControls
         label="Mosaic Controls"
@@ -445,9 +437,10 @@ export function contTableResponseToData(
   const data = _.unzip(response.mosaic.data[0].value);
 
   return {
-    data: data,
-    independentValues: response.mosaic.data[0].xLabel,
-    dependentValues: response.mosaic.data[0].yLabel,
+    values: data,
+    independentLabels: response.mosaic.data[0].xLabel,
+    dependentLabels: response.mosaic.data[0].yLabel,
+
     pValue: response.statsTable[0].pvalue,
     degreesFreedom: response.statsTable[0].degreesFreedom,
     chisq: response.statsTable[0].chisq,
@@ -469,9 +462,10 @@ export function twoByTwoResponseToData(
   const data = _.unzip(response.mosaic.data[0].value);
 
   return {
-    data: data,
-    independentValues: response.mosaic.data[0].xLabel,
-    dependentValues: response.mosaic.data[0].yLabel,
+    values: data,
+    independentLabels: response.mosaic.data[0].xLabel,
+    dependentLabels: response.mosaic.data[0].yLabel,
+
     pValue: response.statsTable[0].pvalue,
     relativeRisk: response.statsTable[0].relativerisk,
     rrInterval: response.statsTable[0].rrInterval,

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -312,14 +312,14 @@ function MosaicViz(props: Props) {
     <Mosaic
       data={data.value && !data.pending ? data.value : undefined}
       containerStyles={{
-        width: '300px',
-        height: '180px',
+        width: '250px',
+        height: '150px',
       }}
       spacingOptions={{
-        marginTop: 40,
+        marginTop: 30,
         marginBottom: 20,
-        marginLeft: 20,
-        marginRight: 10,
+        marginLeft: 30,
+        marginRight: 20,
       }}
       showColumnLabels={false}
       displayLibraryControls={false}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1015,7 +1015,7 @@ function processInputData<T extends number | Date>(
     }
   });
 
-  return { dataSetProcess, xMin, xMax, yMin, yMax };
+  return { dataSetProcess: { series: dataSetProcess }, xMin, xMax, yMin, yMax };
 }
 
 /*

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1,7 +1,5 @@
 // load scatter plot component
-import XYPlot, {
-  ScatterplotProps,
-} from '@veupathdb/components/lib/plots/XYPlot';
+import XYPlot, { XYPlotProps } from '@veupathdb/components/lib/plots/XYPlot';
 import { ErrorManagement } from '@veupathdb/components/lib/types/general';
 
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
@@ -292,9 +290,11 @@ function ScatterplotViz(props: Props) {
         fullscreen ? (
           <ScatterplotWithControls
             // data.value
-            data={[...data.value.dataSetProcess]}
-            width={1000}
-            height={600}
+            data={data.value.dataSetProcess}
+            containerStyles={{
+              width: '1000px',
+              height: '600px',
+            }}
             // title={'Scatter plot'}
             independentAxisLabel={
               findVariable(vizConfig.xAxisVariable)?.displayName
@@ -302,9 +302,12 @@ function ScatterplotViz(props: Props) {
             dependentAxisLabel={
               findVariable(vizConfig.yAxisVariable)?.displayName
             }
-            independentAxisRange={[data.value.xMin, data.value.xMax]}
+            independentAxisRange={{
+              min: data.value.xMin,
+              max: data.value.xMax,
+            }}
             // block this for now
-            dependentAxisRange={[data.value.yMin, data.value.yMax]}
+            dependentAxisRange={{ min: data.value.yMin, max: data.value.yMax }}
             // XYPlotControls valueSpecInitial
             valueSpec={vizConfig.valueSpecConfig}
             // valueSpec={valueSpecInitial}
@@ -316,17 +319,27 @@ function ScatterplotViz(props: Props) {
         ) : (
           // thumbnail/grid view
           <XYPlot
-            data={[...data.value.dataSetProcess]}
-            width={230}
-            height={150}
-            independentAxisRange={[data.value.xMin, data.value.xMax]}
+            data={data.value.dataSetProcess}
+            containerStyles={{
+              width: '230px',
+              height: '150px',
+            }}
+            independentAxisRange={{
+              min: data.value.xMin,
+              max: data.value.xMax,
+            }}
             // block this for now
-            dependentAxisRange={[data.value.yMin, data.value.yMax]}
+            dependentAxisRange={{ min: data.value.yMin, max: data.value.yMax }}
             // new props for better displaying grid view
             displayLegend={false}
             displayLibraryControls={false}
-            staticPlot={true}
-            margin={{ l: 30, r: 20, b: 15, t: 20 }}
+            interactive={false}
+            spacingOptions={{
+              marginLeft: 30,
+              marginRight: 20,
+              marginBottom: 15,
+              marginTop: 20,
+            }}
             showSpinner={data.pending}
           />
         )
@@ -334,9 +347,18 @@ function ScatterplotViz(props: Props) {
         // no data or data error case: with control
         <>
           <XYPlot
-            data={[]}
-            width={fullscreen ? 1000 : 230}
-            height={fullscreen ? 600 : 150}
+            data={undefined}
+            containerStyles={
+              fullscreen
+                ? {
+                    width: '1000px',
+                    height: '600px',
+                  }
+                : {
+                    width: '230px',
+                    height: '150px',
+                  }
+            }
             independentAxisLabel={
               fullscreen
                 ? findVariable(vizConfig.xAxisVariable)?.displayName
@@ -347,10 +369,19 @@ function ScatterplotViz(props: Props) {
                 ? findVariable(vizConfig.yAxisVariable)?.displayName
                 : undefined
             }
-            displayLegend={fullscreen ? true : false}
+            displayLegend={fullscreen}
             displayLibraryControls={false}
-            staticPlot={fullscreen ? false : true}
-            margin={fullscreen ? {} : { l: 30, r: 20, b: 15, t: 20 }}
+            interactive={fullscreen}
+            spacingOptions={
+              fullscreen
+                ? {}
+                : {
+                    marginLeft: 30,
+                    marginRight: 20,
+                    marginBottom: 15,
+                    marginTop: 20,
+                  }
+            }
             showSpinner={data.pending}
           />
           {visualization.type === 'scatterplot' && fullscreen && (
@@ -380,7 +411,7 @@ function ScatterplotViz(props: Props) {
   );
 }
 
-type ScatterplotWithControlsProps = ScatterplotProps & {
+type ScatterplotWithControlsProps = XYPlotProps & {
   valueSpec: string | undefined;
   onValueSpecChange: (value: string) => void;
   vizType: string;
@@ -410,7 +441,7 @@ function ScatterplotWithControls({
         {...ScatterplotProps}
         data={data}
         // add controls
-        displayLegend={data.length > 1}
+        displayLegend={data?.series && data.series.length > 1}
         displayLibraryControls={false}
       />
       {/*  XYPlotControls: check vizType (only for scatterplot for now) */}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2882,10 +2882,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.3.14":
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.14.tgz#5b5df11fe6233e7d93402ea4cb9f57bb870e4fb9"
-  integrity sha512-a3xVpBSVaOl46B/clzrsFovA0Rl2pBg5pnQnLWSxNymbMn/IBmh3muiIfkX76wgjd+gRMAWVaLfqHwkgVSz/Uw==
+"@veupathdb/components@^0.3.15":
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.15.tgz#3e6f60beb6d11de2cc660b25583ba5c6e6f2080f"
+  integrity sha512-z52+V5fP6ohKnu46hag0sgkVgLjdJcFsVJQKMsAu2EXDjwJbRRRbR/EoJnAGcTVe5C8O3zVrsdzzS5eG8lDM3g==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Depends on web-components PR is https://github.com/VEuPathDB/web-components/pull/150 (`plot-props-tidy`)

Nothing really revolutionary here, however, take a look at `HistogramFilter` - the nasty double use of `HistogramControls` has been replaced by `SelectedRangeControl` and `HistogramControls`.

I could similarly update `HistogramVisualization` to use its own small set of controls instead of `HistogramControls`.  I may do this after I hit 'create' on this PR. (done!)

Before this is merged, please can @moontrip fix the ScatterplotVisualization - assigning to you too thanks!