### PR TITLE
Allow user to browse variables without creating an anlysis resource.

### DIFF
--- a/src/lib/core/__test__/hooks/useAnalysis.test.tsx
+++ b/src/lib/core/__test__/hooks/useAnalysis.test.tsx
@@ -129,7 +129,6 @@ describe('useAnalysis', () => {
   it('should update store on copy', async () => {
     const { result, waitFor } = render();
     await waitFor(() => result.current.status === Status.Loaded);
-    if (result.current.copyAnalysis == null) return;
     const res = await result.current.copyAnalysis();
     const analyses = await analysisClient.getAnalyses();
     const newAnalysis = analyses.find((analysis) => analysis.id === res.id);
@@ -142,7 +141,6 @@ describe('useAnalysis', () => {
   it('should update store on delete', async () => {
     const { result, waitFor } = render();
     await waitFor(() => result.current.status === Status.Loaded);
-    if (result.current.deleteAnalysis == null) return;
     await result.current.deleteAnalysis();
     const analyses = await analysisClient.getAnalyses();
     const analysis = analyses.find((analysis) => analysis.id === key);

--- a/src/lib/core/__test__/hooks/useAnalysis.test.tsx
+++ b/src/lib/core/__test__/hooks/useAnalysis.test.tsx
@@ -129,6 +129,7 @@ describe('useAnalysis', () => {
   it('should update store on copy', async () => {
     const { result, waitFor } = render();
     await waitFor(() => result.current.status === Status.Loaded);
+    if (result.current.copyAnalysis == null) return;
     const res = await result.current.copyAnalysis();
     const analyses = await analysisClient.getAnalyses();
     const newAnalysis = analyses.find((analysis) => analysis.id === res.id);
@@ -141,6 +142,7 @@ describe('useAnalysis', () => {
   it('should update store on delete', async () => {
     const { result, waitFor } = render();
     await waitFor(() => result.current.status === Status.Loaded);
+    if (result.current.deleteAnalysis == null) return;
     await result.current.deleteAnalysis();
     const analyses = await analysisClient.getAnalyses();
     const analysis = analyses.find((analysis) => analysis.id === key);

--- a/src/lib/core/components/EDAWorkspaceContainer.tsx
+++ b/src/lib/core/components/EDAWorkspaceContainer.tsx
@@ -15,7 +15,7 @@ import { workspaceTheme } from './workspaceTheme';
 const theme = createMuiTheme(workspaceTheme);
 export interface Props {
   studyId: string;
-  analysisId: string;
+  analysisId?: string;
   children: React.ReactChild | React.ReactChild[];
   className?: string;
   analysisClient: AnalysisClient;

--- a/src/lib/core/components/EDAWorkspaceContainer.tsx
+++ b/src/lib/core/components/EDAWorkspaceContainer.tsx
@@ -15,7 +15,6 @@ import { workspaceTheme } from './workspaceTheme';
 const theme = createMuiTheme(workspaceTheme);
 export interface Props {
   studyId: string;
-  analysisId?: string;
   children: React.ReactChild | React.ReactChild[];
   className?: string;
   analysisClient: AnalysisClient;

--- a/src/lib/core/hooks/analysis.ts
+++ b/src/lib/core/hooks/analysis.ts
@@ -32,8 +32,8 @@ export type AnalysisState = {
   setStarredVariables: Setter<'starredVariables'>;
   setVariableUISettings: Setter<'variableUISettings'>;
   saveAnalysis: () => Promise<void>;
-  copyAnalysis?: () => Promise<{ id: string }>;
-  deleteAnalysis?: () => Promise<void>;
+  copyAnalysis: () => Promise<{ id: string }>;
+  deleteAnalysis: () => Promise<void>;
 };
 
 export function useAnalysis(analysisId: string): AnalysisState {

--- a/src/lib/core/hooks/analysis.ts
+++ b/src/lib/core/hooks/analysis.ts
@@ -1,7 +1,7 @@
 import { useStateWithHistory } from '@veupathdb/wdk-client/lib/Hooks/StateWithHistory';
 import { useCallback, useEffect, useState } from 'react';
 import { useAnalysisClient } from './workspace';
-import { Analysis } from '../types/analysis';
+import { Analysis, NewAnalysis } from '../types/analysis';
 import { usePromise } from './promise';
 
 type Setter<T extends keyof Analysis> = (value: Analysis[T]) => void;
@@ -16,7 +16,7 @@ export enum Status {
 export type AnalysisState = {
   status: Status;
   hasUnsavedChanges: boolean;
-  analysis?: Analysis;
+  analysis?: Analysis | NewAnalysis;
   error?: unknown;
   canUndo: boolean;
   canRedo: boolean;
@@ -28,9 +28,9 @@ export type AnalysisState = {
   setDerivedVariables: Setter<'derivedVariables'>;
   setStarredVariables: Setter<'starredVariables'>;
   setVariableUISettings: Setter<'variableUISettings'>;
-  copyAnalysis: () => Promise<{ id: string }>;
-  deleteAnalysis: () => Promise<void>;
   saveAnalysis: () => Promise<void>;
+  copyAnalysis?: () => Promise<{ id: string }>;
+  deleteAnalysis?: () => Promise<void>;
 };
 
 export function useAnalysis(analysisId: string): AnalysisState {

--- a/src/lib/core/types/analysis.ts
+++ b/src/lib/core/types/analysis.ts
@@ -30,3 +30,16 @@ export const Analysis = t.intersection([
     modified: t.string,
   }),
 ]);
+
+export function makeNewAnalysis(studyId: string): NewAnalysis {
+  return {
+    name: 'Unnamed Analysis',
+    studyId,
+    filters: [],
+    starredVariables: [],
+    derivedVariables: [],
+    visualizations: [],
+    computations: [],
+    variableUISettings: {},
+  };
+}

--- a/src/lib/mapveu/MapVeuAnalysis.tsx
+++ b/src/lib/mapveu/MapVeuAnalysis.tsx
@@ -33,8 +33,8 @@ export function MapVeuAnalysis(props: Props) {
         {' '}
         <dt>Name</dt>
         <dd>{analysis?.name}</dd>
-        <dt>Created</dt>
-        <dd>{analysis.created}</dd>
+        {/* <dt>Created</dt>
+        <dd>{analysis.created}</dd> */}
       </dl>
     </>
   );

--- a/src/lib/mapveu/MapVeuContainer.tsx
+++ b/src/lib/mapveu/MapVeuContainer.tsx
@@ -39,7 +39,6 @@ export function MapVeuContainer() {
           ) => (
             <EDAWorkspaceContainer
               studyId={props.match.params.studyId}
-              analysisId={props.match.params.analysisId}
               subsettingClient={edaClient}
               analysisClient={mockAnalysisStore}
               dataClient={dataClient}

--- a/src/lib/workspace/AnalysisList.tsx
+++ b/src/lib/workspace/AnalysisList.tsx
@@ -22,30 +22,10 @@ export function AnalysisList(props: Props) {
   const studyId = studyRecord.id.map((part) => part.value).join('/');
   const history = useHistory();
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
-  const { analyses, deleteAnalyses } = useAnalysisList(
-    analysisStore
-  );
-  const analysisList = analyses ? analyses.filter((analysis) => analysis.studyId === studyId) : undefined;
-  const createNewAnalysis = React.useCallback(async () => {
-    const { id } = await analysisStore.createAnalysis({
-      name: 'Unnamed Analysis',
-      studyId,
-      filters: [],
-      starredVariables: [],
-      derivedVariables: [],
-      visualizations: [],
-      computations: [],
-      variableUISettings: {},
-    });
-    const newLocation = {
-      ...history.location,
-      pathname:
-        history.location.pathname +
-        (history.location.pathname.endsWith('/') ? '' : '/') +
-        id,
-    };
-    history.push(newLocation);
-  }, [analysisStore, history, studyId]);
+  const { analyses, deleteAnalyses } = useAnalysisList(analysisStore);
+  const analysisList = analyses
+    ? analyses.filter((analysis) => analysis.studyId === studyId)
+    : undefined;
   const loadAnalysis = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const file = event.currentTarget.files && event.currentTarget.files[0];
@@ -133,14 +113,6 @@ export function AnalysisList(props: Props) {
         {
           selectionRequired: false,
           element: (
-            <button type="button" className="btn" onClick={createNewAnalysis}>
-              Start a new analysis
-            </button>
-          ),
-        },
-        {
-          selectionRequired: false,
-          element: (
             <>
               <input
                 hidden
@@ -187,7 +159,6 @@ export function AnalysisList(props: Props) {
       ],
     }),
     [
-      createNewAnalysis,
       loadAnalysis,
       analysisList,
       selected,

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -4,6 +4,7 @@ import { AnalysisSummary } from './AnalysisSummary';
 import {
   AnalysisState,
   EntityDiagram,
+  Status,
   useStudyMetadata,
   useStudyRecord,
 } from '../core';
@@ -33,6 +34,7 @@ export function AnalysisPanel(props: Props) {
   const { analysisState } = props;
   const studyRecord = useStudyRecord();
   const {
+    status,
     analysis,
     setName,
     copyAnalysis,
@@ -59,6 +61,14 @@ export function AnalysisPanel(props: Props) {
       setLastVizPath(relativePath.replace('/visualizations', ''));
     }
   }, [location, routeBase]);
+
+  if (status === Status.Error)
+    return (
+      <div>
+        <h2>Error</h2>
+        <p>Could not load the analysis.</p>
+      </div>
+    );
   if (analysis == null) return <Loading />;
   return (
     <div className={cx('-Analysis')}>

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -28,10 +28,11 @@ import { Loading } from '@veupathdb/wdk-client/lib/Components';
 
 interface Props {
   analysisState: AnalysisState;
+  hideCopyAndSave?: boolean;
 }
 
 export function AnalysisPanel(props: Props) {
-  const { analysisState } = props;
+  const { analysisState, hideCopyAndSave = false } = props;
   const studyRecord = useStudyRecord();
   const {
     status,
@@ -75,9 +76,9 @@ export function AnalysisPanel(props: Props) {
       <AnalysisSummary
         analysis={analysis}
         setAnalysisName={setName}
-        copyAnalysis={copyAnalysis}
+        copyAnalysis={hideCopyAndSave ? undefined : copyAnalysis}
         saveAnalysis={saveAnalysis}
-        deleteAnalysis={deleteAnalysis}
+        deleteAnalysis={hideCopyAndSave ? undefined : deleteAnalysis}
         onFilterIconClick={() =>
           setGlobalFiltersDialogOpen(!globalFiltersDialogOpen)
         }

--- a/src/lib/workspace/AnalysisSummary.tsx
+++ b/src/lib/workspace/AnalysisSummary.tsx
@@ -2,17 +2,17 @@ import { SaveableTextEditor } from '@veupathdb/wdk-client/lib/Components';
 import React from 'react';
 import { useHistory, useRouteMatch } from 'react-router';
 import Path from 'path';
-import { Analysis } from '../core';
+import { Analysis, NewAnalysis } from '../core';
 import { ActionIconButton } from './ActionIconButton';
 import { Button, Icon } from '@material-ui/core';
 import { cx } from './Utils';
 
 interface Props {
-  analysis: Analysis;
+  analysis: Analysis | NewAnalysis;
   setAnalysisName: (name: string) => void;
-  copyAnalysis: () => Promise<{ id: string }>;
+  copyAnalysis?: () => Promise<{ id: string }>;
   saveAnalysis: () => Promise<void>;
-  deleteAnalysis: () => Promise<void>;
+  deleteAnalysis?: () => Promise<void>;
   onFilterIconClick: () => void;
   globalFiltersDialogOpen: boolean;
 }
@@ -28,14 +28,18 @@ export function AnalysisSummary(props: Props) {
   } = props;
   const history = useHistory();
   const { url } = useRouteMatch();
-  const handleCopy = async () => {
-    const res = await copyAnalysis();
-    history.replace(Path.resolve(url, `../${res.id}`));
-  };
-  const handleDelete = async () => {
-    await deleteAnalysis();
-    history.replace(Path.resolve(url, '..'));
-  };
+  const handleCopy =
+    copyAnalysis &&
+    (async () => {
+      const res = await copyAnalysis();
+      history.replace(Path.resolve(url, `../${res.id}`));
+    });
+  const handleDelete =
+    deleteAnalysis &&
+    (async () => {
+      await deleteAnalysis();
+      history.replace(Path.resolve(url, '..'));
+    });
   return (
     <div className={cx('-AnalysisSummary')}>
       <div className={cx('-AnalysisSummaryLeft')}>
@@ -55,16 +59,20 @@ export function AnalysisSummary(props: Props) {
         )}
       </div>
       <div className={cx('-AnalysisSummaryRight')}>
-        <ActionIconButton
-          iconClassName="clone"
-          hoverText="Copy analysis"
-          action={handleCopy}
-        />
-        <ActionIconButton
-          iconClassName="trash"
-          hoverText="Delete analysis"
-          action={handleDelete}
-        />
+        {handleCopy && (
+          <ActionIconButton
+            iconClassName="clone"
+            hoverText="Copy analysis"
+            action={handleCopy}
+          />
+        )}
+        {handleDelete && (
+          <ActionIconButton
+            iconClassName="trash"
+            hoverText="Delete analysis"
+            action={handleDelete}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/lib/workspace/NewAnalysis.tsx
+++ b/src/lib/workspace/NewAnalysis.tsx
@@ -8,6 +8,7 @@ import {
   NewAnalysis,
   Status,
   useAnalysisClient,
+  usePreloadAnalysis,
   useStudyRecord,
   VariableUISetting,
 } from '../core';
@@ -20,6 +21,7 @@ export function NewAnalysisPage() {
     makeNewAnalysis(studyRecord.id[0].value)
   );
   const analysisClient = useAnalysisClient();
+  const preloadAnalysis = usePreloadAnalysis();
   const history = useHistory();
   const location = useLocation();
   const { url } = useRouteMatch();
@@ -29,13 +31,14 @@ export function NewAnalysisPage() {
       subPath: string = location.pathname.slice(url.length)
     ) => {
       const { id } = await analysisClient.createAnalysis(newAnalysis);
+      await preloadAnalysis(id);
       const newLocation = {
         ...location,
         pathname: Path.resolve(url, '..', id + subPath),
       };
       history.replace(newLocation);
     },
-    [analysisClient, history, location, url]
+    [analysisClient, history, location, preloadAnalysis, url]
   );
   const saveAnalysis = useCallback(() => {
     return createAnalysis(analysis);

--- a/src/lib/workspace/NewAnalysis.tsx
+++ b/src/lib/workspace/NewAnalysis.tsx
@@ -1,47 +1,108 @@
-import { RestrictedPage } from '@veupathdb/web-common/lib/App/DataRestriction/RestrictedPage';
-import { useApprovalStatus } from '@veupathdb/web-common/lib/hooks/dataRestriction';
-import React, { useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
-import { Task } from '@veupathdb/wdk-client/lib/Utils/Task';
-import { AnalysisClient } from '../core';
+import Path from 'path';
+import React, { useCallback, useMemo, useState } from 'react';
+import { useLocation, useRouteMatch, useHistory } from 'react-router-dom';
+import {
+  AnalysisState,
+  Filter,
+  makeNewAnalysis,
+  NewAnalysis,
+  Status,
+  useAnalysisClient,
+  useStudyRecord,
+  VariableUISetting,
+} from '../core';
+import { AnalysisPanel } from './AnalysisPanel';
+import { Visualization } from '../core/types/visualization';
 
-interface Props {
-  analysisClient: AnalysisClient;
-  studyId: string;
-}
-
-export function NewAnalysis(props: Props) {
-  const { analysisClient: analysisStore, studyId } = props;
-  const approvalStatus = useApprovalStatus(studyId, 'analysis');
+export function NewAnalysisPage() {
+  const studyRecord = useStudyRecord();
+  const [analysis, setAnalysis] = useState(
+    makeNewAnalysis(studyRecord.id[0].value)
+  );
+  const analysisClient = useAnalysisClient();
   const history = useHistory();
-  useEffect(() => {
-    if (approvalStatus !== 'approved') {
-      return;
-    }
-
-    return Task.fromPromise(() =>
-      analysisStore.createAnalysis({
-        name: 'Unnamed Analysis',
-        studyId,
-        filters: [],
-        starredVariables: [],
-        derivedVariables: [],
-        visualizations: [],
-        computations: [],
-        variableUISettings: {},
-      })
-    ).run(({ id }) => {
+  const location = useLocation();
+  const { url } = useRouteMatch();
+  const createAnalysis = useCallback(
+    async (
+      newAnalysis: NewAnalysis,
+      subPath: string = location.pathname.slice(url.length)
+    ) => {
+      const { id } = await analysisClient.createAnalysis(newAnalysis);
       const newLocation = {
-        ...history.location,
-        pathname: `./${id}`,
+        ...location,
+        pathname: Path.resolve(url, '..', id + subPath),
       };
       history.replace(newLocation);
-    });
-  }, [analysisStore, history, studyId, approvalStatus]);
-
-  return (
-    <RestrictedPage approvalStatus={approvalStatus}>
-      <div style={{ fontSize: '3em' }}>Creating new analysis...</div>
-    </RestrictedPage>
+    },
+    [analysisClient, history, location, url]
   );
+  const saveAnalysis = useCallback(() => {
+    return createAnalysis(analysis);
+  }, [analysis, createAnalysis]);
+  const setName = useCallback(
+    (name: string) => {
+      createAnalysis({ ...analysis, name });
+    },
+    [analysis, createAnalysis]
+  );
+  const setFilters = useCallback(
+    (filters: Filter[]) => {
+      createAnalysis({ ...analysis, filters });
+    },
+    [analysis, createAnalysis]
+  );
+  const setStarredVariables = useCallback(
+    (starredVariables: string[]) => {
+      createAnalysis({ ...analysis, starredVariables });
+    },
+    [analysis, createAnalysis]
+  );
+  const setDerivedVariables = useCallback(() => {}, []);
+  const setVisualizations = useCallback(
+    (visualizations: Visualization[]) => {
+      createAnalysis(
+        { ...analysis, visualizations },
+        Path.resolve(
+          location.pathname.slice(url.length),
+          '..',
+          visualizations[0].id
+        )
+      );
+    },
+    [analysis, createAnalysis, location.pathname, url.length]
+  );
+
+  const analysisState = useMemo(
+    (): AnalysisState => ({
+      analysis,
+      setDerivedVariables,
+      setFilters,
+      setName,
+      setStarredVariables,
+      setVariableUISettings: (
+        variableUISettings: Record<string, VariableUISetting>
+      ) => {
+        setAnalysis((analysis) => ({ ...analysis, variableUISettings }));
+      },
+      setVisualizations,
+      saveAnalysis,
+      status: Status.Loaded,
+      hasUnsavedChanges: true,
+      canRedo: false,
+      canUndo: false,
+      undo: () => {},
+      redo: () => {},
+    }),
+    [
+      analysis,
+      saveAnalysis,
+      setDerivedVariables,
+      setFilters,
+      setName,
+      setStarredVariables,
+      setVisualizations,
+    ]
+  );
+  return <AnalysisPanel analysisState={analysisState} />;
 }

--- a/src/lib/workspace/NewAnalysis.tsx
+++ b/src/lib/workspace/NewAnalysis.tsx
@@ -59,6 +59,12 @@ export function NewAnalysisPage() {
     [analysis, createAnalysis]
   );
   const setDerivedVariables = useCallback(() => {}, []);
+  const setVariableUISettings = useCallback(
+    (variableUISettings: Record<string, VariableUISetting>) => {
+      setAnalysis((analysis) => ({ ...analysis, variableUISettings }));
+    },
+    []
+  );
   const setVisualizations = useCallback(
     (visualizations: Visualization[]) => {
       createAnalysis(
@@ -80,11 +86,7 @@ export function NewAnalysisPage() {
       setFilters,
       setName,
       setStarredVariables,
-      setVariableUISettings: (
-        variableUISettings: Record<string, VariableUISetting>
-      ) => {
-        setAnalysis((analysis) => ({ ...analysis, variableUISettings }));
-      },
+      setVariableUISettings,
       setVisualizations,
       saveAnalysis,
       status: Status.Loaded,
@@ -101,6 +103,7 @@ export function NewAnalysisPage() {
       setFilters,
       setName,
       setStarredVariables,
+      setVariableUISettings,
       setVisualizations,
     ]
   );

--- a/src/lib/workspace/NewAnalysis.tsx
+++ b/src/lib/workspace/NewAnalysis.tsx
@@ -40,6 +40,12 @@ export function NewAnalysisPage() {
   const saveAnalysis = useCallback(() => {
     return createAnalysis(analysis);
   }, [analysis, createAnalysis]);
+  const copyAnalysis = useCallback(() => {
+    throw new Error('Cannot copy an unsaved analysis.');
+  }, []);
+  const deleteAnalysis = useCallback(() => {
+    throw new Error('Cannot delete an unsaved analysis.');
+  }, []);
   const setName = useCallback(
     (name: string) => {
       createAnalysis({ ...analysis, name });
@@ -89,6 +95,8 @@ export function NewAnalysisPage() {
       setVariableUISettings,
       setVisualizations,
       saveAnalysis,
+      copyAnalysis,
+      deleteAnalysis,
       status: Status.Loaded,
       hasUnsavedChanges: true,
       canRedo: false,
@@ -98,6 +106,8 @@ export function NewAnalysisPage() {
     }),
     [
       analysis,
+      copyAnalysis,
+      deleteAnalysis,
       saveAnalysis,
       setDerivedVariables,
       setFilters,
@@ -107,5 +117,5 @@ export function NewAnalysisPage() {
       setVisualizations,
     ]
   );
-  return <AnalysisPanel analysisState={analysisState} />;
+  return <AnalysisPanel analysisState={analysisState} hideCopyAndSave />;
 }

--- a/src/lib/workspace/SavedAnalysis.tsx
+++ b/src/lib/workspace/SavedAnalysis.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useAnalysis } from '../core';
+import { AnalysisPanel } from './AnalysisPanel';
+
+interface Props {
+  analysisId: string;
+}
+
+export function SavedAnalysis(props: Props) {
+  const { analysisId } = props;
+  const analysisState = useAnalysis(analysisId);
+  return <AnalysisPanel analysisState={analysisState} />;
+}

--- a/src/lib/workspace/WorkspaceContainer.tsx
+++ b/src/lib/workspace/WorkspaceContainer.tsx
@@ -13,12 +13,14 @@ import {
 import { VariableDescriptor } from '../core/types/variable';
 import { EDAWorkspaceHeading } from './EDAWorkspaceHeading';
 import { mockAnalysisStore } from './Mocks';
-import { AnalysisPanel } from './AnalysisPanel';
 import { cx, findFirstVariable } from './Utils';
+import { SavedAnalysis } from './SavedAnalysis';
+import { NewAnalysisPage } from './NewAnalysis';
+import { AnalysisPanel } from './AnalysisPanel';
 
 interface Props {
   studyId: string;
-  analysisId: string;
+  analysisId?: string;
   subsettingServiceUrl: string;
   dataServiceUrl: string;
 }
@@ -29,8 +31,8 @@ export function WorkspaceContainer(props: Props) {
     [props.subsettingServiceUrl]
   );
   const dataClient = useMemo(
-    () => new DataClient({ baseUrl: props.subsettingServiceUrl }),
-    [props.subsettingServiceUrl]
+    () => new DataClient({ baseUrl: props.dataServiceUrl }),
+    [props.dataServiceUrl]
   );
   const makeVariableLink = useCallback(
     (
@@ -69,7 +71,11 @@ export function WorkspaceContainer(props: Props) {
         makeVariableLink={makeVariableLink}
       >
         <EDAWorkspaceHeading />
-        <AnalysisPanel analysisId={props.analysisId} />
+        {props.analysisId == null ? (
+          <NewAnalysisPage />
+        ) : (
+          <SavedAnalysis analysisId={props.analysisId} />
+        )}
       </EDAWorkspaceContainer>
     </RestrictedPage>
   );

--- a/src/lib/workspace/WorkspaceContainer.tsx
+++ b/src/lib/workspace/WorkspaceContainer.tsx
@@ -16,7 +16,6 @@ import { mockAnalysisStore } from './Mocks';
 import { cx, findFirstVariable } from './Utils';
 import { SavedAnalysis } from './SavedAnalysis';
 import { NewAnalysisPage } from './NewAnalysis';
-import { AnalysisPanel } from './AnalysisPanel';
 
 interface Props {
   studyId: string;
@@ -62,7 +61,6 @@ export function WorkspaceContainer(props: Props) {
   return (
     <RestrictedPage approvalStatus={approvalStatus}>
       <EDAWorkspaceContainer
-        analysisId={props.analysisId}
         studyId={props.studyId}
         className={cx()}
         analysisClient={mockAnalysisStore}

--- a/src/lib/workspace/WorkspaceRouter.tsx
+++ b/src/lib/workspace/WorkspaceRouter.tsx
@@ -5,7 +5,6 @@ import {
   useRouteMatch,
   Redirect,
 } from 'react-router';
-import { NewAnalysis } from './NewAnalysis';
 import { EDAAnalysisList } from './EDAAnalysisList';
 import { StudyList } from './StudyList';
 import { WorkspaceContainer } from './WorkspaceContainer';
@@ -51,11 +50,11 @@ export function WorkspaceRouter({
       />
       <Route
         path={`${path}/:studyId/new`}
-        exact
         render={(props: RouteComponentProps<{ studyId: string }>) => (
-          <NewAnalysis
+          <WorkspaceContainer
             {...props.match.params}
-            analysisClient={mockAnalysisStore}
+            subsettingServiceUrl={subsettingServiceUrl}
+            dataServiceUrl={dataServiceUrl}
           />
         )}
       />


### PR DESCRIPTION
When the user clicks on "New Analysis", we will no longer eagerly create an analysis on the backend. Instead, we will wait until the user makes a change to the analysis to create the resource on the backend. When this happens, the url will be replaced with an analysis id.

If the user changes binning, sorting, or other `variableUISettings`, a new analysis will not be created, but those settings will be carried over if a new analysis is created.

closes #283 