### PR TITLE
handling double-slashed in the url

### DIFF
--- a/src/lib/workspace/WorkspaceRouter.tsx
+++ b/src/lib/workspace/WorkspaceRouter.tsx
@@ -3,6 +3,7 @@ import {
   RouteComponentProps,
   Switch,
   useRouteMatch,
+  Redirect,
 } from 'react-router';
 import { EDAAnalysisList } from './EDAAnalysisList';
 import { StudyList } from './StudyList';
@@ -24,6 +25,15 @@ export function WorkspaceRouter({
         path={path}
         exact
         render={() => <StudyList subsettingServiceUrl={subsettingServiceUrl} />}
+      />
+      {/* replacing/redirecting double slashes url with single slash one */}
+      <Route
+        exact
+        strict
+        path="(.*//+.*)"
+        render={({ location }) => (
+          <Redirect to={location.pathname.replace(/\/\/+/g, '/')} />
+        )}
       />
       <Route
         path={`${path}/:studyId`}


### PR DESCRIPTION
I don't know how to reproduce this url's double-slashes issue without changing browser's address bar directly, but anyway it can be done by partially removing url and click a link, especially leaving the trailing slash. For example, 

`https://feature.clinepidb.org/ce.feature/app/eda/DS_841a9f5259/3/visualizations/pass-through`

a) deleting `DS_841a9f5259/3/visualizations/pass-through`, which becomes `https://feature.clinepidb.org/ce.feature/app/eda/` and then select a study link

b) simply removing `pass-through` that leaves `https://feature.clinepidb.org/ce.feature/app/eda/DS_841a9f5259/3/visualizations/` but it would automatically become `https://feature.clinepidb.org/ce.feature/app/eda/DS_841a9f5259/3/visualizations//pass-through` due to Route

I have tried several approaches like removing trailing slash in the url, redirecting trailing double slashes to a correct url, but decided to consider more general case: all url containing double slashes are redirecting to the same url with single slash. 

One can test this by comparing feature site and one's dev (local) environment. 
