### PR TITLE
Add a proxy for the Dataset Access Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The following environment variables are used by the `yarn start` script:
 | `WDK_SERVICE_URL`                     | Full url to a running WDK REST Service            |
 | `EDA_SUBSETTING_SERVICE_URL`          | Full url to a running EDA Subsetting Service      |
 | `EDA_DATA_SERVICE_URL`                | Full url to a running EDA Data Service            |
+| `DATASET_ACCESS_SERVICE_URL`          | Full url to a running Dataset Access Service      |
 | `REACT_APP_DISABLE_DATA_RESTRICTIONS` | If present and `true`, disables data restrictions |
 
 ## Learn More

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import {
   enableRestriction,
   reduxMiddleware,
 } from '@veupathdb/web-common/lib/App/DataRestriction/DataRestrictionUtils';
+import { withPermissions } from '@veupathdb/web-common/lib/components/Permissions';
 import { useAttemptActionClickHandler } from '@veupathdb/web-common/lib/hooks/dataRestriction';
 
 import Header from './Header';
@@ -63,6 +64,7 @@ initialize({
     ...routes,
   ],
   componentWrappers: {
+    DataRestrictionDaemon: withPermissions,
     SiteHeader: () => Header,
     Page: (DefaultComponent: React.ComponentType<Props>) => {
       return function ClinEpiPage(props: Props) {

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -38,6 +38,18 @@ module.exports = function (app) {
       onProxyReq: addAuthCookie,
     })
   );
+  app.use(
+    '/dataset-access',
+    createProxyMiddleware({
+      target: process.env.DATASET_ACCESS_SERVICE_URL,
+      pathRewrite: { [`^/dataset-access`]: '' },
+      secure: false,
+      changeOrigin: true,
+      followRedirects: true,
+      logLevel: 'debug',
+      onProxyReq: addAuthCookie,
+    })
+  );
 };
 
 function addAuthCookie(proxyReq) {


### PR DESCRIPTION
The [Dataset Access Service](https://github.com/VEuPathDB/service-dataset-access) is used to determine which studies a registered user is approved to access.

This PR adds a proxy to this service to the dev server. (In the short term, we won't actually be exercising this proxy, as the service is only consulted to determine the permissions of *registered* users, and currently, our local dev environment doesn't support login.)

**Note:** An example of a valid `DATASET_ACCESS_SERVICE_URL` is `https://feature.clinepidb.org/dataset-access`.