### PR TITLE
Use adjustBinEndToEndOfDay prop for HistogramVisualisation

### DIFF
--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -311,6 +311,7 @@ function HistogramViz(props: Props) {
             findEntityAndVariable(entities, vizConfig.overlayVariable)?.variable
               .displayName
           }
+          adjustBinEndToEndOfDay
         />
       ) : (
         // thumbnail/grid view
@@ -335,6 +336,7 @@ function HistogramViz(props: Props) {
           dependentAxisLogScale={vizConfig.dependentAxisLogScale}
           interactive={false}
           showSpinner={data.pending}
+          adjustBinEndToEndOfDay
         />
       )}
     </div>


### PR DESCRIPTION
Requires https://github.com/VEuPathDB/web-components/pull/167

This super-simple change adds the `adjustBinEndToEndOfDay` prop to the Histogram component for the HistogramVisualisation (which receives date-based bin data like this `binStart: 2001-03-01, binEnd: 2001-03-31`)

The HistogramFilter uses the Distribution endpoint which returns `binStart: 2001-03-01, binEnd: 2001-04-01`

Here is the HistogramFilter which doesn't use the day-adjustment any more.  All fixed!
![image](https://user-images.githubusercontent.com/308639/126013605-514cd193-0564-49e5-ab70-9c1d4f83a8f1.png)
