### PR TITLE
following dependency order and showing viz description

### DIFF
--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -95,6 +95,7 @@ function ConfiguredVisualizations(props: Props) {
     [computationId, visualizations]
   );
   if (computation == null) return <div>Computation not found</div>;
+
   return (
     <Grid>
       <Link replace to={`${url}/new`} className={cx('-NewVisualization')}>
@@ -105,6 +106,8 @@ function ConfiguredVisualizations(props: Props) {
         .map((viz) => {
           const type = visualizationTypes[viz.type];
           const meta = visualizationsOverview.find((v) => v.name === viz.type);
+          // dataElementDependencyOrder should be passed for grid view/thumbnail
+          const dataElementDependencyOrder = meta?.dataElementDependencyOrder;
           return (
             <div key={viz.id}>
               <div className={cx('-ConfiguredVisualization')}>
@@ -154,6 +157,8 @@ function ConfiguredVisualizations(props: Props) {
                     filters={filters}
                     starredVariables={starredVariables}
                     toggleStarredVariable={toggleStarredVariable}
+                    // dataElementDependencyOrder should be passed for grid view/thumbnail
+                    dataElementDependencyOrder={dataElementDependencyOrder}
                   />
                 ) : (
                   <div>Visualization type not implemented: {viz.type}</div>
@@ -203,27 +208,30 @@ function NewVisualizationPicker(props: Props) {
               className={cx('-PickerEntry', vizType == null && 'disabled')}
               key={`vizType${index}`}
             >
-              <button
-                type="button"
-                disabled={vizType == null}
-                onClick={async () => {
-                  const id = uuid();
-                  addVisualization({
-                    id,
-                    computationId: computationId,
-                    type: vizOverview.name!,
-                    displayName: 'Unnamed visualization',
-                    configuration: vizType?.createDefaultConfig(),
-                  });
-                  history.replace(`../${computationId}/${id}`);
-                }}
-              >
-                {vizType ? (
-                  <vizType.selectorComponent {...vizOverview} />
-                ) : (
-                  <PlaceholderIcon name={vizOverview.name} />
-                )}
-              </button>
+              {/* add viz description tooltip for viz picker */}
+              <Tooltip title={<>{vizOverview.description}</>}>
+                <button
+                  type="button"
+                  disabled={vizType == null}
+                  onClick={async () => {
+                    const id = uuid();
+                    addVisualization({
+                      id,
+                      computationId: computationId,
+                      type: vizOverview.name!,
+                      displayName: 'Unnamed visualization',
+                      configuration: vizType?.createDefaultConfig(),
+                    });
+                    history.replace(`../${computationId}/${id}`);
+                  }}
+                >
+                  {vizType ? (
+                    <vizType.selectorComponent {...vizOverview} />
+                  ) : (
+                    <PlaceholderIcon name={vizOverview.name} />
+                  )}
+                </button>
+              </Tooltip>
               <div className={cx('-PickerEntryName')}>
                 <div>{vizOverview.displayName}</div>
               </div>
@@ -328,7 +336,10 @@ function FullScreenVisualization(props: Props & { id: string }) {
               }
             />
           </h3>
-          <div className="Subtitle">{overview?.displayName}</div>
+          {/* add viz description */}
+          <div className="Subtitle">
+            {overview?.displayName}: {overview?.description}
+          </div>
           <vizType.fullscreenComponent
             dataElementConstraints={constraints}
             dataElementDependencyOrder={dataElementDependencyOrder}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -336,10 +336,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
               }
             />
           </h3>
-          {/* add viz description */}
-          <div className="Subtitle">
-            {overview?.displayName}: {overview?.description}
-          </div>
+          <div className="Subtitle">{overview?.displayName}</div>
           <vizType.fullscreenComponent
             dataElementConstraints={constraints}
             dataElementDependencyOrder={dataElementDependencyOrder}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -18,6 +18,7 @@ import {
 import { usePromise } from '../../../hooks/promise';
 import { useFindEntityAndVariable } from '../../../hooks/study';
 import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
+import { useFindOutputEntity } from '../../../hooks/findOutputEntity';
 import { Filter } from '../../../types/filter';
 import { PromiseType } from '../../../types/utility';
 import { VariableDescriptor } from '../../../types/variable';
@@ -145,14 +146,12 @@ function BoxplotViz(props: Props) {
   const findEntityAndVariable = useFindEntityAndVariable(entities);
 
   // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams
-  const outputEntity = useMemo(() => {
-    const outputEntityVariableName =
-      dataElementDependencyOrder != null &&
-      dataElementDependencyOrder[0] === 'yAxisVariable'
-        ? vizConfig.yAxisVariable
-        : vizConfig.xAxisVariable;
-    return findEntityAndVariable(outputEntityVariableName)?.entity;
-  }, [dataElementDependencyOrder, vizConfig, findEntityAndVariable]);
+  const outputEntity = useFindOutputEntity(
+    dataElementDependencyOrder,
+    vizConfig,
+    'xAxisVariable',
+    entities
+  );
 
   const data = usePromise(
     useCallback(async (): Promise<PromiseBoxplotData | undefined> => {

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -166,7 +166,9 @@ function BoxplotViz(props: Props) {
         filters ?? [],
         vizConfig.xAxisVariable,
         vizConfig.yAxisVariable,
-        vizConfig.overlayVariable
+        vizConfig.overlayVariable,
+        // add dataElementDependencyOrder
+        dataElementDependencyOrder
       );
 
       // boxplot
@@ -298,7 +300,13 @@ function BoxplotViz(props: Props) {
                 data.pending ? undefined : data.value?.completeCases
               }
               filters={filters}
-              outputEntityId={vizConfig.xAxisVariable?.entityId}
+              outputEntityId={
+                // add outputEntityId per dataElementDependencyOrder
+                dataElementDependencyOrder != null &&
+                dataElementDependencyOrder[0] === 'yAxisVariable'
+                  ? vizConfig.yAxisVariable?.entityId
+                  : vizConfig.xAxisVariable?.entityId
+              }
               variableSpecs={[
                 {
                   role: 'X-axis',
@@ -429,14 +437,20 @@ function getRequestParams(
   filters: Filter[],
   xAxisVariable: VariableDescriptor,
   yAxisVariable: VariableDescriptor,
-  overlayVariable?: VariableDescriptor
+  overlayVariable?: VariableDescriptor,
+  // add dataElementDependencyOrder here
+  dataElementDependencyOrder?: string[]
 ): getRequestParamsProps {
   return {
     studyId,
     filters,
     config: {
-      // is outputEntityId correct?
-      outputEntityId: xAxisVariable.entityId,
+      // add outputEntityId per dataElementDependencyOrder
+      outputEntityId:
+        dataElementDependencyOrder != null &&
+        dataElementDependencyOrder[0] === 'yAxisVariable'
+          ? yAxisVariable?.entityId
+          : xAxisVariable.entityId,
       // post options: 'all', 'outliers'
       points: 'outliers',
       mean: 'TRUE',

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -144,6 +144,16 @@ function BoxplotViz(props: Props) {
 
   const findEntityAndVariable = useFindEntityAndVariable(entities);
 
+  // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams
+  const outputEntity = useMemo(() => {
+    const outputEntityVariableName =
+      dataElementDependencyOrder != null &&
+      dataElementDependencyOrder[0] === 'yAxisVariable'
+        ? vizConfig.yAxisVariable
+        : vizConfig.xAxisVariable;
+    return findEntityAndVariable(outputEntityVariableName)?.entity;
+  }, [dataElementDependencyOrder, vizConfig, findEntityAndVariable]);
+
   const data = usePromise(
     useCallback(async (): Promise<PromiseBoxplotData | undefined> => {
       const xAxisVariable = findEntityAndVariable(vizConfig.xAxisVariable);
@@ -167,8 +177,8 @@ function BoxplotViz(props: Props) {
         vizConfig.xAxisVariable,
         vizConfig.yAxisVariable,
         vizConfig.overlayVariable,
-        // add dataElementDependencyOrder
-        dataElementDependencyOrder
+        // pass outputEntity.id
+        outputEntity?.id
       );
 
       // boxplot
@@ -251,7 +261,7 @@ function BoxplotViz(props: Props) {
       {fullscreen ? (
         <>
           <OutputEntityTitle
-            entity={findEntityAndVariable(vizConfig.xAxisVariable)?.entity}
+            entity={outputEntity}
             outputSize={data.pending ? undefined : data.value?.outputSize}
           />
           <div
@@ -300,13 +310,7 @@ function BoxplotViz(props: Props) {
                 data.pending ? undefined : data.value?.completeCases
               }
               filters={filters}
-              outputEntityId={
-                // add outputEntityId per dataElementDependencyOrder
-                dataElementDependencyOrder != null &&
-                dataElementDependencyOrder[0] === 'yAxisVariable'
-                  ? vizConfig.yAxisVariable?.entityId
-                  : vizConfig.xAxisVariable?.entityId
-              }
+              outputEntityId={outputEntity?.id}
               variableSpecs={[
                 {
                   role: 'X-axis',
@@ -438,19 +442,15 @@ function getRequestParams(
   xAxisVariable: VariableDescriptor,
   yAxisVariable: VariableDescriptor,
   overlayVariable?: VariableDescriptor,
-  // add dataElementDependencyOrder here
-  dataElementDependencyOrder?: string[]
+  // pass outputEntityId
+  outputEntityId?: string
 ): getRequestParamsProps {
   return {
     studyId,
     filters,
     config: {
       // add outputEntityId per dataElementDependencyOrder
-      outputEntityId:
-        dataElementDependencyOrder != null &&
-        dataElementDependencyOrder[0] === 'yAxisVariable'
-          ? yAxisVariable?.entityId
-          : xAxisVariable.entityId,
+      outputEntityId: outputEntityId,
       // post options: 'all', 'outliers'
       points: 'outliers',
       mean: 'TRUE',

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -181,6 +181,16 @@ function MosaicViz(props: Props) {
 
   const findEntityAndVariable = useFindEntityAndVariable(entities);
 
+  // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams
+  const outputEntity = useMemo(() => {
+    const outputEntityVariableName =
+      dataElementDependencyOrder != null &&
+      dataElementDependencyOrder[0] === 'yAxisVariable'
+        ? vizConfig.yAxisVariable
+        : vizConfig.xAxisVariable;
+    return findEntityAndVariable(outputEntityVariableName)?.entity;
+  }, [dataElementDependencyOrder, vizConfig, findEntityAndVariable]);
+
   const data = usePromise(
     useCallback(async (): Promise<ContTableData | TwoByTwoData | undefined> => {
       const xAxisVariable = findEntityAndVariable(vizConfig.xAxisVariable)
@@ -205,8 +215,8 @@ function MosaicViz(props: Props) {
         filters ?? [],
         vizConfig.xAxisVariable,
         vizConfig.yAxisVariable,
-        // add dataElementDependencyOrder
-        dataElementDependencyOrder
+        // pass outputEntity.id
+        outputEntity?.id ?? ''
       );
 
       if (isTwoByTwo) {
@@ -319,13 +329,7 @@ function MosaicViz(props: Props) {
         <VariableCoverageTable
           completeCases={data.pending ? undefined : data.value?.completeCases}
           filters={filters}
-          outputEntityId={
-            // add outputEntityId per dataElementDependencyOrder
-            dataElementDependencyOrder != null &&
-            dataElementDependencyOrder[0] === 'yAxisVariable'
-              ? vizConfig.yAxisVariable?.entityId
-              : vizConfig.xAxisVariable?.entityId
-          }
+          outputEntityId={outputEntity?.id}
           variableSpecs={[
             {
               role: 'X-axis',
@@ -423,7 +427,7 @@ function MosaicViz(props: Props) {
 
       {fullscreen && (
         <OutputEntityTitle
-          entity={findEntityAndVariable(vizConfig.xAxisVariable)?.entity}
+          entity={outputEntity}
           outputSize={data.pending ? undefined : data.value?.outputSize}
         />
       )}
@@ -525,19 +529,15 @@ function getRequestParams(
   filters: Filter[],
   xAxisVariable: VariableDescriptor,
   yAxisVariable: VariableDescriptor,
-  // add dataElementDependencyOrder here
-  dataElementDependencyOrder?: string[]
+  // pass outputEntityId
+  outputEntityId: string
 ): MosaicRequestParams {
   return {
     studyId,
     filters,
     config: {
-      // add outputEntityId per dataElementDependencyOrder
-      outputEntityId:
-        dataElementDependencyOrder != null &&
-        dataElementDependencyOrder[0] === 'yAxisVariable'
-          ? yAxisVariable?.entityId
-          : xAxisVariable.entityId,
+      // add outputEntityId
+      outputEntityId: outputEntityId,
       xAxisVariable: xAxisVariable,
       yAxisVariable: yAxisVariable,
     },

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -204,7 +204,9 @@ function MosaicViz(props: Props) {
         studyId,
         filters ?? [],
         vizConfig.xAxisVariable,
-        vizConfig.yAxisVariable
+        vizConfig.yAxisVariable,
+        // add dataElementDependencyOrder
+        dataElementDependencyOrder
       );
 
       if (isTwoByTwo) {
@@ -317,7 +319,13 @@ function MosaicViz(props: Props) {
         <VariableCoverageTable
           completeCases={data.pending ? undefined : data.value?.completeCases}
           filters={filters}
-          outputEntityId={vizConfig.xAxisVariable?.entityId}
+          outputEntityId={
+            // add outputEntityId per dataElementDependencyOrder
+            dataElementDependencyOrder != null &&
+            dataElementDependencyOrder[0] === 'yAxisVariable'
+              ? vizConfig.yAxisVariable?.entityId
+              : vizConfig.xAxisVariable?.entityId
+          }
           variableSpecs={[
             {
               role: 'X-axis',
@@ -516,13 +524,20 @@ function getRequestParams(
   studyId: string,
   filters: Filter[],
   xAxisVariable: VariableDescriptor,
-  yAxisVariable: VariableDescriptor
+  yAxisVariable: VariableDescriptor,
+  // add dataElementDependencyOrder here
+  dataElementDependencyOrder?: string[]
 ): MosaicRequestParams {
   return {
     studyId,
     filters,
     config: {
-      outputEntityId: xAxisVariable.entityId,
+      // add outputEntityId per dataElementDependencyOrder
+      outputEntityId:
+        dataElementDependencyOrder != null &&
+        dataElementDependencyOrder[0] === 'yAxisVariable'
+          ? yAxisVariable?.entityId
+          : xAxisVariable.entityId,
       xAxisVariable: xAxisVariable,
       yAxisVariable: yAxisVariable,
     },

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -18,6 +18,7 @@ import {
 import { usePromise } from '../../../hooks/promise';
 import { useFindEntityAndVariable } from '../../../hooks/study';
 import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
+import { useFindOutputEntity } from '../../../hooks/findOutputEntity';
 import { Filter } from '../../../types/filter';
 import { PromiseType } from '../../../types/utility';
 import { VariableDescriptor } from '../../../types/variable';
@@ -182,14 +183,12 @@ function MosaicViz(props: Props) {
   const findEntityAndVariable = useFindEntityAndVariable(entities);
 
   // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams
-  const outputEntity = useMemo(() => {
-    const outputEntityVariableName =
-      dataElementDependencyOrder != null &&
-      dataElementDependencyOrder[0] === 'yAxisVariable'
-        ? vizConfig.yAxisVariable
-        : vizConfig.xAxisVariable;
-    return findEntityAndVariable(outputEntityVariableName)?.entity;
-  }, [dataElementDependencyOrder, vizConfig, findEntityAndVariable]);
+  const outputEntity = useFindOutputEntity(
+    dataElementDependencyOrder,
+    vizConfig,
+    'xAxisVariable',
+    entities
+  );
 
   const data = usePromise(
     useCallback(async (): Promise<ContTableData | TwoByTwoData | undefined> => {

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -19,6 +19,7 @@ import {
 import { usePromise } from '../../../hooks/promise';
 import { useFindEntityAndVariable } from '../../../hooks/study';
 import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
+import { useFindOutputEntity } from '../../../hooks/findOutputEntity';
 import { Filter } from '../../../types/filter';
 // import { StudyEntity } from '../../../types/study';
 import { PromiseType } from '../../../types/utility';
@@ -113,9 +114,9 @@ function createDefaultConfig(): ScatterplotConfig {
   };
 }
 
-type ScatterplotConfig = t.TypeOf<typeof ScatterplotConfig>;
+export type ScatterplotConfig = t.TypeOf<typeof ScatterplotConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-const ScatterplotConfig = t.partial({
+export const ScatterplotConfig = t.partial({
   xAxisVariable: VariableDescriptor,
   yAxisVariable: VariableDescriptor,
   overlayVariable: VariableDescriptor,
@@ -213,14 +214,12 @@ function ScatterplotViz(props: Props) {
   );
 
   // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams
-  const outputEntity = useMemo(() => {
-    const outputEntityVariableName =
-      dataElementDependencyOrder != null &&
-      dataElementDependencyOrder[0] === 'yAxisVariable'
-        ? vizConfig.yAxisVariable
-        : vizConfig.xAxisVariable;
-    return findEntityAndVariable(outputEntityVariableName)?.entity;
-  }, [dataElementDependencyOrder, vizConfig, findEntityAndVariable]);
+  const outputEntity = useFindOutputEntity(
+    dataElementDependencyOrder,
+    vizConfig,
+    'xAxisVariable',
+    entities
+  );
 
   const data = usePromise(
     useCallback(async (): Promise<PromiseXYPlotData | undefined> => {

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -212,6 +212,24 @@ function ScatterplotViz(props: Props) {
     [updateVizConfig]
   );
 
+  // outputEntity for OutputEntityTitle's outputEntity prop
+  const outputEntity = useMemo(() => {
+    const outputEntityVariableName =
+      dataElementDependencyOrder != null &&
+      dataElementDependencyOrder[0] === 'yAxisVariable'
+        ? vizConfig.yAxisVariable
+        : vizConfig.xAxisVariable;
+    return findEntityAndVariable(outputEntityVariableName)?.entity;
+  }, [dataElementDependencyOrder, vizConfig, findEntityAndVariable]);
+
+  // outputEntityId for getRequestParams
+  const outputEntityId = useMemo(() => {
+    return dataElementDependencyOrder != null &&
+      dataElementDependencyOrder[0] === 'yAxisVariable'
+      ? vizConfig.yAxisVariable?.entityId
+      : vizConfig.xAxisVariable?.entityId;
+  }, [dataElementDependencyOrder, vizConfig, findEntityAndVariable]);
+
   const data = usePromise(
     useCallback(async (): Promise<PromiseXYPlotData | undefined> => {
       const xAxisVariable = findEntityAndVariable(vizConfig.xAxisVariable)
@@ -243,8 +261,8 @@ function ScatterplotViz(props: Props) {
         vizConfig.xAxisVariable,
         vizConfig.yAxisVariable,
         vizConfig.overlayVariable,
-        // add dataElementDependencyOrder
-        dataElementDependencyOrder,
+        // pass outputEntityId
+        outputEntityId,
         // add visualization.type
         visualization.type,
         // XYPlotControls
@@ -342,7 +360,7 @@ function ScatterplotViz(props: Props) {
       {fullscreen ? (
         <>
           <OutputEntityTitle
-            entity={findEntityAndVariable(vizConfig.xAxisVariable)?.entity}
+            entity={outputEntity}
             outputSize={data.pending ? undefined : data.value?.outputSize}
           />
           <div
@@ -425,13 +443,7 @@ function ScatterplotViz(props: Props) {
                   : undefined
               }
               filters={filters}
-              outputEntityId={
-                // add outputEntityId per dataElementDependencyOrder
-                dataElementDependencyOrder != null &&
-                dataElementDependencyOrder[0] === 'yAxisVariable'
-                  ? vizConfig.yAxisVariable?.entityId
-                  : vizConfig.xAxisVariable?.entityId
-              }
+              outputEntityId={outputEntityId}
               variableSpecs={[
                 {
                   role: 'X-axis',
@@ -603,8 +615,8 @@ function getRequestParams(
   // set yAxisVariable as optional for densityplot
   yAxisVariable?: VariableDescriptor,
   overlayVariable?: VariableDescriptor,
-  // add dataElementDependencyOrder
-  dataElementDependencyOrder?: string[],
+  // pass outputEntityId
+  outputEntityId?: string,
   // add visualization.type
   vizType?: string,
   // XYPlotControls
@@ -623,12 +635,8 @@ function getRequestParams(
       studyId,
       filters,
       config: {
-        // add outputEntityId per dataElementDependencyOrder
-        outputEntityId:
-          dataElementDependencyOrder != null &&
-          dataElementDependencyOrder[0] === 'yAxisVariable'
-            ? yAxisVariable?.entityId
-            : xAxisVariable.entityId,
+        // add outputEntityId
+        outputEntityId: outputEntityId,
         xAxisVariable: xAxisVariable,
         yAxisVariable: yAxisVariable,
         overlayVariable: overlayVariable,
@@ -640,12 +648,8 @@ function getRequestParams(
       studyId,
       filters,
       config: {
-        // add outputEntityId per dataElementDependencyOrder
-        outputEntityId:
-          dataElementDependencyOrder != null &&
-          dataElementDependencyOrder[0] === 'yAxisVariable'
-            ? yAxisVariable?.entityId
-            : xAxisVariable.entityId,
+        // add outputEntityId
+        outputEntityId: outputEntityId,
         // XYPlotControls
         valueSpec: valueSpecValue,
         xAxisVariable: xAxisVariable,

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -243,6 +243,8 @@ function ScatterplotViz(props: Props) {
         vizConfig.xAxisVariable,
         vizConfig.yAxisVariable,
         vizConfig.overlayVariable,
+        // add dataElementDependencyOrder
+        dataElementDependencyOrder,
         // add visualization.type
         visualization.type,
         // XYPlotControls
@@ -283,7 +285,6 @@ function ScatterplotViz(props: Props) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       {fullscreen && (
-        //DKDKDK add margin-bottom
         <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
           <InputVariables
             inputs={[
@@ -425,7 +426,11 @@ function ScatterplotViz(props: Props) {
               }
               filters={filters}
               outputEntityId={
-                findEntityAndVariable(vizConfig.xAxisVariable)?.entity.id
+                // add outputEntityId per dataElementDependencyOrder
+                dataElementDependencyOrder != null &&
+                dataElementDependencyOrder[0] === 'yAxisVariable'
+                  ? vizConfig.yAxisVariable?.entityId
+                  : vizConfig.xAxisVariable?.entityId
               }
               variableSpecs={[
                 {
@@ -580,10 +585,16 @@ export function scatterplotResponseToData(
   };
 }
 
-// add an extended type
+// add an extended type including dataElementDependencyOrder
 type getRequestParamsProps =
-  | (ScatterplotRequestParams & { vizType?: string })
-  | (LineplotRequestParams & { vizType?: string });
+  | (ScatterplotRequestParams & {
+      vizType?: string;
+      dataElementDependencyOrder?: string[];
+    })
+  | (LineplotRequestParams & {
+      vizType?: string;
+      dataElementDependencyOrder?: string[];
+    });
 
 function getRequestParams(
   studyId: string,
@@ -592,6 +603,8 @@ function getRequestParams(
   // set yAxisVariable as optional for densityplot
   yAxisVariable?: VariableDescriptor,
   overlayVariable?: VariableDescriptor,
+  // add dataElementDependencyOrder
+  dataElementDependencyOrder?: string[],
   // add visualization.type
   vizType?: string,
   // XYPlotControls
@@ -610,8 +623,12 @@ function getRequestParams(
       studyId,
       filters,
       config: {
-        // is outputEntityId correct?
-        outputEntityId: xAxisVariable.entityId,
+        // add outputEntityId per dataElementDependencyOrder
+        outputEntityId:
+          dataElementDependencyOrder != null &&
+          dataElementDependencyOrder[0] === 'yAxisVariable'
+            ? yAxisVariable?.entityId
+            : xAxisVariable.entityId,
         xAxisVariable: xAxisVariable,
         yAxisVariable: yAxisVariable,
         overlayVariable: overlayVariable,
@@ -623,8 +640,12 @@ function getRequestParams(
       studyId,
       filters,
       config: {
-        // is outputEntityId correct?
-        outputEntityId: xAxisVariable.entityId,
+        // add outputEntityId per dataElementDependencyOrder
+        outputEntityId:
+          dataElementDependencyOrder != null &&
+          dataElementDependencyOrder[0] === 'yAxisVariable'
+            ? yAxisVariable?.entityId
+            : xAxisVariable.entityId,
         // XYPlotControls
         valueSpec: valueSpecValue,
         xAxisVariable: xAxisVariable,

--- a/src/lib/core/hooks/findOutputEntity.ts
+++ b/src/lib/core/hooks/findOutputEntity.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import { VariableDescriptor } from '../types/variable';
+import { StudyEntity } from '../types/study';
+import { useFindEntityAndVariable } from './study';
+
+export function useFindOutputEntity(
+  dataElementDependencyOrder: string[] | undefined,
+  // need to add string at Record's Type due to valueSpecConfig
+  dataElementVariables: Record<string, VariableDescriptor | string | undefined>,
+  defaultVariableName: string,
+  entities: StudyEntity[]
+) {
+  const findEntityAndVariable = useFindEntityAndVariable(entities);
+  return useMemo(() => {
+    const variableName =
+      dataElementDependencyOrder == null ||
+      dataElementDependencyOrder.length === 0
+        ? defaultVariableName
+        : dataElementDependencyOrder[0];
+    const variable = dataElementVariables[variableName];
+    // need to clarify 'as VariableDescriptor' due to Record Type's string (valueSpecConfig)
+    return findEntityAndVariable(variable as VariableDescriptor)?.entity;
+  }, [
+    dataElementDependencyOrder,
+    dataElementVariables,
+    defaultVariableName,
+    entities,
+  ]);
+}


### PR DESCRIPTION
This PR includes dependency order issue (#240) and viz description (#238): possibly addressing another issues like #227 and [EDADataService one](https://github.com/VEuPathDB/EdaDataService/issues/41) in this work. 

For dependency order, as of now four vizs that have X/Y variables such as scatter, line, mosaic, and box plot vizs are the targets to be addressed. Also realized that grid view/thumbnail did not have `dataElementDependencyOrder` props, thus it was required to pass it to the grid view/thumbnail (at `VisualizationsContainer`). I have known two cases at least (see Figures 1 and 2) that threw errors for specific combination of variables, which can be reproduced at feature site. After following the dependency order, it seems to work properly now.

Regarding viz description, `VisualizationsContainer` component was changed to allow the features such as tooltip for variable picker (see Figure 3) and description at viz. As of now, I have added viz description at the next of each viz's name, e.g., for scatter plot viz, it was implemented as "Scatter plot: Visualize the relationship between two continuous variables": refer to Figures 1 (scatter plot) and 2 (mosaic plot). 

**Figure 1**
![scatter-depend0](https://user-images.githubusercontent.com/12802305/127325334-d86edaba-fdaf-49b9-ac42-a1a5a0756c0b.png)

**Figure 2**
![mosaic-depend0](https://user-images.githubusercontent.com/12802305/127325355-c9abb544-0616-4e2a-b4bb-6f39763c36ae.png)

**Figure3**
![scatter-thumbnail0](https://user-images.githubusercontent.com/12802305/127325368-6133637f-c744-4f22-83b9-fe4c9e6a2227.png)

