### PR TITLE
set variable coverage table width

### DIFF
--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -158,7 +158,7 @@
 
 .VariableCoverageTable {
   @include data-table;
-  max-width: 500px;
+  width: 500px;
 
   margin-top: 1.5em;
   margin-left: 3em;


### PR DESCRIPTION
As discussed in https://github.com/VEuPathDB/web-eda/issues/229, Jamie and I thought we should set a variable coverage table width so that the table does not change with the variable selection. This will alleviate the issue Danielle experienced.