### PR TITLE
dependentAxisLabel always Count in subset histogram

### DIFF
--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -532,7 +532,7 @@ function HistogramPlotWithControls({
         displayLibraryControls={displayLibraryControls}
         onSelectedRangeChange={handleSelectedRangeChange}
         barLayout={barLayout}
-        dependentAxisLabel={`Count of ${entityName}`}
+        dependentAxisLabel="Count"
         // add independentAxisLabel
         independentAxisLabel={variableName}
         independentAxisRange={uiState.independentAxisRange}

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -356,7 +356,6 @@ export function HistogramFilter(props: Props) {
           defaultUIState={defaultUIState}
           updateUIState={updateUIState}
           variableName={variable.displayName}
-          entityName={entity.displayName}
           showSpinner={data.pending}
         />
       </div>
@@ -372,7 +371,6 @@ type HistogramPlotWithControlsProps = HistogramProps & {
   filter?: DateRangeFilter | NumberRangeFilter;
   // add variableName for independentAxisLabel
   variableName: string;
-  entityName: string;
 };
 
 function HistogramPlotWithControls({
@@ -384,7 +382,6 @@ function HistogramPlotWithControls({
   filter,
   // variableName for independentAxisLabel
   variableName,
-  entityName,
   ...histogramProps
 }: HistogramPlotWithControlsProps) {
   const handleBinWidthChange = useCallback(


### PR DESCRIPTION
_Addresses issue #288_

Set the y axis label of the histogram in the subsetting tab to always read "Count". See attached image.

Tested locally with GEMS and PRISM2.

<img width="746" alt="Screen Shot 2021-08-19 at 2 56 26 PM" src="https://user-images.githubusercontent.com/11710234/130130042-8ffcd155-d24f-41d2-9d96-32150e6da088.png">
