### PR TITLE
legend title, legend bug, interactive, enableOverlay

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -228,8 +228,7 @@ function BarplotViz(props: Props) {
           barLayout={'group'}
           displayLegend={
             data.value &&
-            (data.value.series.length > 1 ||
-              typeof vizConfig.overlayVariable !== 'undefined')
+            (data.value.series.length > 1 || vizConfig.overlayVariable != null)
           }
           independentAxisLabel={
             vizConfig.xAxisVariable

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -44,23 +44,16 @@ function FullscreenComponent(props: VisualizationProps) {
 }
 
 function createDefaultConfig(): BarplotConfig {
-  return {
-    enableOverlay: true,
-  };
+  return {};
 }
 
 type BarplotConfig = t.TypeOf<typeof BarplotConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-const BarplotConfig = t.intersection([
-  t.type({
-    enableOverlay: t.boolean,
-  }),
-  t.partial({
-    xAxisVariable: VariableDescriptor,
-    overlayVariable: VariableDescriptor,
-    facetVariable: VariableDescriptor,
-  }),
-]);
+const BarplotConfig = t.partial({
+  xAxisVariable: VariableDescriptor,
+  overlayVariable: VariableDescriptor,
+  facetVariable: VariableDescriptor,
+});
 
 type Props = VisualizationProps & {
   fullscreen: boolean;
@@ -150,7 +143,7 @@ function BarplotViz(props: Props) {
         studyId,
         filters ?? [],
         vizConfig.xAxisVariable!,
-        vizConfig.enableOverlay ? vizConfig.overlayVariable : undefined
+        vizConfig.overlayVariable
       );
 
       // barplot
@@ -233,7 +226,11 @@ function BarplotViz(props: Props) {
           }}
           orientation={'vertical'}
           barLayout={'group'}
-          displayLegend={data.value?.series.length > 1}
+          displayLegend={
+            data.value &&
+            (data.value.series.length > 1 ||
+              typeof vizConfig.overlayVariable !== 'undefined')
+          }
           independentAxisLabel={
             vizConfig.xAxisVariable
               ? findVariable(vizConfig.xAxisVariable)?.displayName
@@ -241,6 +238,8 @@ function BarplotViz(props: Props) {
           }
           dependentAxisLabel={'Count'}
           showSpinner={data.pending}
+          interactive={true}
+          legendTitle={findVariable(vizConfig.overlayVariable)?.displayName}
         />
       ) : (
         // thumbnail/grid view

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -62,7 +62,6 @@ function FullscreenComponent(props: VisualizationProps) {
 
 function createDefaultConfig(): HistogramConfig {
   return {
-    enableOverlay: true,
     dependentAxisLogScale: false,
   };
 }
@@ -71,7 +70,6 @@ type HistogramConfig = t.TypeOf<typeof HistogramConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 const HistogramConfig = t.intersection([
   t.type({
-    enableOverlay: t.boolean,
     dependentAxisLogScale: t.boolean,
   }),
   t.partial({
@@ -193,7 +191,7 @@ function HistogramViz(props: Props) {
         filters ?? [],
         vizConfig.xAxisVariable,
         xAxisVariable.type,
-        vizConfig.enableOverlay ? vizConfig.overlayVariable : undefined,
+        vizConfig.overlayVariable,
         vizConfig.binWidth,
         vizConfig.binWidthTimeUnit
       );
@@ -201,7 +199,6 @@ function HistogramViz(props: Props) {
       return histogramResponseToData(await response, xAxisVariable.type);
     }, [
       vizConfig.xAxisVariable,
-      vizConfig.enableOverlay,
       vizConfig.overlayVariable,
       vizConfig.binWidth,
       vizConfig.binWidthTimeUnit,
@@ -278,14 +275,19 @@ function HistogramViz(props: Props) {
           orientation={'vertical'}
           barLayout={'stack'}
           displayLegend={
-            data.value?.series?.length && data.value.series.length > 1
-              ? true
-              : false
+            data.value &&
+            (data.value.series.length > 1 ||
+              typeof vizConfig.overlayVariable !== 'undefined')
           }
           independentAxisLabel={
             xAxisVariable ? xAxisVariable.displayName : 'Bins'
           }
           showSpinner={data.pending}
+          interactive={true}
+          legendTitle={
+            findEntityAndVariable(entities, vizConfig.overlayVariable)?.variable
+              .displayName
+          }
         />
       ) : (
         // thumbnail/grid view

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -276,8 +276,7 @@ function HistogramViz(props: Props) {
           barLayout={'stack'}
           displayLegend={
             data.value &&
-            (data.value.series.length > 1 ||
-              typeof vizConfig.overlayVariable !== 'undefined')
+            (data.value.series.length > 1 || vizConfig.overlayVariable != null)
           }
           independentAxisLabel={
             xAxisVariable ? xAxisVariable.displayName : 'Bins'

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -88,9 +88,7 @@ function TwoByTwoFullscreenComponent(props: VisualizationProps) {
 }
 
 function createDefaultConfig(): MosaicConfig {
-  return {
-    // enableOverlay: true,
-  };
+  return {};
 }
 
 type MosaicConfig = t.TypeOf<typeof MosaicConfig>;
@@ -303,6 +301,7 @@ function MosaicViz(props: Props) {
           }
           displayLegend={true}
           showSpinner={data.pending}
+          interactive={true}
         />
       </div>
       {statsTable}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -292,7 +292,7 @@ function ScatterplotViz(props: Props) {
             displayLegend={
               data.value &&
               (data.value.dataSetProcess.series.length > 1 ||
-                typeof vizConfig.overlayVariable !== 'undefined')
+                vizConfig.overlayVariable != null)
             }
             independentAxisLabel={
               findVariable(vizConfig.xAxisVariable)?.displayName

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -67,25 +67,19 @@ function FullscreenComponent(props: VisualizationProps) {
 
 function createDefaultConfig(): ScatterplotConfig {
   return {
-    enableOverlay: true,
     valueSpecConfig: 'Raw',
   };
 }
 
 type ScatterplotConfig = t.TypeOf<typeof ScatterplotConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-const ScatterplotConfig = t.intersection([
-  t.type({
-    enableOverlay: t.boolean,
-  }),
-  t.partial({
-    xAxisVariable: VariableDescriptor,
-    yAxisVariable: VariableDescriptor,
-    overlayVariable: VariableDescriptor,
-    facetVariable: VariableDescriptor,
-    valueSpecConfig: t.string,
-  }),
-]);
+const ScatterplotConfig = t.partial({
+  xAxisVariable: VariableDescriptor,
+  yAxisVariable: VariableDescriptor,
+  overlayVariable: VariableDescriptor,
+  facetVariable: VariableDescriptor,
+  valueSpecConfig: t.string,
+});
 
 type Props = VisualizationProps & {
   fullscreen: boolean;
@@ -195,7 +189,7 @@ function ScatterplotViz(props: Props) {
         filters ?? [],
         vizConfig.xAxisVariable,
         vizConfig.yAxisVariable,
-        vizConfig.enableOverlay ? vizConfig.overlayVariable : undefined,
+        vizConfig.overlayVariable,
         // add visualization.type
         visualization.type,
         // XYPlotControls
@@ -295,6 +289,11 @@ function ScatterplotViz(props: Props) {
               height: '600px',
             }}
             // title={'Scatter plot'}
+            displayLegend={
+              data.value &&
+              (data.value.dataSetProcess.series.length > 1 ||
+                typeof vizConfig.overlayVariable !== 'undefined')
+            }
             independentAxisLabel={
               findVariable(vizConfig.xAxisVariable)?.displayName
             }
@@ -314,6 +313,8 @@ function ScatterplotViz(props: Props) {
             // send visualization.type here
             vizType={visualization.type}
             showSpinner={data.pending}
+            interactive={true}
+            legendTitle={findVariable(vizConfig.overlayVariable)?.displayName}
           />
         ) : (
           // thumbnail/grid view
@@ -440,7 +441,6 @@ function ScatterplotWithControls({
         {...ScatterplotProps}
         data={data}
         // add controls
-        displayLegend={data?.series && data.series.length > 1}
         displayLibraryControls={false}
       />
       {/*  XYPlotControls: check vizType (only for scatterplot for now) */}


### PR DESCRIPTION
This PR addresses three small issues and one bug for vizs at once. For Mosaic plot, only d) is addressed as it does not have overlay (concerning a) and b)) and c) was already addressed. Boxplot viz was already addressed at other PR.

a) [Visualization: Legend missing when overlay variable has only one value #211](https://github.com/VEuPathDB/web-eda/issues/211)

b) [Visualizations: create legend title with overlay variable's name for all plots #148](https://github.com/VEuPathDB/web-eda/issues/148) - hope you don't mind my work instead of you, Bob ;)

c) [Visualizations: remove redundant enableOverlay viz state #183](https://github.com/VEuPathDB/web-eda/issues/183)

d) set `interactive` props for full screen mode (no ticket exists)

Some screenshots for a) and b) - filter: Bangladesh only

![scatter-legend-title](https://user-images.githubusercontent.com/12802305/124848716-642b8300-df6b-11eb-9101-0ab2076ddfd1.png)

![histogram-legend-title](https://user-images.githubusercontent.com/12802305/124848756-79a0ad00-df6b-11eb-8f2c-dbe128bbb520.png)

![barplot-legend-title](https://user-images.githubusercontent.com/12802305/124848765-7d343400-df6b-11eb-9c8b-be37ba40c030.png)
