### PR TITLE
Move featured vars and compat vars toggle to above tree

### DIFF
--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -301,121 +301,11 @@ export default function VariableList(props: VariableListProps) {
     ]
   );
 
-  const wrapTreeSection = useCallback(
-    (treeSection: React.ReactNode) => {
-      const tooltipContent = (
-        <>
-          Some variables cannot be used here. Use this to toggle their presence
-          below.
-          <br />
-          <br />
-          <strong>
-            <Link
-              to=""
-              onClick={(e) => {
-                e.preventDefault();
-                alert('Comming soon');
-              }}
-            >
-              <Icon fa="info-circle" /> Learn more
-            </Link>
-          </strong>{' '}
-          about variable compatibility
-        </>
-      );
-      return (
-        <>
-          {disabledFields.size > 0 && (
-            <div className={cx('-DisabledVariablesToggle')}>
-              <HtmlTooltip
-                css={
-                  {
-                    /*
-                     * This is needed to address a compiler error.
-                     * Not sure why it's complaining, but here we are...
-                     */
-                  }
-                }
-                title={tooltipContent}
-                interactive
-                enterDelay={500}
-                enterNextDelay={500}
-                leaveDelay={0}
-              >
-                <button
-                  className="link"
-                  type="button"
-                  onClick={() => {
-                    setHideDisabledFields(!hideDisabledFields);
-                  }}
-                >
-                  <Toggle on={hideDisabledFields} /> Only show compatible
-                  variables
-                </button>
-              </HtmlTooltip>
-            </div>
-          )}
-          {featuredFields.length && (
-            <div className="FeaturedVariables">
-              <details
-                open={Options.featuredVariablesOpen}
-                onToggle={(event: React.SyntheticEvent<HTMLDetailsElement>) => {
-                  Options.featuredVariablesOpen = event.currentTarget.open;
-                }}
-              >
-                <summary>
-                  <h3>Featured variables</h3>
-                </summary>
-                <ul>
-                  {featuredFields.map((field) => {
-                    const isActive = field.term === activeField?.term;
-                    const isDisabled = disabledFields.has(field.term);
-                    const variableId = field.term.split('/')[1];
-                    return (
-                      <li
-                        key={field.term}
-                        className="wdk-CheckboxTreeItem wdk-CheckboxTreeItem__leaf"
-                      >
-                        <div className="wdk-CheckboxTreeNodeContent">
-                          <FieldNode
-                            field={field}
-                            isActive={isActive}
-                            isDisabled={isDisabled}
-                            searchTerm=""
-                            handleFieldSelect={handleFieldSelect}
-                            isStarred={starredVariablesSet.has(variableId)}
-                            starredVariablesLoading={starredVariablesLoading}
-                            onClickStar={() =>
-                              toggleStarredVariable(variableId)
-                            }
-                            scrollIntoView={false}
-                          />
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </details>
-            </div>
-          )}
-          {treeSection}
-        </>
-      );
-    },
-    [
-      disabledFields,
-      hideDisabledFields,
-      featuredFields,
-      setHideDisabledFields,
-      activeField?.term,
-      handleFieldSelect,
-      starredVariablesSet,
-      starredVariablesLoading,
-      toggleStarredVariable,
-    ]
-  );
-
   const isAdditionalFilterApplied = showOnlyStarredVariables;
+
+  const allowedFeaturedFields = hideDisabledFields
+    ? featuredFields.filter((field) => !disabledFields.has(field.term))
+    : featuredFields;
 
   const tree = useMemo(() => {
     const tree =
@@ -444,8 +334,100 @@ export default function VariableList(props: VariableListProps) {
     disabledFields,
   ]);
 
+  const tooltipContent = (
+    <>
+      Some variables cannot be used here. Use this to toggle their presence
+      below.
+      <br />
+      <br />
+      <strong>
+        <Link
+          to=""
+          onClick={(e) => {
+            e.preventDefault();
+            alert('Comming soon');
+          }}
+        >
+          <Icon fa="info-circle" /> Learn more
+        </Link>
+      </strong>{' '}
+      about variable compatibility
+    </>
+  );
+
   return (
     <div className={cx('-VariableList')}>
+      {disabledFields.size > 0 && (
+        <div className={cx('-DisabledVariablesToggle')}>
+          <HtmlTooltip
+            css={
+              {
+                /*
+                 * This is needed to address a compiler error.
+                 * Not sure why it's complaining, but here we are...
+                 */
+              }
+            }
+            title={tooltipContent}
+            interactive
+            enterDelay={500}
+            enterNextDelay={500}
+            leaveDelay={0}
+          >
+            <button
+              className="link"
+              type="button"
+              onClick={() => {
+                setHideDisabledFields(!hideDisabledFields);
+              }}
+            >
+              <Toggle on={hideDisabledFields} /> Only show compatible variables
+            </button>
+          </HtmlTooltip>
+        </div>
+      )}
+      {allowedFeaturedFields.length && (
+        <div className="FeaturedVariables">
+          <details
+            open={Options.featuredVariablesOpen}
+            onToggle={(event: React.SyntheticEvent<HTMLDetailsElement>) => {
+              Options.featuredVariablesOpen = event.currentTarget.open;
+            }}
+          >
+            <summary>
+              <h3>Featured variables</h3>
+            </summary>
+            <ul>
+              {allowedFeaturedFields.map((field) => {
+                const isActive = field.term === activeField?.term;
+                const isDisabled = disabledFields.has(field.term);
+                const variableId = field.term.split('/')[1];
+                return (
+                  <li
+                    key={field.term}
+                    className="wdk-CheckboxTreeItem wdk-CheckboxTreeItem__leaf"
+                  >
+                    <div className="wdk-CheckboxTreeNodeContent">
+                      <FieldNode
+                        field={field}
+                        isActive={isActive}
+                        isDisabled={isDisabled}
+                        searchTerm=""
+                        handleFieldSelect={handleFieldSelect}
+                        isStarred={starredVariablesSet.has(variableId)}
+                        starredVariablesLoading={starredVariablesLoading}
+                        onClickStar={() => toggleStarredVariable(variableId)}
+                        scrollIntoView={false}
+                      />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </details>
+        </div>
+      )}
+
       <CheckboxTree
         autoFocusSearchBox={autoFocus}
         tree={tree}
@@ -465,7 +447,6 @@ export default function VariableList(props: VariableListProps) {
         renderNode={renderNode}
         additionalFilters={additionalFilters}
         isAdditionalFilterApplied={isAdditionalFilterApplied}
-        wrapTreeSection={wrapTreeSection}
       />
     </div>
   );

--- a/src/lib/core/components/VariableTree.scss
+++ b/src/lib/core/components/VariableTree.scss
@@ -1,15 +1,10 @@
 .EDAWorkspace-VariableList {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 1px;
-  right: 1px;
+  display: flex;
+  flex-flow: column;
 
   .FeaturedVariables {
     padding: 0.5em 1em;
-    background-color: #f7f7f7;
     border: 1px solid #ccc;
-    box-shadow: 0 0 1px #6f6f6fb0;
     summary {
       outline: none;
       cursor: pointer;
@@ -39,8 +34,8 @@
     padding-left: 1.5em;
   }
 
-  .wdk-CheckboxTree .wdk-AttributeFilterFieldItem,
-  .wdk-CheckboxTree .wdk-Link.wdk-AttributeFilterFieldParent {
+  .wdk-AttributeFilterFieldItem,
+  .wdk-Link.wdk-AttributeFilterFieldParent {
     padding: 0.25em 0.5em;
     border-radius: 0.5em;
     display: inline-block;
@@ -69,7 +64,7 @@
   }
 
   .wdk-CheckboxTree {
-    height: 100%;
+    height: 60vh;
     display: flex;
     flex-flow: column;
   }
@@ -141,7 +136,7 @@
   }
 
   .EDAWorkspace-DisabledVariablesToggle {
-    margin: 0 1em 0.75em;
+    margin: 0.75em;
     button {
       color: #666;
     }
@@ -154,7 +149,7 @@
   &TreeContainer {
     // border: 1px solid;
     border-radius: 0.25em;
-    padding: 0.5em;
+    padding: 0.5em 0.5em 0.5em 0;
     height: 60vh;
     width: 30em;
     position: relative;
@@ -162,6 +157,12 @@
     .wdk-AttributeFilterFieldItem,
     .wdk-AttributeFilterFieldParent {
       color: #2f2f2f;
+    }
+
+    .FeaturedVariables {
+      border: none;
+      border-top: 1px solid #ccc;
+      border-bottom: 1px solid #ccc;
     }
   }
 }

--- a/src/lib/core/components/VariableTree.scss
+++ b/src/lib/core/components/VariableTree.scss
@@ -20,6 +20,7 @@
     ul {
       list-style: none;
       margin: 0;
+      margin-top: 0.25em;
     }
     .Entity {
       font-weight: 500;

--- a/src/lib/workspace/EDAWorkspace.scss
+++ b/src/lib/workspace/EDAWorkspace.scss
@@ -189,7 +189,7 @@
   &-Subsetting {
     display: grid;
     grid:
-      [row1-start] 'variables     filter-chips tabular-download' auto [row1-end]
+      [row1-start] '.             filter-chips tabular-download' auto [row1-end]
       [row2-start] 'variables     filter       filter' 1fr [row2-end]
       / auto 1fr auto;
     gap: 1em 3em;

--- a/src/lib/workspace/Subsetting.tsx
+++ b/src/lib/workspace/Subsetting.tsx
@@ -42,30 +42,21 @@ export function Subsetting(props: Props) {
   return (
     <div className={cx('-Subsetting')}>
       <div className="Variables">
-        <div
-          style={{
-            padding: '.5em',
-            height: '60vh',
-            width: '30em',
-            position: 'relative',
+        <VariableTree
+          rootEntity={entities[0]}
+          entityId={entity.id}
+          starredVariables={analysisState.analysis?.starredVariables}
+          toggleStarredVariable={toggleStarredVariable}
+          variableId={variable.id}
+          onChange={(variable) => {
+            if (variable) {
+              const { entityId, variableId } = variable;
+              history.replace(
+                makeVariableLink({ entityId, variableId }, studyMetadata)
+              );
+            } else history.replace('..');
           }}
-        >
-          <VariableTree
-            rootEntity={entities[0]}
-            entityId={entity.id}
-            starredVariables={analysisState.analysis?.starredVariables}
-            toggleStarredVariable={toggleStarredVariable}
-            variableId={variable.id}
-            onChange={(variable) => {
-              if (variable) {
-                const { entityId, variableId } = variable;
-                history.replace(
-                  makeVariableLink({ entityId, variableId }, studyMetadata)
-                );
-              } else history.replace('..');
-            }}
-          />
-        </div>
+        />
       </div>
       <div className="FilterChips">
         <FilterChipList


### PR DESCRIPTION
The PR moves feature variables and the compatible variables toggle to above the variable tree. It also simplifies some styling used to make the variables in the tree scrollable.

### Screenshot
![image](https://user-images.githubusercontent.com/365139/128937805-f3d4c0a7-a838-4667-befc-f59fee32f137.png)

### Related issue
#268
#286