### PR TITLE
Fully resolve path to new anlaysis to prevent incorrect parsing

### DIFF
--- a/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, useRouteMatch } from 'react-router-dom';
+import Path from 'path';
 import { cx } from './Utils';
 import { useStudyRecord } from '../core';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
@@ -49,7 +50,7 @@ export function EDAWorkspaceHeading() {
               to={
                 url.endsWith(studyRecord.id[0].value)
                   ? `${url}/new`
-                  : `${url}/../new`
+                  : Path.resolve(url, '../new')
               }
             >
               New analysis


### PR DESCRIPTION
Prior to this PR, when in an analysis, the **New analysis** button would link to a route such as `/eda/DS_841a9f5259/34/../new`. **react-router** would  match on this exact string, rather than the resolved path of `/eda/DS_841a9f5259/new`. The fix is to fully resolve the path before passing to the `Link` component.