### PR TITLE
Improve histogram and barplot viz controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.3.20",
+    "@veupathdb/components": "^0.3.22",
     "@veupathdb/wdk-client": "^0.1.4",
     "@veupathdb/web-common": "^0.1.2",
     "debounce-promise": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,10 +2889,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.3.20":
-  version "0.3.20"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.20.tgz#7ac7d189ce00233b3c4b777d1d4b57ebc5d97438"
-  integrity sha512-VCuPE4BIDOifV7mW+yz8ZxQb1Jd7a65AcT3ln4O6wUB40xegCbl5bOq7Po+ZnNtMkjE9HdAc7SobAYi1QVH96g==
+"@veupathdb/components@^0.3.22":
+  version "0.3.22"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.3.22.tgz#d7acc35d558f71e634b54e7f5933bc666b39f56d"
+  integrity sha512-pjq8fwbDTcSC6one9IZ82wnmNEnaDP4sKPQ0foA4A81KWh2QuozW5TnYtK65mK2aDxfQBu3pRJXTdb3BBbCofA==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Depends on https://github.com/VEuPathDB/web-components/pull/169 

So far I have done

- fixed the binWidth control to handle date units
- added absolute/relative control to histogram
- added absolute/relative and logscale controls to barplot

I've chosen not to add zooming controls to histogram x-axis at this time.
Maybe wait until after #98 to add this, if still wanted.