### PR TITLE
Rearrange action buttons and update styling

### DIFF
--- a/src/lib/core/components/EDAAnalysisListContainer.tsx
+++ b/src/lib/core/components/EDAAnalysisListContainer.tsx
@@ -5,7 +5,10 @@ import { SubsettingClient } from '../api/subsetting-api';
 import { DataClient } from '../api/data-api';
 import { WorkspaceContext } from '../context/WorkspaceContext';
 import ErrorStatus from '@veupathdb/wdk-client/lib/Components/PageStatus/Error';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core';
+import { workspaceTheme } from './workspaceTheme';
 
+const theme = createMuiTheme(workspaceTheme);
 interface Props {
   studyId: string;
   children: React.ReactChild | React.ReactChild[];
@@ -45,7 +48,7 @@ export function EDAAnalysisListContainer(props: Props) {
           dataClient,
         }}
       >
-        {children}
+        <ThemeProvider theme={theme}>{children}</ThemeProvider>
       </WorkspaceContext.Provider>
     </div>
   );

--- a/src/lib/core/hooks/study.ts
+++ b/src/lib/core/hooks/study.ts
@@ -50,7 +50,8 @@ export function useWdkStudyRecord(datasetId: string): HookValue | undefined {
             getScopes(node).includes('eda')
         )
         .map(getNodeId)
-        .toArray();
+        .toArray()
+        .concat(['bulk_download_url']);
       const studyRecord = await wdkService
         .getRecord(
           STUDY_RECORD_CLASS_NAME,

--- a/src/lib/workspace/AnalysisSummary.tsx
+++ b/src/lib/workspace/AnalysisSummary.tsx
@@ -56,13 +56,6 @@ export function AnalysisSummary(props: Props) {
       </div>
       <div className={cx('-AnalysisSummaryRight')}>
         <ActionIconButton
-          iconClassName="download"
-          hoverText="Bulk download study"
-          action={() => {
-            alert('Coming soon');
-          }}
-        />
-        <ActionIconButton
           iconClassName="clone"
           hoverText="Copy analysis"
           action={handleCopy}

--- a/src/lib/workspace/EDAWorkspace.scss
+++ b/src/lib/workspace/EDAWorkspace.scss
@@ -17,7 +17,7 @@
       'title linkouts' auto
       / auto 1fr;
     gap: 1em;
-    align-items: baseline;
+    align-items: center;
     line-height: 1;
     margin-bottom: 0.5em;
   }
@@ -74,12 +74,12 @@
 
   &-Linkouts {
     grid-area: linkouts;
-    font-size: 1.25em;
+    font-size: 1.5em;
     display: grid;
     grid-auto-flow: column;
     gap: 1em;
     margin-right: auto;
-    margin-left: 2em;
+    // margin-left: 1ex;
   }
 
   &-Analysis {
@@ -95,12 +95,12 @@
   &-AnalysisSummaryLeft {
     display: flex;
     align-items: center;
-    margin-right: auto;
   }
 
   &-AnalysisSummaryRight {
     display: flex;
     align-items: center;
+    font-size: 0.8em;
   }
 
   &-AnalysisNameEditBox {

--- a/src/lib/workspace/EDAWorkspace.scss
+++ b/src/lib/workspace/EDAWorkspace.scss
@@ -19,7 +19,9 @@
     gap: 1em;
     align-items: center;
     line-height: 1;
-    margin-bottom: 0.5em;
+    border-bottom: 1px solid lightgray;
+    margin-bottom: 1em;
+    padding-bottom: 0.75em;
   }
 
   h1 {
@@ -79,7 +81,10 @@
     grid-auto-flow: column;
     gap: 1em;
     margin-right: auto;
-    // margin-left: 1ex;
+    margin-left: 2em;
+    a {
+      font-size: 0.75em;
+    }
   }
 
   &-Analysis {
@@ -143,6 +148,10 @@
 
     h1 {
       font-size: 1em;
+    }
+
+    .WorkspaceNavigation--Item {
+      margin-right: 1.25em;
     }
   }
 

--- a/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -13,12 +13,30 @@ export function EDAWorkspaceHeading() {
     <div className={cx('-Heading')}>
       <h1>{safeHtml(studyRecord.displayName)}</h1>
       <div className={cx('-Linkouts')}>
+        {studyRecord.attributes.bulk_download_url && (
+          <div>
+            <Tooltip title="Download study files">
+              <Button
+                variant="text"
+                color="primary"
+                startIcon={<Icon className="fa fa-download fa-fw" />}
+                component={Link}
+                to={
+                  (studyRecord.attributes
+                    .bulk_download_url as LinkAttributeValue).url
+                }
+              >
+                &nbsp;Download
+              </Button>
+            </Tooltip>
+          </div>
+        )}
         <div>
           <Tooltip title="Create a new analysis">
             <Button
-              variant="outlined"
+              variant="text"
               color="primary"
-              startIcon={<Icon className="fa fa-plus" />}
+              startIcon={<Icon className="fa fa-plus fa-fw" />}
               component={Link}
               to={
                 url.endsWith(studyRecord.id[0].value)
@@ -26,28 +44,10 @@ export function EDAWorkspaceHeading() {
                   : `${url}/../new`
               }
             >
-              New
+              New analysis
             </Button>
           </Tooltip>
         </div>
-        {studyRecord.attributes.bulk_download_url && (
-          <div>
-            <Tooltip title="Download study files">
-              <Button
-                variant="outlined"
-                color="primary"
-                startIcon={<Icon className="fa fa-download" />}
-                component={Link}
-                to={
-                  (studyRecord.attributes
-                    .bulk_download_url as LinkAttributeValue).url
-                }
-              >
-                Download
-              </Button>
-            </Tooltip>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -1,14 +1,54 @@
 import React from 'react';
+import { Link, useRouteMatch } from 'react-router-dom';
 import { cx } from './Utils';
 import { useStudyRecord } from '../core';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+import { Button, Tooltip, Icon } from '@material-ui/core';
+import { LinkAttributeValue } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 
 export function EDAWorkspaceHeading() {
   const studyRecord = useStudyRecord();
+  const { url } = useRouteMatch();
   return (
     <div className={cx('-Heading')}>
       <h1>{safeHtml(studyRecord.displayName)}</h1>
-      <div className={cx('-Linkouts')}></div>
+      <div className={cx('-Linkouts')}>
+        <div>
+          <Tooltip title="Create a new analysis">
+            <Button
+              variant="outlined"
+              color="primary"
+              startIcon={<Icon className="fa fa-plus" />}
+              component={Link}
+              to={
+                url.endsWith(studyRecord.id[0].value)
+                  ? `${url}/new`
+                  : `${url}/../new`
+              }
+            >
+              New
+            </Button>
+          </Tooltip>
+        </div>
+        {studyRecord.attributes.bulk_download_url && (
+          <div>
+            <Tooltip title="Download study files">
+              <Button
+                variant="outlined"
+                color="primary"
+                startIcon={<Icon className="fa fa-download" />}
+                component={Link}
+                to={
+                  (studyRecord.attributes
+                    .bulk_download_url as LinkAttributeValue).url
+                }
+              >
+                Download
+              </Button>
+            </Tooltip>
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
On an analysis page, the action icons at the top of the page have been updated. There are two classes of actions: study, and analysis.

- Study actions are : **New analysis** and **Download study files**
- Analysis actions are: **Edit name**, **Duplicate analysis**, and **Delete analysis**

_Note the download action will not work on a locally running site._