### PR TITLE
changing percentage style at variable coverage table

### DIFF
--- a/src/lib/core/components/VariableCoverageTable.tsx
+++ b/src/lib/core/components/VariableCoverageTable.tsx
@@ -33,10 +33,10 @@ export interface VariableCoverageTableRow {
   completeCount?: number;
   /* absolute count of entities which are missing the variable */
   incompleteCount?: number;
-  /* percent of subset entities which have the variable */
-  completePercent?: number;
-  /* percent of subset entities which are missing the variable */
-  incompletePercent?: number;
+  /* percent of subset entities which have the variable: allowing string like '< 1', '> 99' */
+  completePercent?: number | string;
+  /* percent of subset entities which are missing the variable: allowing string like '< 1', '> 99' */
+  incompletePercent?: number | string;
 }
 
 export function VariableCoverageTable({
@@ -78,7 +78,10 @@ export function VariableCoverageTable({
                   {row.completeCount?.toLocaleString()}
                   {row.completePercent != null && (
                     <span className="percentage">
-                      ({row.completePercent.toFixed(2)}%)
+                      {/* check number or string like '< 1', '> 99' */}
+                      {typeof row.completePercent === 'number'
+                        ? '(' + row.completePercent.toFixed(2) + '%)'
+                        : '(' + row.completePercent + '%)'}
                     </span>
                   )}
                 </td>
@@ -86,7 +89,10 @@ export function VariableCoverageTable({
                   {row.incompleteCount?.toLocaleString()}
                   {row.incompletePercent != null && (
                     <span className="percentage">
-                      ({row.incompletePercent.toFixed(2)}%)
+                      {/* check number or string like '< 1', '> 99' */}
+                      {typeof row.incompletePercent === 'number'
+                        ? '(' + row.incompletePercent.toFixed(2) + '%)'
+                        : '(' + row.incompletePercent + '%)'}
                     </span>
                   )}
                 </td>

--- a/src/lib/core/hooks/variableCoverage.ts
+++ b/src/lib/core/hooks/variableCoverage.ts
@@ -10,6 +10,8 @@ import {
 import { Filter } from '../types/filter';
 
 import { useEntityCounts } from './entityCounts';
+// use toPercentage function for handling very high or small percentage
+import { toPercentage } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/AttributeFilterUtils';
 
 /**
  * Returns an array of data to be rendered in a VariableCoverageTable
@@ -73,11 +75,15 @@ export function useVariableCoverageTableRows(
         return {
           ...baseRowWithCounts,
           incompleteCount,
-          completePercent:
-            (baseRowWithCounts.completeCount / variableFilteredEntityCount) *
-            100,
-          incompletePercent:
-            (incompleteCount / variableFilteredEntityCount) * 100,
+          // use toPercentage function for handling very high or small percentage
+          completePercent: toPercentage(
+            baseRowWithCounts.completeCount,
+            variableFilteredEntityCount
+          ),
+          incompletePercent: toPercentage(
+            incompleteCount,
+            variableFilteredEntityCount
+          ),
         };
       }),
     [


### PR DESCRIPTION
Following #250 issue, `toPercentage()` is used for variable coverage table. But one question remains that the function, `toPercentage`, is actually returned either `> 99` or `< 1` (see screenshot that was tested at scatterplot viz), not decimal points like `> 99.99` or `< 0.01`. If we need to support more precise decimal points like Bob mentioned in the issue, then we can probably make a function that is similar to `toPercentage()`. Just let me know @bobular :)

![scatter-percent1](https://user-images.githubusercontent.com/12802305/127031570-50f8b3ec-1811-4ab3-ad68-7366aab249f5.png)



