### PR TITLE
Variable tree updates

### DIFF
--- a/src/lib/core/api/ioTransformer.ts
+++ b/src/lib/core/api/ioTransformer.ts
@@ -1,6 +1,8 @@
 import { isLeft } from 'fp-ts/lib/Either';
 import { Decoder } from 'io-ts';
 
+const nl = '\n';
+
 export function ioTransformer<I, A>(decoder: Decoder<I, A>) {
   return async function decodeOrThrow(value: I): Promise<A> {
     const result = decoder.decode(value);
@@ -13,10 +15,13 @@ export function ioTransformer<I, A>(decoder: Decoder<I, A>) {
               `${context.key || '[root]'} (type: ${context.type.name})`
           )
           .join('\n  of ');
-        return (message += `Invalid value ${JSON.stringify(
-          error.value
-        )} supplied to ${context}\n\n`);
-      }, '');
+        return (
+          message +
+          `Invalid value \`${JSON.stringify(error.value)}\` supplied to ` +
+          context +
+          nl.repeat(3)
+        );
+      }, 'Unexpected backend type(s) encountered:' + nl.repeat(2));
       throw new Error(message);
     }
     return result.right;

--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -355,7 +355,7 @@ export default function VariableList(props: VariableListProps) {
                   const isActive = field.term === activeField?.term;
                   const isDisabled = disabledFields.has(field.term);
                   return (
-                    <li>
+                    <li key={field.term}>
                       <a
                         className={
                           'wdk-AttributeFilterFieldItem' +

--- a/src/lib/core/components/VariableTree.scss
+++ b/src/lib/core/components/VariableTree.scss
@@ -5,6 +5,21 @@
   left: 1px;
   right: 1px;
 
+  .FeaturedVariables {
+    padding: 0 1em;
+    background-color: #fafafa;
+    box-shadow: 0 0 1px #6f6f6f5c;
+    h3 {
+      font-size: 1.05em;
+    }
+    ul {
+      list-style: none;
+    }
+    .Entity {
+      font-weight: 500;
+    }
+  }
+
   .wdk-CheckboxTreeItem {
     padding-left: 1.5em;
   }
@@ -13,6 +28,7 @@
   .wdk-CheckboxTree .wdk-Link.wdk-AttributeFilterFieldParent {
     padding: 0.25em 0.5em;
     border-radius: 0.5em;
+    display: inline-block;
   }
 
   /* All entities */
@@ -37,17 +53,18 @@
     display: flex;
   }
 
-  /* height of CheckboxTree - use vh */
   .wdk-CheckboxTree {
-    height: calc(100% - 6em);
+    height: 100%;
+    display: flex;
+    flex-flow: column;
   }
 
   /* configuring scrolling for CheckboxTree list only: anchoring search bar */
   .wdk-CheckboxTree > .wdk-CheckboxTreeList {
     position: relative;
-    height: calc(100% - 3em);
     overflow: auto;
     padding: 0 1em;
+    flex-grow: 2;
   }
 
   .wdk-CheckboxTreeNodeContent {

--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -11,13 +11,6 @@ import { edaVariableToWdkField } from '../utils/wdk-filter-param-adapter';
 import VariableList from './VariableList';
 import './VariableTree.scss';
 
-// TODO Populate valuesMap with properties of variables.
-// This is used by the search functionality of FieldList.
-// It should be a map from field term to string.
-// In WDK searches, this is a concatenated string of values
-// for categorical-type variables.
-const valuesMap: Record<string, string> = {};
-
 export interface Props {
   rootEntity: StudyEntity;
   starredVariables?: string[];
@@ -49,6 +42,24 @@ export function VariableTree(props: Props) {
       ),
     [rootEntity]
   );
+
+  // This is used by the search functionality of FieldList.
+  // It should be a map from field term to string.
+  // In WDK searches, this is a concatenated string of values
+  // for categorical-type variables.
+  const valuesMap = useMemo(() => {
+    const valuesMap: Record<string, string> = {};
+    for (const entity of entities) {
+      for (const variable of entity.variables) {
+        if (variable.type !== 'category' && variable.vocabulary) {
+          valuesMap[`${entity.id}/${variable.id}`] = variable.vocabulary.join(
+            ' '
+          );
+        }
+      }
+    }
+    return valuesMap;
+  }, [entities]);
 
   const fields = useMemo(() => {
     return entities.flatMap((entity) => {

--- a/src/lib/workspace/Utils.ts
+++ b/src/lib/workspace/Utils.ts
@@ -8,6 +8,11 @@ export function findFirstVariable(
   variables: VariableTreeNode[],
   parentId: string
 ): VariableTreeNode | undefined {
+  const featuredVariable = variables.find(
+    (v) => v.type !== 'category' && v.isFeatured
+  );
+  if (featuredVariable) return featuredVariable;
+
   const variable = variables.find((v) => v.parentId === parentId);
   if (variable == null) return variables.find((v) => v.dataShape != null);
   if (variable.dataShape != null) return variable;


### PR DESCRIPTION
This PR incorporates new variable metadata into the `VariableTree` component. It also includes some CSS updates for the scroll-able section of the variable tree, and an improvement to `io-ts` validation error messages.

The featured variables are rendered above the tree of variables. It is a separate section from the tree, which does not scroll with the rest of the variables. This allows the selected variable to be visible within the view of the tree, without losing the context of the featured variables section.

This will all require some UX review.

closes #196 
closes #194 