### PR TITLE
change hard-corded part of viz tab behavior

### DIFF
--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -122,7 +122,8 @@ export function AnalysisPanel(props: Props) {
             display: 'Visualize',
             // check whether user is at viz's full screen mode
             route: inFullscreenVisualization
-              ? '/visualizations/pass-through'
+              ? // remove everything from the last '/' to the end (UUID in this case)
+                location.pathname.replace(routeBase, '').replace(/\/[^/]*$/, '')
               : `/visualizations${lastVizPath}`,
             exact: false,
           },

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -42,18 +42,6 @@ export function AnalysisPanel(props: Props) {
   const location = useLocation();
   const [lastVarPath, setLastVarPath] = useState('');
   const [lastVizPath, setLastVizPath] = useState('');
-  // check whether a user is at viz's full screen mode
-  const inFullscreenVisualization = useMemo(() => {
-    const relativePath = location.pathname.replace(routeBase, '');
-    const lastUrlElement = relativePath.split('/').pop();
-
-    // 'Browse and Subset' and the 'Visualize' selector do not have a UUID in the url
-    return (
-      lastUrlElement?.match(
-        '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
-      ) != null
-    );
-  }, [location, routeBase]);
 
   useEffect(() => {
     const relativePath = location.pathname.replace(routeBase, '');
@@ -120,10 +108,11 @@ export function AnalysisPanel(props: Props) {
           },
           {
             display: 'Visualize',
-            // check whether user is at viz's full screen mode
-            route: inFullscreenVisualization
-              ? // remove everything from the last '/' to the end (for this case, UUID)
-                location.pathname.replace(routeBase, '').replace(/\/[^/]*$/, '')
+            // check whether user is at viz
+            route: location.pathname
+              .replace(routeBase, '')
+              .includes('/visualizations')
+              ? '/visualizations'
               : `/visualizations${lastVizPath}`,
             exact: false,
           },

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -122,7 +122,7 @@ export function AnalysisPanel(props: Props) {
             display: 'Visualize',
             // check whether user is at viz's full screen mode
             route: inFullscreenVisualization
-              ? // remove everything from the last '/' to the end (UUID in this case)
+              ? // remove everything from the last '/' to the end (for this case, UUID)
                 location.pathname.replace(routeBase, '').replace(/\/[^/]*$/, '')
               : `/visualizations${lastVizPath}`,
             exact: false,

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -111,7 +111,7 @@ export function AnalysisPanel(props: Props) {
             // check whether user is at viz
             route: location.pathname
               .replace(routeBase, '')
-              .includes('/visualizations')
+              .startsWith('/visualizations')
               ? '/visualizations'
               : `/visualizations${lastVizPath}`,
             exact: false,


### PR DESCRIPTION
Following @bobular 's opinion, I have changed the hard-corded part, `/visualize/pass-through` to use a programmatic approach using regex.