### PR TITLE
Subsetting histogram: selected range bounds enforcement is now handled by the client, fix single-day subsets, tweak button widths

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.6.0",
+    "@veupathdb/components": "^0.7.0",
     "@veupathdb/wdk-client": "^0.2.0",
     "@veupathdb/web-common": "^0.1.5",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -553,7 +553,7 @@ function HistogramPlotWithControls({
             onClick={handleDependentAxisSettingsReset}
             containerStyles={{
               paddingTop: '1.0em',
-              width: '50%',
+              width: '60%',
               float: 'right',
             }}
           />
@@ -588,7 +588,7 @@ function HistogramPlotWithControls({
             onClick={handleIndependentAxisSettingsReset}
             containerStyles={{
               paddingTop: '1.0em',
-              width: '50%',
+              width: '60%',
               float: 'right',
             }}
           />

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -492,18 +492,6 @@ function HistogramPlotWithControls({
     return { min: filter.min, max: filter.max } as NumberOrDateRange;
   }, [filter]);
 
-  const selectedRangeBounds = useMemo((): NumberOrDateRange | undefined => {
-    return data?.series[0]?.summary && data?.valueType
-      ? fullISODateRange(
-          {
-            min: data.series[0].summary.min,
-            max: data.series[0].summary.max,
-          } as NumberOrDateRange,
-          data.valueType
-        )
-      : undefined;
-  }, [data?.series, data?.valueType]);
-
   const widgetHeight = '4em';
 
   return (
@@ -512,7 +500,6 @@ function HistogramPlotWithControls({
         label={`Subset on ${variableName}`}
         valueType={data?.valueType}
         selectedRange={selectedRange}
-        selectedRangeBounds={selectedRangeBounds}
         onSelectedRangeChange={handleSelectedRangeChange}
       />
       <Histogram
@@ -520,7 +507,6 @@ function HistogramPlotWithControls({
         data={data}
         interactive={true}
         selectedRange={selectedRange}
-        selectedRangeBounds={selectedRangeBounds}
         opacity={opacity}
         displayLegend={displayLegend}
         displayLibraryControls={displayLibraryControls}
@@ -529,7 +515,6 @@ function HistogramPlotWithControls({
         dependentAxisLabel={`Count of ${entityName}`}
         // add independentAxisLabel
         independentAxisLabel={variableName}
-        isZoomed={uiState.independentAxisRange ? true : false}
         independentAxisRange={uiState.independentAxisRange}
         dependentAxisRange={uiState.dependentAxisRange}
         dependentAxisLogScale={uiState.dependentAxisLogScale}

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -492,6 +492,20 @@ function HistogramPlotWithControls({
     return { min: filter.min, max: filter.max } as NumberOrDateRange;
   }, [filter]);
 
+  // selectedRangeBounds is used for auto-filling the start (or end)
+  // in the SelectedRangeControl
+  const selectedRangeBounds = useMemo((): NumberOrDateRange | undefined => {
+    return data?.series[0]?.summary && data?.valueType
+      ? fullISODateRange(
+          {
+            min: data.series[0].summary.min,
+            max: data.series[0].summary.max,
+          } as NumberOrDateRange,
+          data.valueType
+        )
+      : undefined;
+  }, [data?.series, data?.valueType]);
+
   const widgetHeight = '4em';
 
   return (
@@ -500,6 +514,7 @@ function HistogramPlotWithControls({
         label={`Subset on ${variableName}`}
         valueType={data?.valueType}
         selectedRange={selectedRange}
+        selectedRangeBounds={selectedRangeBounds}
         onSelectedRangeChange={handleSelectedRangeChange}
       />
       <Histogram

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -508,7 +508,7 @@ function HistogramPlotWithControls({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [data, updateFilter]
+    [updateFilter, selectedRangeBounds]
   );
 
   const widgetHeight = '4em';

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -387,27 +387,6 @@ function HistogramPlotWithControls({
   entityName,
   ...histogramProps
 }: HistogramPlotWithControlsProps) {
-  const handleSelectedRangeChange = useCallback(
-    (range?: NumberOrDateRange) => {
-      if (range) {
-        updateFilter({
-          min:
-            typeof range.min === 'string'
-              ? padISODateTime(range.min)
-              : range.min,
-          max:
-            typeof range.max === 'string'
-              ? padISODateTime(range.max)
-              : range.max,
-        } as NumberOrDateRange);
-      } else {
-        updateFilter(); // clear the filter if range is undefined
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [data, updateFilter]
-  );
-
   const handleBinWidthChange = useCallback(
     (newBinWidth: NumberOrTimeDelta) => {
       updateUIState({
@@ -505,6 +484,32 @@ function HistogramPlotWithControls({
         )
       : undefined;
   }, [data?.series, data?.valueType]);
+
+  const handleSelectedRangeChange = useCallback(
+    (range?: NumberOrDateRange) => {
+      if (range) {
+        updateFilter(
+          enforceBounds(
+            {
+              min:
+                typeof range.min === 'string'
+                  ? padISODateTime(range.min)
+                  : range.min,
+              max:
+                typeof range.max === 'string'
+                  ? padISODateTime(range.max)
+                  : range.max,
+            } as NumberOrDateRange,
+            selectedRangeBounds
+          )
+        );
+      } else {
+        updateFilter(); // clear the filter if range is undefined
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [data, updateFilter]
+  );
 
   const widgetHeight = '4em';
 
@@ -669,5 +674,19 @@ function computeBinSlider(
       const min = rangeSize / 1000;
       return { min, max, step: min };
     }
+  }
+}
+
+function enforceBounds(
+  range: NumberOrDateRange,
+  bounds: NumberOrDateRange | undefined
+) {
+  if (bounds) {
+    return {
+      min: range.min < bounds.min ? bounds.min : range.min,
+      max: range.max > bounds.max ? bounds.max : range.max,
+    } as NumberOrDateRange;
+  } else {
+    return range;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,10 +2889,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.6.0.tgz#2e8076e91f05176a908b440be4b6b4e3e23a67bb"
-  integrity sha512-b37yxFmhqgIMNUCHgG/YnHmjqSOiXaIbrPtDLA7pHCtFiRqvhe4otmzC7+drE7rVxsUuvJ0ontl7lMf85760qA==
+"@veupathdb/components@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.7.0.tgz#9f3e62d1b3bda37c14bb6c93f4440e680a382b62"
+  integrity sha512-ufwuf8x2LQvnnEffMEvuv+n1kbObFLTkKFRWGyprh+6yji2HjRP7FmPeowXb4RYrEPczufdov29+SDYrw7ouKw==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Depends on https://github.com/VEuPathDB/web-components/pull/190

The components PR simplifies some of the internals of `Histogram` by removing its handling of `selectedRangeBounds`

Here we reinstate the bounds check on the EDA side - see `enforceBounds`.

There were some very minor bugs in single-day resolution range subset selections - these have now all been resolved.

Edit to add: Actually one of the "minor date-related bugs" was not minor at all.  If you selected a single bar, at any resolution (month, year, day etc), in a date-variable histogram (subsetting), you would see that the size of the subset is not the same as the number of entities represented by the bar.  This is because the filter created is including the end day.  So a bin that is labelled "01 Jan 2018 to 01 Feb 2018" needs to create a filter "01 Jan 2018 to 31 Jan 2018".  This has now been fixed, but at the Histogram component level, which means at some point we should document exactly what the bin and filter specifications are.  I will add a technical debt ticket.