### PR TITLE
Adapt client to latest API changes

### DIFF
--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -67,6 +67,7 @@ export interface HistogramRequestParams {
   config: {
     outputEntityId: string;
     valueSpec: 'count' | 'proportion';
+    barmode: 'overlay' | 'stack';
     xAxisVariable: VariableDescriptor;
     overlayVariable?: VariableDescriptor; // TO DO: should this be StringVariable??
     facetVariable?: ZeroToTwoVariables; // ditto here
@@ -143,6 +144,7 @@ export interface BarplotRequestParams {
     outputEntityId: string;
     // add proportion as it seems to be coming
     valueSpec: 'count' | 'identity' | 'proportion';
+    barmode: 'group' | 'stack';
     xAxisVariable: VariableDescriptor;
     // barplot add prop
     overlayVariable?: VariableDescriptor;

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -49,7 +49,7 @@ const sampleSizeTableArray = array(
 export type CompleteCasesTableRow = TypeOf<typeof completeCases>;
 const completeCases = partial({
   // set union for size as it depends on the presence of overlay variable
-  completeCases: union([number, array(number)]),
+  completeCases: number,
   variableDetails: type({
     entityId: string,
     variableId: string,
@@ -388,7 +388,7 @@ export interface BoxplotRequestParams {
     points: 'outliers' | 'all';
     // boolean or string?
     // mean: boolean;
-    mean: 'true' | 'false';
+    mean: 'TRUE' | 'FALSE';
     // not quite sure of overlayVariable and facetVariable yet
     // facetVariable?: ZeroToTwoVariables;
     xAxisVariable: VariableDescriptor;
@@ -406,6 +406,7 @@ const BoxplotResponseData = array(
       q1: array(number),
       q3: array(number),
       median: array(number),
+      label: array(string),
     }),
     partial({
       // outliers type

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -387,6 +387,7 @@ function getRequestParams(
       overlayVariable: overlayVariable,
       // valueSpec: manually inputted for now
       valueSpec: 'count',
+      barmode: 'group', // or 'stack'
       // this works too
       // valueSpec: 'proportion',
       // valueSpec: 'identity',

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -413,7 +413,7 @@ export function boxplotResponseToData(
           ? data.overlayVariableDetails.value
           : 'Data',
         // this will be used as x-axis tick labels
-        label: data[response.boxplot.config.xVariableDetails.variableId],
+        label: data.label, // [response.boxplot.config.xVariableDetails.variableId],
       })
     ),
     completeCases: response.completeCasesTable,
@@ -439,7 +439,7 @@ function getRequestParams(
       outputEntityId: xAxisVariable.entityId,
       // post options: 'all', 'outliers'
       points: 'outliers',
-      mean: 'true',
+      mean: 'TRUE',
       xAxisVariable: xAxisVariable,
       yAxisVariable: yAxisVariable,
       overlayVariable: overlayVariable,

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -518,6 +518,7 @@ function getRequestParams(
     config: {
       outputEntityId: variable.entityId,
       valueSpec: 'count',
+      barmode: 'stack',
       xAxisVariable: variable,
       overlayVariable,
       ...binSpec,

--- a/src/lib/core/hooks/variableCoverage.ts
+++ b/src/lib/core/hooks/variableCoverage.ts
@@ -97,26 +97,16 @@ export function useVariableCoverageTableRows(
 export function useCompleteCasesMap(
   completeCasesTable: CompleteCasesTable = []
 ): Record<string, number> {
-  return useMemo(() => {
-    const nonemptyRows = completeCasesTable.filter(isNonemptyRow);
-
-    // variableDetails.variableId is of the form {entityId}.{variableId}
-    const rowsByVariableId = keyBy(
-      nonemptyRows,
-      ({ variableDetails }) => variableDetails.variableId
-    );
-
-    return mapValues(rowsByVariableId, ({ completeCases }) =>
-      Array.isArray(completeCases) ? completeCases[0] : completeCases
-    );
-  }, [completeCasesTable]);
-}
-
-function isNonemptyRow(
-  completeCasesTableRow: CompleteCasesTableRow
-): completeCasesTableRow is Required<CompleteCasesTableRow> {
-  return (
-    completeCasesTableRow.variableDetails != null ||
-    completeCasesTableRow.completeCases != null
+  return useMemo(
+    () =>
+      // the reduce essentially performs a lodash.keyBy, with empty row protection
+      completeCasesTable.reduce((map, { completeCases, variableDetails }) => {
+        if (completeCases != null && variableDetails != null) {
+          const key = `${variableDetails.entityId}.${variableDetails.variableId}`;
+          map[key] = completeCases;
+        }
+        return map;
+      }, {} as Record<string, number>),
+    [completeCasesTable]
   );
 }


### PR DESCRIPTION
Just a draft placeholder PR to make it clear I'm working on this.

Here is Danielle's list of changes:

1. fixes to binning date histos for the viz tab
1. making sure facetVariableDetails is always an array
4. updated viz descriptions
5. fixing variableId in the various variableDetails (so it stops saying entityId.variableId)
6. updates to the 'proportion' option for bar and histo (note: the request will now have to specify a barmode)
7. fix the boxplot bug where 'rawData' was out of order
8. add support for showing 'No data' as a value for strata vars (note: new showMissingness prop in request)
9. include a count of 'plottedIncompleteCases' (normally 0, unless new 'showMissingness' is on)
10. make statsTables in the responses optional (for when 'showMissingness' is on)
11. new `data.label` prop for boxplot response in place of entity.variable-named key
12. `mean: 'true' | 'false'` now capitalized `'TRUE' | 'FALSE'`