### PR TITLE
Issue 198 adapt HistogramFilter to use extra variable annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.3.17",
+    "@veupathdb/components": "^0.3.18",
     "@veupathdb/wdk-client": "^0.1.4",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -378,9 +378,6 @@ function HistogramPlotWithControls({
 
   const handleIndependentAxisRangeChange = useCallback(
     (newRange?: NumberOrDateRange) => {
-      console.log(
-        `handleIndependentAxisRangeChange newRange: ${newRange?.min} to ${newRange?.max}`
-      );
       updateUIState({
         // when the independent axis range is 'zoomed', reset the binWidth
         // so the back end provides a suitable value

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -1,5 +1,11 @@
-import HistogramControls from '@veupathdb/components/lib/components/plotControls/HistogramControls';
 import SelectedRangeControl from '@veupathdb/components/lib/components/plotControls/SelectedRangeControl';
+import BinWidthControl from '@veupathdb/components/lib/components/plotControls/BinWidthControl';
+import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
+import Switch from '@veupathdb/components/lib/components/widgets/Switch';
+import Button from '@veupathdb/components/lib/components/widgets/Button';
+import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
+import { NumberRangeInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateRangeInputs';
+
 import Histogram, {
   HistogramProps,
 } from '@veupathdb/components/lib/plots/Histogram';
@@ -430,14 +436,6 @@ function HistogramPlotWithControls({
   const displayLegend = true;
   const displayLibraryControls = false;
   const opacity = 100;
-  const errorManagement = useMemo((): ErrorManagement => {
-    return {
-      errors: [],
-      addError: (error: Error) => {},
-      removeError: (error: Error) => {},
-      clearAllErrors: () => {},
-    };
-  }, []);
 
   const selectedRange = useMemo((): NumberOrDateRange | undefined => {
     if (filter == null) return;
@@ -490,28 +488,63 @@ function HistogramPlotWithControls({
           verticalPaddingAdjustment: 20,
         }}
       />
-      <HistogramControls
-        label={undefined}
-        valueType={data?.valueType}
-        barLayout={barLayout}
-        displayLegend={displayLegend}
-        displayLibraryControls={displayLibraryControls}
-        opacity={opacity}
-        orientation={histogramProps.orientation}
-        binWidth={data?.binWidth}
-        onBinWidthChange={handleBinWidthChange}
-        binWidthRange={data?.binWidthRange}
-        binWidthStep={data?.binWidthStep}
-        errorManagement={errorManagement}
-        independentAxisRange={uiState.independentAxisRange}
-        onIndependentAxisRangeChange={handleIndependentAxisRangeChange}
-        onIndependentAxisSettingsReset={handleIndependentAxisSettingsReset}
-        dependentAxisRange={uiState.dependentAxisRange}
-        onDependentAxisRangeChange={handleDependentAxisRangeChange}
-        onDependentAxisSettingsReset={handleDependentAxisSettingsReset}
-        dependentAxisLogScale={uiState.dependentAxisLogScale}
-        toggleDependentAxisLogScale={handleDependentAxisLogScale}
-      />
+
+      <div style={{ display: 'flex', flexDirection: 'row' }}>
+        <LabelledGroup label="Y-axis" containerStyles={{}}>
+          <Switch
+            label="Log Scale:"
+            state={uiState.dependentAxisLogScale}
+            onStateChange={handleDependentAxisLogScale}
+            containerStyles={{ paddingBottom: '0.3125em' }}
+          />
+
+          <NumberRangeInput
+            label="Range:"
+            range={uiState.dependentAxisRange}
+            onRangeChange={(newRange?: NumberOrDateRange) => {
+              handleDependentAxisRangeChange(newRange as NumberRange);
+            }}
+            allowPartialRange={false}
+          />
+
+          <Button
+            type={'solid'}
+            text={'Reset to defaults'}
+            onClick={handleDependentAxisSettingsReset}
+            containerStyles={{
+              paddingTop: '1.0em',
+              width: '100%',
+            }}
+          />
+        </LabelledGroup>
+
+        <LabelledGroup label="X-axis" containerStyles={{}}>
+          <BinWidthControl
+            binWidth={data?.binWidth}
+            binWidthStep={data?.binWidthStep}
+            binWidthRange={data?.binWidthRange}
+            onBinWidthChange={handleBinWidthChange}
+            valueType={data?.valueType}
+          />
+
+          <AxisRangeControl
+            label="Range:"
+            range={uiState.independentAxisRange}
+            onRangeChange={handleIndependentAxisRangeChange}
+            valueType={data?.valueType}
+          />
+
+          <Button
+            type={'solid'}
+            text={'Reset to defaults'}
+            onClick={handleIndependentAxisSettingsReset}
+            containerStyles={{
+              paddingTop: '1.0em',
+              width: '100%',
+            }}
+          />
+        </LabelledGroup>
+      </div>
     </div>
   );
 }

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -33,7 +33,7 @@ import { StudyEntity, StudyMetadata } from '../../types/study';
 import { TimeUnit, NumberOrDateRange, NumberRange } from '../../types/general';
 import { gray, red } from './colors';
 import { HistogramVariable } from './types';
-import { parseTimeDelta } from '../../utils/date-conversion';
+import { parseTimeDelta, fullISODateRange } from '../../utils/date-conversion';
 
 type Props = {
   studyMetadata: StudyMetadata;
@@ -447,10 +447,14 @@ function HistogramPlotWithControls({
     return { min: filter.min, max: filter.max } as NumberOrDateRange;
   }, [filter]);
 
-  const selectedRangeBounds = {
-    min: data?.series[0]?.summary?.min,
-    max: data?.series[0]?.summary?.max,
-  } as NumberOrDateRange;
+  const selectedRangeBounds = useMemo((): NumberOrDateRange | undefined => {
+    return data?.series[0]?.summary
+      ? fullISODateRange({
+          min: data.series[0].summary.min,
+          max: data.series[0].summary.max,
+        } as NumberOrDateRange)
+      : undefined;
+  }, [data?.series]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -445,13 +445,16 @@ function HistogramPlotWithControls({
   }, [filter]);
 
   const selectedRangeBounds = useMemo((): NumberOrDateRange | undefined => {
-    return data?.series[0]?.summary
-      ? fullISODateRange({
-          min: data.series[0].summary.min,
-          max: data.series[0].summary.max,
-        } as NumberOrDateRange)
+    return data?.series[0]?.summary && data?.valueType
+      ? fullISODateRange(
+          {
+            min: data.series[0].summary.min,
+            max: data.series[0].summary.max,
+          } as NumberOrDateRange,
+          data.valueType
+        )
       : undefined;
-  }, [data?.series]);
+  }, [data?.series, data?.valueType]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -283,7 +283,6 @@ function HistogramViz(props: Props) {
           }
           interactive={true}
           showSpinner={data.pending}
-          interactive={true}
           legendTitle={
             findEntityAndVariable(entities, vizConfig.overlayVariable)?.variable
               .displayName

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -267,7 +267,7 @@ function HistogramViz(props: Props) {
       )}
       {fullscreen ? (
         <HistogramPlotWithControls
-          data={data.value && !data.pending ? data.value : undefined}
+          data={data.value}
           onBinWidthChange={onBinWidthChange}
           dependentAxisLogScale={vizConfig.dependentAxisLogScale}
           handleDependentAxisLogScale={handleDependentAxisLogScale}
@@ -285,6 +285,7 @@ function HistogramViz(props: Props) {
           independentAxisLabel={
             xAxisVariable ? xAxisVariable.displayName : 'Bins'
           }
+          interactive={true}
           showSpinner={data.pending}
         />
       ) : (

--- a/src/lib/core/utils/date-conversion.ts
+++ b/src/lib/core/utils/date-conversion.ts
@@ -1,4 +1,7 @@
-import { TimeDelta } from '@veupathdb/components/lib/types/general';
+import {
+  TimeDelta,
+  NumberOrDateRange,
+} from '@veupathdb/components/lib/types/general';
 import { isTimeUnit } from '@veupathdb/components/lib/types/guards';
 
 /**
@@ -22,6 +25,20 @@ export function padISODateTime(ISODate: string): string {
     fixedISODateTime = fixedISODateTime + 'Z';
   }
   return fixedISODateTime;
+}
+
+/**
+ * Take a number or date range and if it's a date range,
+ * convert min and max to full ISO format datetimes.
+ */
+export function fullISODateRange(range: NumberOrDateRange): NumberOrDateRange {
+  if (typeof range.min === 'number' && typeof range.max === 'number')
+    return range;
+  else
+    return {
+      min: padISODateTime(range.min as string),
+      max: padISODateTime(range.max as string),
+    };
 }
 
 /**

--- a/src/lib/core/utils/date-conversion.ts
+++ b/src/lib/core/utils/date-conversion.ts
@@ -31,14 +31,16 @@ export function padISODateTime(ISODate: string): string {
  * Take a number or date range and if it's a date range,
  * convert min and max to full ISO format datetimes.
  */
-export function fullISODateRange(range: NumberOrDateRange): NumberOrDateRange {
-  if (typeof range.min === 'number' && typeof range.max === 'number')
-    return range;
-  else
-    return {
-      min: padISODateTime(range.min as string),
-      max: padISODateTime(range.max as string),
-    };
+export function fullISODateRange(
+  range: NumberOrDateRange,
+  valueType: 'number' | 'date'
+): NumberOrDateRange {
+  return valueType === 'number'
+    ? range
+    : {
+        min: padISODateTime(range.min as string),
+        max: padISODateTime(range.max as string),
+      };
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,10 +2889,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.3.17":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.17.tgz#4415224554c2cf5ab3ccc6dd76f8536af2db024a"
-  integrity sha512-8iTgjT2MPT2xAZ9k0M4O+lfaPm+ETcrIaqlQh3d8qaj7EOQHAsGN/nvKoI1ZoRpXRNOIFHFhVgV1gPbH2ZmcIw==
+"@veupathdb/components@^0.3.18":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.18.tgz#06c45cfa07d51555453303125cb5789b4b05d5e8"
+  integrity sha512-nf7tKacfSjnfHWW+klmlf2RW6FbBH7mJCS7v2DNkrRKZHVjejGYT/jYZ6flH+NkpyBJRNkE+Nh8bbYx8MSMNBQ==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Fixes #198 

Requires https://github.com/VEuPathDB/web-components/pull/163 in `web-components`

I also improved the UX I hope with this additional fix: if the user changes the x-range, then any existing binWidth settings are reset and the back-end will return something suitable.  This means that we have proper semantic zoom now enabled. I also enabled the new spinner.

Ready for testing and review but there are some known issues remaining

- [x] `studies/GEMSCC0003-1` endpoint isn't returning bin slider min, max or step - do we need to calculate it on client? Probably not, but see [#eda-backend thread](https://epvb.slack.com/archives/C01894F7P89/p1625495362391600)
- [x] when zooming in to a few weeks, and the bin width is "1 day",  then the bar width is wafer thin - I think the calculations are lacking 24 hours (especially if binStart and binEnd are the same date)
- [x] new bug found - when x-axis zoom min == max, the back end gives a 500 and with a date variable this can "kill" this variable in subsetting (no way to get the histogram back without deleting the analysis and starting again)
- [x] ~~check that data outside the curator's displayRangeMin/Max is not cut off~~