### PR TITLE
Restrict EDA Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@types/debounce-promise": "^3.1.3",
     "@veupathdb/components": "^0.3.23",
     "@veupathdb/wdk-client": "^0.1.6",
-    "@veupathdb/web-common": "^0.1.2",
+    "@veupathdb/web-common": "^0.1.3",
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",
     "io-ts": "^2.2.13",

--- a/src/lib/workspace/EDAAnalysisList.tsx
+++ b/src/lib/workspace/EDAAnalysisList.tsx
@@ -1,3 +1,5 @@
+import { RestrictedPage } from '@veupathdb/web-common/lib/App/DataRestriction/RestrictedPage';
+import { useApprovalStatus } from '@veupathdb/web-common/lib/hooks/dataRestriction';
 import React, { useMemo } from 'react';
 import { EDAAnalysisListContainer } from '../core';
 import { SubsettingClient } from '../core/api/subsetting-api';
@@ -24,16 +26,20 @@ export function EDAAnalysisList(props: Props) {
     [props.dataServiceUrl]
   );
 
+  const approvalStatus = useApprovalStatus(props.studyId, 'analysis');
+
   return (
-    <EDAAnalysisListContainer
-      studyId={props.studyId}
-      subsettingClient={subsettingClient}
-      dataClient={dataClient}
-      className={cx()}
-      analysisClient={mockAnalysisStore}
-    >
-      <EDAWorkspaceHeading />
-      <AnalysisList analysisStore={mockAnalysisStore} />
-    </EDAAnalysisListContainer>
+    <RestrictedPage approvalStatus={approvalStatus}>
+      <EDAAnalysisListContainer
+        studyId={props.studyId}
+        subsettingClient={subsettingClient}
+        dataClient={dataClient}
+        className={cx()}
+        analysisClient={mockAnalysisStore}
+      >
+        <EDAWorkspaceHeading />
+        <AnalysisList analysisStore={mockAnalysisStore} />
+      </EDAAnalysisListContainer>
+    </RestrictedPage>
   );
 }

--- a/src/lib/workspace/NewAnalysis.tsx
+++ b/src/lib/workspace/NewAnalysis.tsx
@@ -1,3 +1,5 @@
+import { RestrictedPage } from '@veupathdb/web-common/lib/App/DataRestriction/RestrictedPage';
+import { useApprovalStatus } from '@veupathdb/web-common/lib/hooks/dataRestriction';
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Task } from '@veupathdb/wdk-client/lib/Utils/Task';
@@ -10,28 +12,36 @@ interface Props {
 
 export function NewAnalysis(props: Props) {
   const { analysisClient: analysisStore, studyId } = props;
+  const approvalStatus = useApprovalStatus(studyId, 'analysis');
   const history = useHistory();
-  useEffect(
-    () =>
-      Task.fromPromise(
-        analysisStore.createAnalysis({
-          name: 'Unnamed Analysis',
-          studyId,
-          filters: [],
-          starredVariables: [],
-          derivedVariables: [],
-          visualizations: [],
-          computations: [],
-          variableUISettings: {},
-        })
-      ).run(({ id }) => {
-        const newLocation = {
-          ...history.location,
-          pathname: `./${id}`,
-        };
-        history.push(newLocation);
-      }),
-    [analysisStore, history, studyId]
+  useEffect(() => {
+    if (approvalStatus !== 'approved') {
+      return;
+    }
+
+    return Task.fromPromise(
+      analysisStore.createAnalysis({
+        name: 'Unnamed Analysis',
+        studyId,
+        filters: [],
+        starredVariables: [],
+        derivedVariables: [],
+        visualizations: [],
+        computations: [],
+        variableUISettings: {},
+      })
+    ).run(({ id }) => {
+      const newLocation = {
+        ...history.location,
+        pathname: `./${id}`,
+      };
+      history.push(newLocation);
+    });
+  }, [analysisStore, history, studyId, approvalStatus]);
+
+  return (
+    <RestrictedPage approvalStatus={approvalStatus}>
+      <div style={{ fontSize: '3em' }}>Creating new analysis...</div>
+    </RestrictedPage>
   );
-  return <div style={{ fontSize: '3em' }}>Creating new analysis...</div>;
 }

--- a/src/lib/workspace/WorkspaceContainer.tsx
+++ b/src/lib/workspace/WorkspaceContainer.tsx
@@ -1,5 +1,7 @@
 import { find } from '@veupathdb/wdk-client/lib/Utils/IterableUtils';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
+import { RestrictedPage } from '@veupathdb/web-common/lib/App/DataRestriction/RestrictedPage';
+import { useApprovalStatus } from '@veupathdb/web-common/lib/hooks/dataRestriction';
 import React, { useCallback, useMemo } from 'react';
 import { useRouteMatch } from 'react-router';
 import {
@@ -53,18 +55,22 @@ export function WorkspaceContainer(props: Props) {
     },
     [url]
   );
+  const approvalStatus = useApprovalStatus(props.studyId, 'analysis');
+
   return (
-    <EDAWorkspaceContainer
-      analysisId={props.analysisId}
-      studyId={props.studyId}
-      className={cx()}
-      analysisClient={mockAnalysisStore}
-      dataClient={dataClient}
-      subsettingClient={subsettingClient}
-      makeVariableLink={makeVariableLink}
-    >
-      <EDAWorkspaceHeading />
-      <AnalysisPanel analysisId={props.analysisId} />
-    </EDAWorkspaceContainer>
+    <RestrictedPage approvalStatus={approvalStatus}>
+      <EDAWorkspaceContainer
+        analysisId={props.analysisId}
+        studyId={props.studyId}
+        className={cx()}
+        analysisClient={mockAnalysisStore}
+        dataClient={dataClient}
+        subsettingClient={subsettingClient}
+        makeVariableLink={makeVariableLink}
+      >
+        <EDAWorkspaceHeading />
+        <AnalysisPanel analysisId={props.analysisId} />
+      </EDAWorkspaceContainer>
+    </RestrictedPage>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2997,10 +2997,10 @@
     spin.js "^4.0.0"
     uuid "^8.1.0"
 
-"@veupathdb/web-common@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.1.2.tgz#8748eca36d24ea8bf1728236106cb7f07e5b2318"
-  integrity sha512-hz+l+wNGXAVz0GJdxUi40ppNSDJLFd9AkAH+FCr2OdcFKKSFXxg/CkGkQ9Hyf4YHmtdXifVRf6lqozfNfJYRVg==
+"@veupathdb/web-common@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.1.3.tgz#a2909ddb8e66260c952ad031722d291c62f97347"
+  integrity sha512-BhrlQwI2gX25obKp0OucgUBi7TMVaodgAu/lVrlX+QIkXGvq6136njUEUpPpDdlgb2fRXMjDAF6vftL62prbMg==
   dependencies:
     custom-event-polyfill "^1.0.7"
     md5 "^2.3.0"


### PR DESCRIPTION
This PR guards the following 3 pages with an ["analysis" Data Restriction](https://github.com/VEuPathDB/EbrcWebsiteCommon/blob/18a8f968dafda026e5d664ffd629f8222f864748/Client/src/App/DataRestriction/DataRestrictionUtils.js#L17):

1. EDAAnalysisList (our temporary landing page of the analyses for a single study)
2. WorkspaceContainer (the main "browse/subset/visualize" page)
3. NewAnalysis (creates a new analysis and redirects to it)

It make use of a [new hook and utility component](https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/58).