### PR TITLE
Use updated distribution endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.3.18",
+    "@veupathdb/components": "^0.3.19",
     "@veupathdb/wdk-client": "^0.1.4",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -297,12 +297,30 @@ export function HistogramFilter(props: Props) {
             }}
           >
             <div className="histogram-summary-stats">
-              <b>Min:</b> {formatStatValue(fgSummaryStats.min, variable.type)}{' '}
-              &emsp; <b>Mean:</b>{' '}
-              {formatStatValue(fgSummaryStats.mean, variable.type)} &emsp;
-              <b>Median:</b>{' '}
-              {formatStatValue(fgSummaryStats.median, variable.type)} &emsp;{' '}
-              <b>Max:</b> {formatStatValue(fgSummaryStats.max, variable.type)}
+              {fgSummaryStats.min != null && (
+                <>
+                  <b>Min:</b>{' '}
+                  {formatStatValue(fgSummaryStats.min, variable.type)} &emsp;
+                </>
+              )}
+              {fgSummaryStats.mean != null && (
+                <>
+                  <b>Mean:</b>{' '}
+                  {formatStatValue(fgSummaryStats.mean, variable.type)} &emsp;
+                </>
+              )}
+              {fgSummaryStats.median != null && (
+                <>
+                  <b>Median:</b>{' '}
+                  {formatStatValue(fgSummaryStats.median, variable.type)} &emsp;
+                </>
+              )}
+              {fgSummaryStats.max != null && (
+                <>
+                  <b>Max:</b>{' '}
+                  {formatStatValue(fgSummaryStats.max, variable.type)} &emsp;
+                </>
+              )}
             </div>
             <UnknownCount
               activeFieldState={{
@@ -596,6 +614,14 @@ function distributionResponseToDataSeries(
     name,
     color,
     bins,
+    summary: {
+      min: response.statistics.subsetMin!,
+      mean: response.statistics.subsetMean!,
+      max: response.statistics.subsetMax!,
+      q1: undefined!,
+      q3: undefined!,
+      median: undefined!,
+    },
   };
 }
 
@@ -605,7 +631,7 @@ function formatStatValue(
   type: HistogramVariable['type']
 ) {
   return type === 'date'
-    ? value
+    ? String(value).replace(/T.*$/, '')
     : Number(value).toLocaleString(undefined, {
         maximumFractionDigits: 4,
       });

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -39,7 +39,7 @@ import { StudyEntity, StudyMetadata } from '../../types/study';
 import { TimeUnit, NumberOrDateRange, NumberRange } from '../../types/general';
 import { gray, red } from './colors';
 import { HistogramVariable } from './types';
-import { parseTimeDelta, fullISODateRange } from '../../utils/date-conversion';
+import { fullISODateRange } from '../../utils/date-conversion';
 
 type Props = {
   studyMetadata: StudyMetadata;
@@ -90,14 +90,12 @@ export function HistogramFilter(props: Props) {
       };
 
     // else date variable
-    const binWidthString = variable.binWidthOverride ?? variable.binWidth;
-    const binWidth = binWidthString
-      ? parseTimeDelta(binWidthString)
-      : undefined;
+    const binWidth = variable.binWidthOverride ?? variable.binWidth;
+    const binUnits = variable.binUnits;
 
     return {
-      binWidth: binWidth?.value,
-      binWidthTimeUnit: binWidth?.unit as TimeUnit, // bit nasty!
+      binWidth: binWidth,
+      binWidthTimeUnit: binUnits, // bit nasty!
       independentAxisRange:
         variable.displayRangeMin != null && variable.displayRangeMax != null
           ? { min: variable.displayRangeMin, max: variable.displayRangeMax }

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -84,7 +84,7 @@ export function HistogramFilter(props: Props) {
         independentAxisRange:
           variable.displayRangeMin != null && variable.displayRangeMax != null
             ? { min: variable.displayRangeMin, max: variable.displayRangeMax }
-            : { min: Math.min(0, variable.rangeMin!), max: variable.rangeMax! },
+            : { min: Math.min(0, variable.rangeMin), max: variable.rangeMax },
         ...otherDefaults,
       };
 
@@ -102,8 +102,8 @@ export function HistogramFilter(props: Props) {
               max: variable.displayRangeMax + 'T00:00:00',
             }
           : {
-              min: variable.rangeMin! + 'T00:00:00',
-              max: variable.rangeMax! + 'T00:00:00',
+              min: variable.rangeMin + 'T00:00:00',
+              max: variable.rangeMax + 'T00:00:00',
             },
       ...otherDefaults,
     };

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -36,7 +36,6 @@ import { HistogramVariable } from './types';
 import { fullISODateRange, padISODateTime } from '../../utils/date-conversion';
 import { getDistribution } from './util';
 import { DistributionResponse } from '../../api/subsetting-api';
-import { MenuItem, Select } from '@material-ui/core';
 
 type Props = {
   studyMetadata: StudyMetadata;
@@ -394,15 +393,6 @@ function HistogramPlotWithControls({
     [updateUIState]
   );
 
-  const handleBinUnitChange = useCallback(
-    (newBinUnit: string) => {
-      updateUIState({
-        binWidthTimeUnit: newBinUnit as TimeUnit,
-      });
-    },
-    [updateUIState]
-  );
-
   const handleIndependentAxisRangeChange = useCallback(
     (newRange?: NumberOrDateRange) => {
       updateUIState({
@@ -556,19 +546,15 @@ function HistogramPlotWithControls({
             binWidth={data?.binWidth}
             binWidthStep={data?.binWidthStep}
             binWidthRange={data?.binWidthRange}
+            binUnit={uiState.binWidthTimeUnit ?? 'year'}
+            binUnitOptions={
+              data?.valueType === 'date'
+                ? ['day', 'week', 'month', 'year']
+                : undefined
+            }
             onBinWidthChange={handleBinWidthChange}
             valueType={data?.valueType}
           />
-
-          <Select
-            value={uiState.binWidthTimeUnit ?? 'year'}
-            onChange={(e) => handleBinUnitChange(String(e.target.value))}
-          >
-            <MenuItem value="day">Day</MenuItem>
-            <MenuItem value="week">Week</MenuItem>
-            <MenuItem value="month">Month</MenuItem>
-            <MenuItem value="year">Year</MenuItem>
-          </Select>
 
           <AxisRangeControl
             label="Range:"
@@ -631,7 +617,7 @@ function computeBinSlider(
 ) {
   switch (type) {
     case 'date': {
-      return { min: 1, max: 1000, step: 1 };
+      return { min: 1, max: 60, step: 1 };
     }
     case 'number': {
       const { min: rangeMin, max: rangeMax } = range as NumberRange;

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -33,9 +33,10 @@ import { StudyEntity, StudyMetadata } from '../../types/study';
 import { TimeUnit, NumberOrDateRange, NumberRange } from '../../types/general';
 import { gray, red } from './colors';
 import { HistogramVariable } from './types';
-import { fullISODateRange } from '../../utils/date-conversion';
+import { fullISODateRange, padISODateTime } from '../../utils/date-conversion';
 import { getDistribution } from './util';
 import { DistributionResponse } from '../../api/subsetting-api';
+import { MenuItem, Select } from '@material-ui/core';
 
 type Props = {
   studyMetadata: StudyMetadata;
@@ -393,14 +394,30 @@ function HistogramPlotWithControls({
     [updateUIState]
   );
 
+  const handleBinUnitChange = useCallback(
+    (newBinUnit: string) => {
+      updateUIState({
+        binWidthTimeUnit: newBinUnit as TimeUnit,
+      });
+    },
+    [updateUIState]
+  );
+
   const handleIndependentAxisRangeChange = useCallback(
     (newRange?: NumberOrDateRange) => {
       updateUIState({
-        // when the independent axis range is 'zoomed', reset the binWidth
-        // so the back end provides a suitable value
-        binWidth: undefined,
-        binWidthTimeUnit: undefined,
-        independentAxisRange: newRange,
+        independentAxisRange:
+          newRange &&
+          ({
+            min:
+              typeof newRange.min === 'string'
+                ? padISODateTime(newRange.min)
+                : newRange.min,
+            max:
+              typeof newRange.max === 'string'
+                ? padISODateTime(newRange.max)
+                : newRange.max,
+          } as NumberOrDateRange),
       });
     },
     [updateUIState]
@@ -542,6 +559,16 @@ function HistogramPlotWithControls({
             onBinWidthChange={handleBinWidthChange}
             valueType={data?.valueType}
           />
+
+          <Select
+            value={uiState.binWidthTimeUnit ?? 'year'}
+            onChange={(e) => handleBinUnitChange(String(e.target.value))}
+          >
+            <MenuItem value="day">Day</MenuItem>
+            <MenuItem value="week">Week</MenuItem>
+            <MenuItem value="month">Month</MenuItem>
+            <MenuItem value="year">Year</MenuItem>
+          </Select>
 
           <AxisRangeControl
             label="Range:"

--- a/src/lib/core/types/study.ts
+++ b/src/lib/core/types/study.ts
@@ -24,12 +24,20 @@ export const VariableType = t.keyof({
   longitude: null,
 });
 
-export const VariableDataShape = t.keyof({
-  continuous: null,
+export const CategoryVariableDataShape = t.keyof({
   categorical: null,
   ordinal: null,
   binary: null,
 });
+
+export const ContinuousVariableDataShape = t.keyof({
+  continuous: null,
+});
+
+export const VariableDataShape = t.union([
+  CategoryVariableDataShape,
+  ContinuousVariableDataShape,
+]);
 
 const VariableDisplayType = t.keyof({
   default: null,
@@ -80,16 +88,24 @@ export const NumberVariable = t.intersection([
   t.type({
     type: t.literal('number'),
     units: t.string,
+    precision: t.number,
   }),
+  t.union([
+    t.type({
+      dataShape: CategoryVariableDataShape,
+    }),
+    t.type({
+      dataShape: ContinuousVariableDataShape,
+      rangeMin: t.number,
+      rangeMax: t.number,
+      binWidth: t.number,
+    }),
+  ]),
   t.partial({
     // TODO This is supposed to be required, but the backend isn't populating it.
-    precision: t.number,
     displayRangeMin: t.number,
     displayRangeMax: t.number,
-    rangeMin: t.number,
-    rangeMax: t.number,
     binWidthOverride: t.number,
-    binWidth: t.number,
   }),
 ]);
 
@@ -99,14 +115,22 @@ export const DateVariable = t.intersection([
   t.type({
     type: t.literal('date'),
   }),
+  t.union([
+    t.type({
+      dataShape: CategoryVariableDataShape,
+    }),
+    t.type({
+      dataShape: ContinuousVariableDataShape,
+      rangeMin: t.string,
+      rangeMax: t.string,
+      binWidth: t.number,
+      binUnits: TimeUnit,
+    }),
+  ]),
   t.partial({
     displayRangeMin: t.string,
     displayRangeMax: t.string,
-    rangeMin: t.string,
-    rangeMax: t.string,
     binWidthOverride: t.number,
-    binWidth: t.number,
-    binUnits: TimeUnit,
   }),
 ]);
 

--- a/src/lib/core/types/study.ts
+++ b/src/lib/core/types/study.ts
@@ -4,6 +4,7 @@ import {
   RecordClass,
   RecordInstance,
 } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import { TimeUnit } from './general';
 
 // Aliases
 // -------
@@ -103,8 +104,9 @@ export const DateVariable = t.intersection([
     displayRangeMax: t.string,
     rangeMin: t.string,
     rangeMax: t.string,
-    binWidthOverride: t.string,
-    binWidth: t.string,
+    binWidthOverride: t.number,
+    binWidth: t.number,
+    binUnits: TimeUnit,
   }),
 ]);
 

--- a/src/lib/core/utils/wdk-filter-param-adapter.ts
+++ b/src/lib/core/utils/wdk-filter-param-adapter.ts
@@ -113,15 +113,13 @@ export function toWdkVariableSummary(
   variable: VariableTreeNode
 ) {
   return {
-    distribution: Object.entries(background.distribution).map(
-      ([value, count]) => ({
-        count,
-        filteredCount: foreground.distribution[value],
-        value,
-      })
-    ),
-    entitiesCount: background.entitiesCount,
-    filteredEntitiesCount: foreground.entitiesCount,
+    distribution: background.histogram.map(({ value, binLabel }, index) => ({
+      count: value,
+      filteredCount: foreground.histogram[index].value,
+      value: binLabel,
+    })),
+    entitiesCount: background.statistics.numDistinctEntityRecords,
+    filteredEntitiesCount: foreground.statistics.numDistinctEntityRecords,
     activeField: edaVariableToWdkField(variable),
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,10 +2889,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.3.18":
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.18.tgz#06c45cfa07d51555453303125cb5789b4b05d5e8"
-  integrity sha512-nf7tKacfSjnfHWW+klmlf2RW6FbBH7mJCS7v2DNkrRKZHVjejGYT/jYZ6flH+NkpyBJRNkE+Nh8bbYx8MSMNBQ==
+"@veupathdb/components@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.19.tgz#e4728619371754517818d65cde5432a5b0acdfb3"
+  integrity sha512-vriEhkT1K+C5yM3KZiessGygNlTivJq+9MFk4/4OiRy2n7cdz0q/U0b7p6I6QvywAxWBuclxQsmj4Y4uDQ0Gjg==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
This PR includes changes to use the updated distribution endpoint for filters in the subsetting tab. The updated endpoint is designed for performance, which is a requirement for subsetting.

One UX compromise is that we cannot do semantic zoom in this context. The front end must always provide range and binning info.

This depends on https://github.com/VEuPathDB/web-components/pull/165 for mouse selection in histograms to work correctly.