### PR TITLE
Switch for showing missing data for overlay variable [DEPRECATED]

### DIFF
--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -80,6 +80,7 @@ export interface HistogramRequestParams {
       xMin: string;
       xMax: string;
     };
+    showMissingness?: 'TRUE' | 'FALSE';
   };
 }
 

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -17,6 +17,7 @@ import {
 interface InputSpec {
   name: string;
   label: string;
+  wrapper?: React.FunctionComponent;
 }
 
 export interface Props {
@@ -180,22 +181,27 @@ export function InputVariables(props: Props) {
   return (
     <div>
       <div className={classes.inputs}>
-        {inputs.map((input, index) => (
-          <div key={input.name} className={classes.input}>
-            <div className={classes.label}>{input.label}</div>
-            <VariableTreeDropdown
-              rootEntity={entities[0]}
-              disabledVariables={disabledVariablesByInputIndex[index]}
-              starredVariables={starredVariables}
-              toggleStarredVariable={toggleStarredVariable}
-              entityId={values[input.name]?.entityId}
-              variableId={values[input.name]?.variableId}
-              onChange={(variable) => {
-                handleChange(input.name, variable);
-              }}
-            />
-          </div>
-        ))}
+        {inputs.map((input, index) => {
+          const Wrapper = input.wrapper ?? (({ children }) => <>{children}</>);
+          return (
+            <Wrapper>
+              <div key={input.name} className={classes.input}>
+                <div className={classes.label}>{input.label}</div>
+                <VariableTreeDropdown
+                  rootEntity={entities[0]}
+                  disabledVariables={disabledVariablesByInputIndex[index]}
+                  starredVariables={starredVariables}
+                  toggleStarredVariable={toggleStarredVariable}
+                  entityId={values[input.name]?.entityId}
+                  variableId={values[input.name]?.variableId}
+                  onChange={(variable) => {
+                    handleChange(input.name, variable);
+                  }}
+                />
+              </div>
+            </Wrapper>
+          );
+        })}
       </div>
       {/* <div className={`${classes.label} ${classes.dataLabel}`}>Data inputs</div> */}
     </div>

--- a/src/lib/core/components/visualizations/MissingDataToggleWrapper.tsx
+++ b/src/lib/core/components/visualizations/MissingDataToggleWrapper.tsx
@@ -1,0 +1,46 @@
+import React, { useCallback } from 'react';
+import { StudyEntity, Variable } from '../../types/study';
+import { makeEntityDisplayName } from '../../utils/study-metadata';
+import Switch from '@veupathdb/components/lib/components/widgets/Switch';
+
+interface MissingDataToggleWrapperProps {
+  state: boolean | undefined;
+  onStateChange: (newState: boolean) => void;
+  outputEntity: StudyEntity | undefined;
+  overlayVariable: Variable | undefined;
+}
+
+export default function useMissingDataToggleWrapper({
+  state,
+  onStateChange,
+  outputEntity,
+  overlayVariable,
+}: MissingDataToggleWrapperProps) {
+  return useCallback(
+    ({ children }) => {
+      return (
+        <div
+          style={{
+            border: '2px solid #f0f0f0',
+            padding: '3px',
+            display: 'flex',
+            flexDirection: 'row',
+          }}
+        >
+          {children}
+          <Switch
+            label={`Include ${
+              outputEntity
+                ? makeEntityDisplayName(outputEntity, true)
+                : 'points'
+            } with no data for selected overlay variable`}
+            state={state}
+            onStateChange={onStateChange}
+            disabled={overlayVariable == null}
+          />
+        </div>
+      );
+    },
+    [outputEntity, state, overlayVariable, onStateChange]
+  );
+}


### PR DESCRIPTION
Fixes #294 

Requires https://github.com/VEuPathDB/web-components/pull/189

Not quite following the spec [mocked up here](https://docs.google.com/presentation/d/14WwD95etPuj6MS0wHQZ9_2X8CbEQrdhw/edit#slide=id.gb82e9eac95_0_121) in order to get something out more quickly for phase 1 (no faceting).

I added a `wrapper` prop to the inputs given to InputVariables, so that a box and a switch could be added to **one** of the input variable widgets.  In future if we group overlay+facet together we'll need to do something a bit more sophisticated.

As usual, I'm not pretending to be a styling and layout expert.

![image](https://user-images.githubusercontent.com/308639/129409731-be438076-9414-4fc7-a33b-e433990110f5.png)

To do still:

- [ ] missing data needs to be grey (will talk to @chowington !)
- [ ] roll out to other viz's
- [ ] style/layout