### PR TITLE
Switch for showing missing data for overlay variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.4.4",
+    "@veupathdb/components": "^0.6.0",
     "@veupathdb/wdk-client": "^0.2.0",
     "@veupathdb/web-common": "^0.1.5",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -80,6 +80,7 @@ export interface HistogramRequestParams {
       xMin: string;
       xMax: string;
     };
+    showMissingness?: 'TRUE' | 'FALSE';
   };
 }
 

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -204,6 +204,7 @@ export interface ScatterplotRequestParams {
     xAxisVariable: VariableDescriptor;
     yAxisVariable: VariableDescriptor;
     overlayVariable?: VariableDescriptor;
+    showMissingness?: 'TRUE' | 'FALSE';
   };
 }
 
@@ -266,6 +267,7 @@ export interface LineplotRequestParams {
     xAxisVariable: VariableDescriptor;
     yAxisVariable: VariableDescriptor;
     overlayVariable?: VariableDescriptor;
+    showMissingness?: 'TRUE' | 'FALSE';
   };
 }
 

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -398,6 +398,7 @@ export interface BoxplotRequestParams {
     xAxisVariable: VariableDescriptor;
     yAxisVariable: VariableDescriptor;
     overlayVariable?: VariableDescriptor;
+    showMissingness?: 'TRUE' | 'FALSE';
   };
 }
 

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -149,6 +149,7 @@ export interface BarplotRequestParams {
     xAxisVariable: VariableDescriptor;
     // barplot add prop
     overlayVariable?: VariableDescriptor;
+    showMissingness?: 'TRUE' | 'FALSE';
   };
 }
 

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -413,11 +413,13 @@ const BoxplotResponseData = array(
       label: array(string),
     }),
     partial({
-      // outliers type
-      outliers: union([number, array(number), array(array(number))]),
-      rawData: union([number, array(number), array(array(number))]),
+      // outliers
+      // back end is returning {} instead of [], e.g.
+      // [ {}, [1,2,3], [4,5,6] ]
+      outliers: array(union([array(number), type({})])),
+      rawData: array(array(number)),
       // mean: array(number),
-      mean: union([number, array(number)]),
+      mean: array(number),
       seriesX: union([array(string), array(number)]),
       seriesY: array(number),
       // need to make sure if below is correct (untested)

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -106,6 +106,7 @@ export const HistogramResponse = type({
     ),
     config: type({
       completeCases: number,
+      plottedIncompleteCases: number,
       binSlider: type({
         min: number,
         max: number,
@@ -158,6 +159,7 @@ export const BarplotResponse = type({
   barplot: type({
     config: type({
       completeCases: number,
+      plottedIncompleteCases: number,
       xVariableDetails: type({
         variableId: string,
         entityId: string,
@@ -241,6 +243,7 @@ export const ScatterplotResponse = type({
     data: ScatterplotResponseData,
     config: type({
       completeCases: number,
+      plottedIncompleteCases: number,
       xVariableDetails: type({
         variableId: string,
         entityId: string,
@@ -297,6 +300,7 @@ export const LineplotResponse = type({
     data: LineplotResponseData,
     config: type({
       completeCases: number,
+      plottedIncompleteCases: number,
       xVariableDetails: type({
         variableId: string,
         entityId: string,
@@ -333,6 +337,7 @@ export const MosaicResponse = type({
     ),
     config: type({
       completeCases: number,
+      plottedIncompleteCases: number,
       xVariableDetails: type({
         variableId: string,
         entityId: string,
@@ -443,6 +448,7 @@ export const BoxplotResponse = type({
     data: BoxplotResponseData,
     config: type({
       completeCases: number,
+      plottedIncompleteCases: number,
       xVariableDetails: type({
         variableId: string,
         entityId: string,

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -74,6 +74,7 @@ const useStyles = makeStyles(
   {
     inputs: {
       display: 'flex',
+      flexWrap: 'wrap',
       marginBottom: '0.5em',
     },
     input: {
@@ -93,9 +94,16 @@ const useStyles = makeStyles(
       fontSize: '1.35em',
       fontWeight: 500,
     },
-    primary: {},
+    primary: {
+      order: 0,
+    },
+    showMissing: {
+      order: 1,
+      flexBasis: '100%',
+      marginTop: '1em',
+    },
     stratification: {
-      border: '1px solid pink',
+      order: 2,
     },
   },
   {
@@ -222,7 +230,8 @@ export function InputVariables(props: Props) {
         ))}
         {onShowMissingnessChange &&
           inputs.filter((input) => input.role === 'stratification').length && (
-            <div className={[classes.input, classes.stratification].join(' ')}>
+            <div className={[classes.input, classes.showMissing].join(' ')}>
+              <h4>Stratification (optional)</h4>
               <Switch
                 label={`Include ${
                   outputEntity
@@ -232,6 +241,10 @@ export function InputVariables(props: Props) {
                 state={showMissingness}
                 onStateChange={onShowMissingnessChange}
                 disabled={!enableShowMissingnessToggle}
+                labelPosition="after"
+                containerStyles={{
+                  marginLeft: '20px',
+                }}
               />
             </div>
           )}

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -13,10 +13,13 @@ import {
   mapStructure,
   preorder,
 } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
+import Switch from '@veupathdb/components/lib/components/widgets/Switch';
+import { makeEntityDisplayName } from '../../utils/study-metadata';
 
 interface InputSpec {
   name: string;
   label: string;
+  role?: 'primary' | 'stratification'; // TO DO: make mandatory when all viz are updated??
 }
 
 export interface Props {
@@ -57,6 +60,12 @@ export interface Props {
    * A callback for toggling the starred state of a variable with a given ID
    */
   toggleStarredVariable: (targetVariableId: string) => void;
+  /** controlled state of stratification variables' showMissingness toggle switch (optional) */
+  showMissingness?: boolean;
+  /** handler for showMissingness state change */
+  onShowMissingnessChange?: (newState: boolean) => void;
+  /** output entity, required for toggle switch label */
+  outputEntity?: StudyEntity;
 }
 
 const useStyles = makeStyles(
@@ -82,6 +91,10 @@ const useStyles = makeStyles(
       fontSize: '1.35em',
       fontWeight: 500,
     },
+    primary: {},
+    stratification: {
+      border: '1px solid pink',
+    },
   },
   {
     name: 'InputVariables',
@@ -98,6 +111,9 @@ export function InputVariables(props: Props) {
     dataElementDependencyOrder,
     starredVariables,
     toggleStarredVariable,
+    showMissingness,
+    onShowMissingnessChange,
+    outputEntity,
   } = props;
   const classes = useStyles();
   const handleChange = (inputName: string, value?: VariableDescriptor) => {
@@ -181,7 +197,12 @@ export function InputVariables(props: Props) {
     <div>
       <div className={classes.inputs}>
         {inputs.map((input, index) => (
-          <div key={input.name} className={classes.input}>
+          <div
+            key={input.name}
+            className={[classes.input, classes[input.role ?? 'primary']].join(
+              ' '
+            )}
+          >
             <div className={classes.label}>{input.label}</div>
             <VariableTreeDropdown
               rootEntity={entities[0]}
@@ -196,6 +217,21 @@ export function InputVariables(props: Props) {
             />
           </div>
         ))}
+        {onShowMissingnessChange &&
+          inputs.filter((input) => input.role === 'stratification').length && (
+            <div className={[classes.input, classes.stratification].join(' ')}>
+              <Switch
+                label={`Include ${
+                  outputEntity
+                    ? makeEntityDisplayName(outputEntity, true)
+                    : 'points'
+                } with no data for selected stratification variable(s)`}
+                state={showMissingness}
+                onStateChange={onShowMissingnessChange}
+                disabled={false /* to be decided: disable or hide completely */}
+              />
+            </div>
+          )}
       </div>
       {/* <div className={`${classes.label} ${classes.dataLabel}`}>Data inputs</div> */}
     </div>

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -193,6 +193,16 @@ export function InputVariables(props: Props) {
     [dataElementDependencyOrder, entities, flattenedConstraints, inputs, values]
   );
 
+  const stratificationIsActive: boolean = useMemo(() => {
+    // are any of the stratification inputs currently set to a variable?
+    // e.g. values['overlayVariable'] is truthy
+    return (
+      inputs.filter(
+        (input) => input.role === 'stratification' && values[input.name]
+      ).length > 0
+    );
+  }, [inputs, values]);
+
   return (
     <div>
       <div className={classes.inputs}>
@@ -228,7 +238,7 @@ export function InputVariables(props: Props) {
                 } with no data for selected stratification variable(s)`}
                 state={showMissingness}
                 onStateChange={onShowMissingnessChange}
-                disabled={false /* to be decided: disable or hide completely */}
+                disabled={!stratificationIsActive}
               />
             </div>
           )}

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -60,6 +60,8 @@ export interface Props {
    * A callback for toggling the starred state of a variable with a given ID
    */
   toggleStarredVariable: (targetVariableId: string) => void;
+  /** When false, disable (gray out) the showMissingness toggle */
+  enableShowMissingnessToggle?: boolean;
   /** controlled state of stratification variables' showMissingness toggle switch (optional) */
   showMissingness?: boolean;
   /** handler for showMissingness state change */
@@ -111,6 +113,7 @@ export function InputVariables(props: Props) {
     dataElementDependencyOrder,
     starredVariables,
     toggleStarredVariable,
+    enableShowMissingnessToggle = false,
     showMissingness,
     onShowMissingnessChange,
     outputEntity,
@@ -193,16 +196,6 @@ export function InputVariables(props: Props) {
     [dataElementDependencyOrder, entities, flattenedConstraints, inputs, values]
   );
 
-  const stratificationIsActive: boolean = useMemo(() => {
-    // are any of the stratification inputs currently set to a variable?
-    // e.g. values['overlayVariable'] is truthy
-    return (
-      inputs.filter(
-        (input) => input.role === 'stratification' && values[input.name]
-      ).length > 0
-    );
-  }, [inputs, values]);
-
   return (
     <div>
       <div className={classes.inputs}>
@@ -238,7 +231,7 @@ export function InputVariables(props: Props) {
                 } with no data for selected stratification variable(s)`}
                 state={showMissingness}
                 onStateChange={onShowMissingnessChange}
-                disabled={!stratificationIsActive}
+                disabled={!enableShowMissingnessToggle}
               />
             </div>
           )}

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -19,7 +19,7 @@ import { makeEntityDisplayName } from '../../utils/study-metadata';
 interface InputSpec {
   name: string;
   label: string;
-  role?: 'primary' | 'stratification'; // TO DO: make mandatory when all viz are updated??
+  role: 'primary' | 'stratification';
 }
 
 export interface Props {

--- a/src/lib/core/components/visualizations/colors.ts
+++ b/src/lib/core/components/visualizations/colors.ts
@@ -1,0 +1,1 @@
+export const gray = '#aaaaaa';

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -150,31 +150,21 @@ function BarplotViz(props: Props) {
     [updateVizConfig]
   );
 
-  const onDependentAxisLogScaleChange = useCallback(
-    (newState?: boolean) => {
+  // prettier-ignore
+  const onChangeHandlerFactory = useCallback(
+    < ValueType,>(key: keyof BarplotConfig) => (newValue?: ValueType) => {
       updateVizConfig({
-        dependentAxisLogScale: newState,
+        [key]: newValue,
       });
     },
     [updateVizConfig]
   );
-
-  const onValueSpecChange = useCallback(
-    (newValueSpec: ValueSpec) => {
-      updateVizConfig({
-        valueSpec: newValueSpec,
-      });
-    },
-    [updateVizConfig]
+  const onDependentAxisLogScaleChange = onChangeHandlerFactory<boolean>(
+    'dependentAxisLogScale'
   );
-
-  const onShowMissingnessChange = useCallback(
-    (newState?: boolean) => {
-      updateVizConfig({
-        showMissingness: newState,
-      });
-    },
-    [updateVizConfig]
+  const onValueSpecChange = onChangeHandlerFactory<ValueSpec>('valueSpec');
+  const onShowMissingnessChange = onChangeHandlerFactory<boolean>(
+    'showMissingness'
   );
 
   const findEntityAndVariable = useFindEntityAndVariable(entities);

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -232,7 +232,7 @@ function BarplotViz(props: Props) {
               },
               {
                 name: 'overlayVariable',
-                label: 'Overlay (optional)',
+                label: 'Overlay',
                 role: 'stratification',
               },
             ]}

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -212,7 +212,7 @@ function BarplotViz(props: Props) {
             vizConfig.showMissingness
           )
         ),
-        vizConfig.showMissingness
+        vizConfig.showMissingness && overlayVariable != null
       );
     }, [
       studyId,

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -246,6 +246,7 @@ function BarplotViz(props: Props) {
             constraints={dataElementConstraints}
             dataElementDependencyOrder={dataElementDependencyOrder}
             starredVariables={starredVariables}
+            enableShowMissingnessToggle={overlayVariable != null}
             toggleStarredVariable={toggleStarredVariable}
             onShowMissingnessChange={onShowMissingnessChange}
             showMissingness={vizConfig.showMissingness}

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -434,7 +434,9 @@ export function barplotResponseToData(
       value: data.value,
     })),
     completeCases: response.completeCasesTable,
-    outputSize: response.barplot.config.completeCases,
+    outputSize:
+      response.barplot.config.completeCases +
+      response.barplot.config.plottedIncompleteCases,
   };
 }
 

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -448,7 +448,9 @@ export function boxplotResponseToData(
       label: data.label, // [response.boxplot.config.xVariableDetails.variableId],
     })),
     completeCases: response.completeCasesTable,
-    outputSize: response.boxplot.config.completeCases,
+    outputSize:
+      response.boxplot.config.completeCases +
+      response.boxplot.config.plottedIncompleteCases,
   };
 }
 

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -274,6 +274,7 @@ function BoxplotViz(props: Props) {
             dataElementDependencyOrder={dataElementDependencyOrder}
             starredVariables={starredVariables}
             toggleStarredVariable={toggleStarredVariable}
+            enableShowMissingnessToggle={overlayVariable != null}
             showMissingness={vizConfig.showMissingness}
             onShowMissingnessChange={onShowMissingnessChange}
             outputEntity={outputEntity}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -395,26 +395,27 @@ export function boxplotResponseToData(
   response: PromiseType<ReturnType<DataClient['getBoxplot']>>
 ): PromiseBoxplotData {
   return {
-    series: response.boxplot.data.map(
-      (data: { [key: string]: any }, index) => ({
-        lowerfence: data.lowerfence,
-        upperfence: data.upperfence,
-        q1: data.q1,
-        q3: data.q3,
-        median: data.median,
-        mean: data.mean ? data.mean : undefined,
-        outliers: data.outliers ? data.outliers : undefined,
-        // currently returns seriesX and seriesY for points: 'all' option
-        // it is necessary to rely on rawData (or seriesX/Y) for boxplot if points: 'all'
-        rawData: data.rawData ? data.rawData : undefined,
-        // this will be used as legend
-        name: data.overlayVariableDetails
-          ? data.overlayVariableDetails.value
-          : 'Data',
-        // this will be used as x-axis tick labels
-        label: data.label, // [response.boxplot.config.xVariableDetails.variableId],
-      })
-    ),
+    series: response.boxplot.data.map((data) => ({
+      lowerfence: data.lowerfence,
+      upperfence: data.upperfence,
+      q1: data.q1,
+      q3: data.q3,
+      median: data.median,
+      mean: data.mean,
+      // correct the {} from back end into []
+      outliers: data.outliers
+        ? data.outliers.map((x: number[] | {}) => (Array.isArray(x) ? x : []))
+        : undefined,
+      // currently returns seriesX and seriesY for points: 'all' option
+      // it is necessary to rely on rawData (or seriesX/Y) for boxplot if points: 'all'
+      rawData: data.rawData ? data.rawData : undefined,
+      // this will be used as legend
+      name: data.overlayVariableDetails
+        ? data.overlayVariableDetails.value
+        : 'Data',
+      // this will be used as x-axis tick labels
+      label: data.label, // [response.boxplot.config.xVariableDetails.variableId],
+    })),
     completeCases: response.completeCasesTable,
     outputSize: response.boxplot.config.completeCases,
   };

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -259,7 +259,7 @@ function BoxplotViz(props: Props) {
               },
               {
                 name: 'overlayVariable',
-                label: 'Overlay (Optional)',
+                label: 'Overlay',
                 role: 'stratification',
               },
             ]}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -39,8 +39,10 @@ import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
 import histogram from './selectorIcons/histogram.svg';
 // import axis label unit util
 import { axisLabelWithUnit } from '../../../utils/axis-label-unit';
-import { vocabularyWithMissingData } from '../../../utils/analysis';
-import { gray } from '../colors';
+import {
+  vocabularyWithMissingData,
+  grayOutLastSeries,
+} from '../../../utils/analysis';
 
 type HistogramDataWithCoverageStatistics = HistogramData & CoverageStatistics;
 
@@ -620,16 +622,16 @@ function reorderData(
   }
 }
 
-function grayOutLastSeries(
-  data: HistogramDataWithCoverageStatistics,
-  showMissingness: boolean = false
-) {
-  return {
-    ...data,
-    series: data.series.map((series, index) =>
-      showMissingness && index === data.series.length - 1
-        ? { ...series, color: gray }
-        : series
-    ),
-  };
-}
+//function grayOutLastSeries(
+//  data: HistogramDataWithCoverageStatistics,
+//  showMissingness: boolean = false
+//) {
+//  return {
+//    ...data,
+//    series: data.series.map((series, index) =>
+//      showMissingness && index === data.series.length - 1
+//        ? { ...series, color: gray }
+//        : series
+//    ),
+//  };
+//}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -180,31 +180,20 @@ function HistogramViz(props: Props) {
     [updateVizConfig]
   );
 
-  const onDependentAxisLogScaleChange = useCallback(
-    (newState?: boolean) => {
+  const onChangeHandlerFactory = useCallback(
+    <ValueType,>(key: keyof HistogramConfig) => (newValue?: ValueType) => {
       updateVizConfig({
-        dependentAxisLogScale: newState,
+        [key]: newValue,
       });
     },
     [updateVizConfig]
   );
-
-  const onValueSpecChange = useCallback(
-    (newValueSpec: ValueSpec) => {
-      updateVizConfig({
-        valueSpec: newValueSpec,
-      });
-    },
-    [updateVizConfig]
+  const onDependentAxisLogScaleChange = onChangeHandlerFactory<boolean>(
+    'dependentAxisLogScale'
   );
-
-  const onShowMissingnessChange = useCallback(
-    (newState?: boolean) => {
-      updateVizConfig({
-        showMissingness: newState,
-      });
-    },
-    [updateVizConfig]
+  const onValueSpecChange = onChangeHandlerFactory<ValueSpec>('valueSpec');
+  const onShowMissingnessChange = onChangeHandlerFactory<boolean>(
+    'showMissingness'
   );
 
   const { xAxisVariable, outputEntity, valueType } = useMemo(() => {

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -250,7 +250,7 @@ function HistogramViz(props: Props) {
             vizConfig.showMissingness
           )
         ),
-        vizConfig.showMissingness
+        vizConfig.showMissingness && overlayVariable != null
       );
     }, [
       vizConfig.xAxisVariable,
@@ -621,17 +621,3 @@ function reorderData(
     return data;
   }
 }
-
-//function grayOutLastSeries(
-//  data: HistogramDataWithCoverageStatistics,
-//  showMissingness: boolean = false
-//) {
-//  return {
-//    ...data,
-//    series: data.series.map((series, index) =>
-//      showMissingness && index === data.series.length - 1
-//        ? { ...series, color: gray }
-//        : series
-//    ),
-//  };
-//}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -239,7 +239,6 @@ function HistogramViz(props: Props) {
         vizConfig
       );
       const response = dataClient.getHistogram(computation.type, params);
-      console.log(overlayVariable?.vocabulary);
       return reorderData(
         histogramResponseToData(await response, xAxisVariable.type),
         vocabularyWithMissingData(
@@ -593,7 +592,6 @@ function reorderData(
   data: HistogramDataWithCoverageStatistics,
   overlayVocabulary: string[] = []
 ) {
-  console.log(overlayVocabulary);
   if (overlayVocabulary.length > 0) {
     // for each value in the overlay vocabulary's correct order
     // find the index in the series where series.name equals that value

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -540,7 +540,9 @@ export function histogramResponseToData(
     binWidthRange,
     binWidthStep,
     completeCases: response.completeCasesTable,
-    outputSize: response.histogram.config.completeCases,
+    outputSize:
+      response.histogram.config.completeCases +
+      response.histogram.config.plottedIncompleteCases,
   };
 }
 

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -40,6 +40,7 @@ import histogram from './selectorIcons/histogram.svg';
 // import axis label unit util
 import { axisLabelWithUnit } from '../../../utils/axis-label-unit';
 import { vocabularyWithMissingData } from '../../../utils/analysis';
+import { gray } from '../colors';
 
 type HistogramDataWithCoverageStatistics = HistogramData & CoverageStatistics;
 
@@ -239,12 +240,15 @@ function HistogramViz(props: Props) {
         vizConfig
       );
       const response = dataClient.getHistogram(computation.type, params);
-      return reorderData(
-        histogramResponseToData(await response, xAxisVariable.type),
-        vocabularyWithMissingData(
-          overlayVariable?.vocabulary,
-          vizConfig.showMissingness
-        )
+      return grayOutLastSeries(
+        reorderData(
+          histogramResponseToData(await response, xAxisVariable.type),
+          vocabularyWithMissingData(
+            overlayVariable?.vocabulary,
+            vizConfig.showMissingness
+          )
+        ),
+        vizConfig.showMissingness
       );
     }, [
       vizConfig.xAxisVariable,
@@ -614,4 +618,18 @@ function reorderData(
   } else {
     return data;
   }
+}
+
+function grayOutLastSeries(
+  data: HistogramDataWithCoverageStatistics,
+  showMissingness: boolean = false
+) {
+  return {
+    ...data,
+    series: data.series.map((series, index) =>
+      showMissingness && index === data.series.length - 1
+        ? { ...series, color: gray }
+        : series
+    ),
+  };
 }

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -286,6 +286,7 @@ function HistogramViz(props: Props) {
             dataElementDependencyOrder={dataElementDependencyOrder}
             starredVariables={starredVariables}
             toggleStarredVariable={toggleStarredVariable}
+            enableShowMissingnessToggle={overlayVariable != null}
             showMissingness={vizConfig.showMissingness}
             onShowMissingnessChange={onShowMissingnessChange}
             outputEntity={outputEntity}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -272,7 +272,7 @@ function HistogramViz(props: Props) {
               },
               {
                 name: 'overlayVariable',
-                label: 'Overlay (optional)',
+                label: 'Overlay',
                 role: 'stratification',
               },
             ]}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -180,8 +180,8 @@ function HistogramViz(props: Props) {
     [updateVizConfig]
   );
 
+  // prettier-ignore
   const onChangeHandlerFactory = useCallback(
-    // prettier-ignore
     < ValueType,>(key: keyof HistogramConfig) => (newValue?: ValueType) => {
       updateVizConfig({
         [key]: newValue,

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -181,7 +181,8 @@ function HistogramViz(props: Props) {
   );
 
   const onChangeHandlerFactory = useCallback(
-    <ValueType,>(key: keyof HistogramConfig) => (newValue?: ValueType) => {
+    // prettier-ignore
+    < ValueType,>(key: keyof HistogramConfig) => (newValue?: ValueType) => {
       updateVizConfig({
         [key]: newValue,
       });

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -288,11 +288,7 @@ function HistogramViz(props: Props) {
             starredVariables={starredVariables}
             toggleStarredVariable={toggleStarredVariable}
             showMissingness={vizConfig.showMissingness}
-            onShowMissingnessChange={
-              overlayVariable /* || facetVariable */
-                ? onShowMissingnessChange
-                : undefined
-            }
+            onShowMissingnessChange={onShowMissingnessChange}
             outputEntity={outputEntity}
           />
         </div>

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -486,7 +486,9 @@ export function contTableResponseToData(
     degreesFreedom: response.statsTable[0].degreesFreedom,
     chisq: response.statsTable[0].chisq,
     completeCases: response.completeCasesTable,
-    outputSize: response.mosaic.config.completeCases,
+    outputSize:
+      response.mosaic.config.completeCases +
+      response.mosaic.config.plottedIncompleteCases,
   };
 }
 

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -389,14 +389,17 @@ function MosaicViz(props: Props) {
               {
                 name: 'xAxisVariable',
                 label: 'X-axis',
+                role: 'primary',
               },
               {
                 name: 'yAxisVariable',
                 label: 'Y-axis',
+                role: 'primary',
               },
               {
                 name: 'facetVariable',
                 label: 'Facet (optional)',
+                role: 'stratification',
               },
             ]}
             entities={entities}

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -398,7 +398,7 @@ function MosaicViz(props: Props) {
               },
               {
                 name: 'facetVariable',
-                label: 'Facet (optional)',
+                label: 'Facet (placeholder)',
                 role: 'stratification',
               },
             ]}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -313,7 +313,7 @@ function ScatterplotViz(props: Props) {
               },
               {
                 name: 'overlayVariable',
-                label: 'Overlay (optional)',
+                label: 'Overlay',
                 role: 'stratification',
               },
             ]}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -204,23 +204,18 @@ function ScatterplotViz(props: Props) {
     [updateVizConfig, findEntityAndVariable, vizConfig.valueSpecConfig]
   );
 
-  // XYPlotControls: add valueSpec option
-  const onValueSpecChange = useCallback(
-    (value: string) => {
+  // prettier-ignore
+  const onChangeHandlerFactory = useCallback(
+    < ValueType,>(key: keyof ScatterplotConfig) => (newValue?: ValueType) => {
       updateVizConfig({
-        valueSpecConfig: value,
+        [key]: newValue,
       });
     },
     [updateVizConfig]
   );
-
-  const onShowMissingnessChange = useCallback(
-    (newState?: boolean) => {
-      updateVizConfig({
-        showMissingness: newState,
-      });
-    },
-    [updateVizConfig]
+  const onValueSpecChange = onChangeHandlerFactory<string>('valueSpecConfig');
+  const onShowMissingnessChange = onChangeHandlerFactory<boolean>(
+    'showMissingness'
   );
 
   // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -680,6 +680,10 @@ function processInputData<T extends number | string>(
       return ColorPaletteDefault[index] ?? 'black'; // TO DO: decide on overflow behaviour
     }
   };
+  const markerSymbol = (index: number) =>
+    showMissingness && index === plotDataSet.data.length - 1
+      ? 'x'
+      : 'circle-open';
 
   // set dataSetProcess as any for now
   let dataSetProcess: any = [];
@@ -752,6 +756,7 @@ function processInputData<T extends number | string>(
         opacity: 0.7,
         marker: {
           color: markerColor(index),
+          symbol: markerSymbol(index),
         },
         // this needs to be here for the case of markers with line or lineplot.
         // always use spline?

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -328,6 +328,7 @@ function ScatterplotViz(props: Props) {
             dataElementDependencyOrder={dataElementDependencyOrder}
             starredVariables={starredVariables}
             toggleStarredVariable={toggleStarredVariable}
+            enableShowMissingnessToggle={overlayVariable != null}
             showMissingness={vizConfig.showMissingness}
             onShowMissingnessChange={onShowMissingnessChange}
             outputEntity={outputEntity}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -51,6 +51,7 @@ import { axisLabelWithUnit } from '../../../utils/axis-label-unit';
 import { StudyEntity } from '../../../types/study';
 import { vocabularyWithMissingData } from '../../../utils/analysis';
 import { gray } from '../colors';
+import { ColorPaletteDefault } from '@veupathdb/components/lib/types/plots/addOns';
 
 // define PromiseXYPlotData
 interface PromiseXYPlotData extends CoverageStatistics {
@@ -671,26 +672,12 @@ function processInputData<T extends number | string>(
   let yMin: number | string | undefined;
   let yMax: number | string | undefined;
 
-  // coloring: using plotly.js default colors
-  const markerColors = [
-    '31, 119, 180', //'#1f77b4',  // muted blue
-    '255, 127, 14', //'#ff7f0e',  // safety orange
-    '44, 160, 44', //'#2ca02c',  // cooked asparagus green
-    '214, 39, 40', //'#d62728',  // brick red
-    '148, 103, 189', //'#9467bd',  // muted purple
-    '140, 86, 75', //'#8c564b',  // chestnut brown
-    '227, 119, 194', //'#e377c2',  // raspberry yogurt pink
-    '127, 127, 127', //'#7f7f7f',  // middle gray
-    '188, 189, 34', //'#bcbd22',  // curry yellow-green
-    '23, 190, 207', //'#17becf'   // blue-teal
-  ];
-
   // function to return color or gray where needed if showMissingness == true
   const markerColor = (index: number) => {
     if (showMissingness && index === plotDataSet.data.length - 1) {
       return gray;
     } else {
-      return `rgb(${markerColors[index]})`;
+      return ColorPaletteDefault[index] ?? 'black'; // TO DO: decide on overflow behaviour
     }
   };
 

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -573,7 +573,10 @@ export function scatterplotResponseToData(
     yMin: yMin,
     yMax: yMax,
     completeCases: response.completeCasesTable,
-    outputSize: response.scatterplot.config.completeCases, // TO DO: won't work with densityplot response, when that's implemented
+    outputSize:
+      response.scatterplot.config.completeCases +
+      response.scatterplot.config.plottedIncompleteCases,
+    // TO DO: won't work with densityplot response, when that's implemented
   };
 }
 

--- a/src/lib/core/hooks/findOutputEntity.ts
+++ b/src/lib/core/hooks/findOutputEntity.ts
@@ -6,7 +6,10 @@ import { useFindEntityAndVariable } from './study';
 export function useFindOutputEntity(
   dataElementDependencyOrder: string[] | undefined,
   // need to add string at Record's Type due to valueSpecConfig
-  dataElementVariables: Record<string, VariableDescriptor | string | undefined>,
+  dataElementVariables: Record<
+    string,
+    VariableDescriptor | string | boolean | undefined
+  >,
   defaultVariableName: string,
   entities: StudyEntity[]
 ) {

--- a/src/lib/core/utils/analysis.ts
+++ b/src/lib/core/utils/analysis.ts
@@ -1,6 +1,7 @@
 import {
   HistogramData,
   BarplotData,
+  BoxplotData,
 } from '@veupathdb/components/lib/types/plots';
 import { gray } from '../components/visualizations/colors';
 
@@ -13,10 +14,9 @@ export function vocabularyWithMissingData(
     : vocabulary;
 }
 
-export function grayOutLastSeries<T extends BarplotData | HistogramData>(
-  data: T,
-  showMissingness: boolean = false
-) {
+export function grayOutLastSeries<
+  T extends BarplotData | HistogramData | { series: BoxplotData }
+>(data: T, showMissingness: boolean = false) {
   return {
     ...data,
     series: data.series.map((series, index) =>

--- a/src/lib/core/utils/analysis.ts
+++ b/src/lib/core/utils/analysis.ts
@@ -1,0 +1,8 @@
+export function vocabularyWithMissingData(
+  vocabulary: string[] = [],
+  includeMissingData: boolean = false
+): string[] {
+  return includeMissingData && vocabulary.length
+    ? [...vocabulary, 'No data']
+    : vocabulary;
+}

--- a/src/lib/core/utils/analysis.ts
+++ b/src/lib/core/utils/analysis.ts
@@ -1,3 +1,9 @@
+import {
+  HistogramData,
+  BarplotData,
+} from '@veupathdb/components/lib/types/plots';
+import { gray } from '../components/visualizations/colors';
+
 export function vocabularyWithMissingData(
   vocabulary: string[] = [],
   includeMissingData: boolean = false
@@ -5,4 +11,18 @@ export function vocabularyWithMissingData(
   return includeMissingData && vocabulary.length
     ? [...vocabulary, 'No data']
     : vocabulary;
+}
+
+export function grayOutLastSeries<T extends BarplotData | HistogramData>(
+  data: T,
+  showMissingness: boolean = false
+) {
+  return {
+    ...data,
+    series: data.series.map((series, index) =>
+      showMissingness && index === data.series.length - 1
+        ? { ...series, color: gray }
+        : series
+    ),
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,10 +2889,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.4.4.tgz#d4b2a3ceec758e7c5df653332bca2f7c73883e35"
-  integrity sha512-UwHJhCmExiT8HD5+FwvGNOnAN5wkQORVs/T/bdZIFGCR15QWZQIUMl2l1kQVEl5UItnl2fAwF0Aq1Y8pLnSd2Q==
+"@veupathdb/components@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.6.0.tgz#2e8076e91f05176a908b440be4b6b4e3e23a67bb"
+  integrity sha512-b37yxFmhqgIMNUCHgG/YnHmjqSOiXaIbrPtDLA7pHCtFiRqvhe4otmzC7+drE7rVxsUuvJ0ontl7lMf85760qA==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Fixes #294 
Requires https://github.com/VEuPathDB/web-components/pull/189 (especially if greyed out switch is required)

Here's a new approach.

I added a new `InputSpec` prop: `role : 'primary' | 'stratification'`

Now `InputVariables` renders the dropdown inputs as usual, but adds an extra CSS class to any stratification input (in future it will be overlay and faceting).  Then it renders a toggle switch with the same class/styling (currently a lovely pink border).

At the moment the toggle is only shown when an overlay variable is selected.  But this could be easily changed to grey out/disable the toggle (like I had in the previous attempt).

I'm assuming that some CSS magic can visually group/lay out the 'stratification' input components appropriately.

![image](https://user-images.githubusercontent.com/308639/129449547-a3c4ec3e-7412-4250-ac6d-333208c0a912.png)
(from GEMS1)