### PR TITLE
Allow analysis subpath to be provided to "latest" route

### DIFF
--- a/src/lib/workspace/WorkspaceRouter.tsx
+++ b/src/lib/workspace/WorkspaceRouter.tsx
@@ -60,11 +60,11 @@ export function WorkspaceRouter({
         )}
       />
       <Route
-        path={`${path}/:studyId/latest`}
-        exact
+        path={`${path}/:studyId/~latest`}
         render={(props: RouteComponentProps<{ studyId: string }>) => (
           <LatestAnalysis
             {...props.match.params}
+            replaceRegexp={/~latest/}
             analysisClient={mockAnalysisStore}
           />
         )}


### PR DESCRIPTION
I forgot about a use case that we should be able to link to a subpath of an analysis. We will need this for linking to the Study Details tab from the homepage of ClinepiDB.