### PR TITLE
keep hide toggle button state at variable selector

### DIFF
--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -85,6 +85,8 @@ interface VariableListProps {
   hideDisabledFields: boolean;
   setHideDisabledFields: (hide: boolean) => void;
   featuredFields: VariableField[];
+  //DKDK onHideToggleChange
+  onHideVariableToggleChange?: (value: boolean) => void;
 }
 
 interface getNodeSearchStringType {
@@ -115,6 +117,8 @@ export default function VariableList(props: VariableListProps) {
     toggleStarredVariable,
     hideDisabledFields,
     setHideDisabledFields,
+    //DKDK onHideVariableToggleChange
+    onHideVariableToggleChange,
   } = props;
   const [searchTerm, setSearchTerm] = useState<string>('');
   const getPathToField = useCallback(
@@ -379,6 +383,9 @@ export default function VariableList(props: VariableListProps) {
               type="button"
               onClick={() => {
                 setHideDisabledFields(!hideDisabledFields);
+                //DKDK onHideVariableToggleChange
+                if (onHideVariableToggleChange)
+                  onHideVariableToggleChange(!hideDisabledFields);
               }}
             >
               <Toggle on={hideDisabledFields} /> Only show compatible variables
@@ -386,7 +393,8 @@ export default function VariableList(props: VariableListProps) {
           </HtmlTooltip>
         </div>
       )}
-      {allowedFeaturedFields.length && (
+      {/* DKDK allowedFeaturedFields.length should have > 0 condition: otherwise, it prints 0 when .length = 0 */}
+      {allowedFeaturedFields.length > 0 && (
         <div className="FeaturedVariables">
           <details
             open={Options.featuredVariablesOpen}

--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -23,6 +23,9 @@ export interface Props {
   onChange: (variable?: VariableDescriptor) => void;
   hideDisabledFields?: boolean;
   setHideDisabledFields?: (hide: boolean) => void;
+  //DKDK onHideVariableToggleChange
+  hideVariableToggleStatus?: boolean;
+  onHideVariableToggleChange?: (value: boolean) => void;
 }
 export function VariableTree(props: Props) {
   const {
@@ -35,6 +38,8 @@ export function VariableTree(props: Props) {
     onChange,
     hideDisabledFields = false,
     setHideDisabledFields = () => {},
+    //DKDK onHideToggleChange
+    onHideVariableToggleChange,
   } = props;
   const entities = useStudyEntities(rootEntity);
 
@@ -163,13 +168,25 @@ export function VariableTree(props: Props) {
       toggleStarredVariable={toggleStarredVariable}
       hideDisabledFields={hideDisabledFields}
       setHideDisabledFields={setHideDisabledFields}
+      //DKDK onHideVariableToggleChange
+      onHideVariableToggleChange={onHideVariableToggleChange}
     />
   );
 }
 
 export function VariableTreeDropdown(props: Props) {
-  const { rootEntity, entityId, variableId, onChange } = props;
-  const [hideDisabledFields, setHideDisabledFields] = useState(false);
+  //DKDK
+  const {
+    rootEntity,
+    entityId,
+    variableId,
+    onChange,
+    hideVariableToggleStatus,
+  } = props;
+  const [hideDisabledFields, setHideDisabledFields] = useState(
+    hideVariableToggleStatus
+  );
+
   const entities = useStudyEntities(rootEntity);
   const variable = entities
     .find((e) => e.id === entityId)

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -20,6 +20,9 @@ interface InputSpec {
   name: string;
   label: string;
   role: 'primary' | 'stratification';
+  //DKDK
+  hideVariableToggleStatus?: boolean;
+  onHideVariableToggleChange?: (value: boolean) => void;
 }
 
 export interface Props {
@@ -225,6 +228,9 @@ export function InputVariables(props: Props) {
               onChange={(variable) => {
                 handleChange(input.name, variable);
               }}
+              //DKDK check hide toggle change
+              hideVariableToggleStatus={input.hideVariableToggleStatus}
+              onHideVariableToggleChange={input.onHideVariableToggleChange}
             />
           </div>
         ))}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -95,6 +95,10 @@ function FullscreenComponent(props: VisualizationProps) {
 function createDefaultConfig(): ScatterplotConfig {
   return {
     valueSpecConfig: 'Raw',
+    //DKDK set hideDisabledFields's default value for each
+    xAxisVariableHideToggle: false,
+    yAxisVariableHideToggle: false,
+    overlayVariableHideToggle: false,
   };
 }
 
@@ -107,6 +111,10 @@ export const ScatterplotConfig = t.partial({
   facetVariable: VariableDescriptor,
   valueSpecConfig: t.string,
   showMissingness: t.boolean,
+  //DKDK set hideDisabledFields's default value for each
+  xAxisVariableHideToggle: t.boolean,
+  yAxisVariableHideToggle: t.boolean,
+  overlayVariableHideToggle: t.boolean,
 });
 
 type Props = VisualizationProps & {
@@ -227,6 +235,36 @@ function ScatterplotViz(props: Props) {
     entities
   );
 
+  //DKDK check hide toggle change
+  const onHideToggleChangeX = useCallback(
+    (value: boolean) => {
+      updateVizConfig({
+        xAxisVariableHideToggle: value,
+      });
+    },
+    [updateVizConfig]
+  );
+
+  //DKDK check hide toggle change
+  const onHideToggleChangeY = useCallback(
+    (value: boolean) => {
+      updateVizConfig({
+        yAxisVariableHideToggle: value,
+      });
+    },
+    [updateVizConfig]
+  );
+
+  //DKDK check hide toggle change
+  const onHideToggleChangeOverlay = useCallback(
+    (value: boolean) => {
+      updateVizConfig({
+        overlayVariableHideToggle: value,
+      });
+    },
+    [updateVizConfig]
+  );
+
   const data = usePromise(
     useCallback(async (): Promise<PromiseXYPlotData | undefined> => {
       // check independentValueType/dependentValueType
@@ -292,6 +330,8 @@ function ScatterplotViz(props: Props) {
       overlayVariable,
       computation.type,
       visualization.type,
+      //DKDK
+      outputEntity,
     ])
   );
 
@@ -300,21 +340,31 @@ function ScatterplotViz(props: Props) {
       {fullscreen && (
         <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
           <InputVariables
+            //DKDK use inputs' property for remembering the state of hide toggle status
             inputs={[
               {
                 name: 'xAxisVariable',
                 label: 'X-axis',
                 role: 'primary',
+                hideVariableToggleStatus:
+                  vizConfig.xAxisVariableHideToggle ?? false,
+                onHideVariableToggleChange: onHideToggleChangeX,
               },
               {
                 name: 'yAxisVariable',
                 label: 'Y-axis',
                 role: 'primary',
+                hideVariableToggleStatus:
+                  vizConfig.yAxisVariableHideToggle ?? false,
+                onHideVariableToggleChange: onHideToggleChangeY,
               },
               {
                 name: 'overlayVariable',
                 label: 'Overlay',
                 role: 'stratification',
+                hideVariableToggleStatus:
+                  vizConfig.overlayVariableHideToggle ?? false,
+                onHideVariableToggleChange: onHideToggleChangeOverlay,
               },
             ]}
             entities={entities}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -95,10 +95,6 @@ function FullscreenComponent(props: VisualizationProps) {
 function createDefaultConfig(): ScatterplotConfig {
   return {
     valueSpecConfig: 'Raw',
-    //DKDK set hideDisabledFields's default value for each
-    xAxisVariableHideToggle: false,
-    yAxisVariableHideToggle: false,
-    overlayVariableHideToggle: false,
   };
 }
 
@@ -111,7 +107,27 @@ export const ScatterplotConfig = t.partial({
   facetVariable: VariableDescriptor,
   valueSpecConfig: t.string,
   showMissingness: t.boolean,
-  //DKDK set hideDisabledFields's default value for each
+  // //DKDK set hideDisabledFields's default value for each
+  // xAxisVariableHideToggle: t.boolean,
+  // yAxisVariableHideToggle: t.boolean,
+  // overlayVariableHideToggle: t.boolean,
+});
+
+//DKDKDK
+function createDefaultButtonConfig(): showVariableButtonConfig {
+  return {
+    xAxisVariableHideToggle: false,
+    yAxisVariableHideToggle: false,
+    overlayVariableHideToggle: false,
+  };
+}
+
+//DKDKDK
+export type showVariableButtonConfig = t.TypeOf<
+  typeof showVariableButtonConfig
+>;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const showVariableButtonConfig = t.partial({
   xAxisVariableHideToggle: t.boolean,
   yAxisVariableHideToggle: t.boolean,
   overlayVariableHideToggle: t.boolean,
@@ -162,6 +178,35 @@ function ScatterplotViz(props: Props) {
       }
     },
     [updateVisualization, visualization, vizConfig]
+  );
+
+  //DKDKDK
+  const vizButtonConfig = useMemo(() => {
+    return pipe(
+      showVariableButtonConfig.decode(visualization?.buttonConfig),
+      getOrElse(
+        (): t.TypeOf<typeof showVariableButtonConfig> =>
+          createDefaultButtonConfig()
+      )
+    );
+  }, [visualization.buttonConfig]);
+
+  console.log('vizButtonConfig =', vizButtonConfig);
+
+  //DKDKDK
+  const updateVizButtonConfig = useCallback(
+    (newConfig: Partial<showVariableButtonConfig>) => {
+      if (updateVisualization) {
+        updateVisualization({
+          ...visualization,
+          buttonConfig: {
+            ...vizButtonConfig,
+            ...newConfig,
+          },
+        });
+      }
+    },
+    [updateVisualization, visualization, vizButtonConfig]
   );
 
   // moved the location of this findEntityAndVariable
@@ -235,34 +280,48 @@ function ScatterplotViz(props: Props) {
     entities
   );
 
-  //DKDK check hide toggle change
+  //DKDKDK check hide toggle change
   const onHideToggleChangeX = useCallback(
     (value: boolean) => {
-      updateVizConfig({
+      updateVizButtonConfig({
         xAxisVariableHideToggle: value,
       });
     },
-    [updateVizConfig]
+    [updateVizButtonConfig]
   );
 
   //DKDK check hide toggle change
   const onHideToggleChangeY = useCallback(
     (value: boolean) => {
-      updateVizConfig({
+      updateVizButtonConfig({
         yAxisVariableHideToggle: value,
       });
     },
-    [updateVizConfig]
+    [updateVizButtonConfig]
   );
 
   //DKDK check hide toggle change
   const onHideToggleChangeOverlay = useCallback(
     (value: boolean) => {
-      updateVizConfig({
+      updateVizButtonConfig({
         overlayVariableHideToggle: value,
       });
     },
-    [updateVizConfig]
+    [updateVizButtonConfig]
+  );
+
+  //DKDK
+  console.log(
+    'vizButtonConfig.xAxisVariableHideToggle =',
+    vizButtonConfig.xAxisVariableHideToggle
+  );
+  console.log(
+    'vizButtonConfig.yAxisVariableHideToggle =',
+    vizButtonConfig.yAxisVariableHideToggle
+  );
+  console.log(
+    'vizButtonConfig.overlayVariableHideToggle =',
+    vizButtonConfig.overlayVariableHideToggle
   );
 
   const data = usePromise(
@@ -341,13 +400,39 @@ function ScatterplotViz(props: Props) {
         <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
           <InputVariables
             //DKDK use inputs' property for remembering the state of hide toggle status
+            // inputs={[
+            //   {
+            //     name: 'xAxisVariable',
+            //     label: 'X-axis',
+            //     role: 'primary',
+            //     hideVariableToggleStatus:
+            //       vizConfig.xAxisVariableHideToggle ?? false,
+            //     onHideVariableToggleChange: onHideToggleChangeX,
+            //   },
+            //   {
+            //     name: 'yAxisVariable',
+            //     label: 'Y-axis',
+            //     role: 'primary',
+            //     hideVariableToggleStatus:
+            //       vizConfig.yAxisVariableHideToggle ?? false,
+            //     onHideVariableToggleChange: onHideToggleChangeY,
+            //   },
+            //   {
+            //     name: 'overlayVariable',
+            //     label: 'Overlay',
+            //     role: 'stratification',
+            //     hideVariableToggleStatus:
+            //       vizConfig.overlayVariableHideToggle ?? false,
+            //     onHideVariableToggleChange: onHideToggleChangeOverlay,
+            //   },
+            // ]}
             inputs={[
               {
                 name: 'xAxisVariable',
                 label: 'X-axis',
                 role: 'primary',
                 hideVariableToggleStatus:
-                  vizConfig.xAxisVariableHideToggle ?? false,
+                  vizButtonConfig.xAxisVariableHideToggle ?? false,
                 onHideVariableToggleChange: onHideToggleChangeX,
               },
               {
@@ -355,7 +440,7 @@ function ScatterplotViz(props: Props) {
                 label: 'Y-axis',
                 role: 'primary',
                 hideVariableToggleStatus:
-                  vizConfig.yAxisVariableHideToggle ?? false,
+                  vizButtonConfig.yAxisVariableHideToggle ?? false,
                 onHideVariableToggleChange: onHideToggleChangeY,
               },
               {
@@ -363,7 +448,7 @@ function ScatterplotViz(props: Props) {
                 label: 'Overlay',
                 role: 'stratification',
                 hideVariableToggleStatus:
-                  vizConfig.overlayVariableHideToggle ?? false,
+                  vizButtonConfig.overlayVariableHideToggle ?? false,
                 onHideVariableToggleChange: onHideToggleChangeOverlay,
               },
             ]}

--- a/src/lib/core/hooks/findOutputEntity.ts
+++ b/src/lib/core/hooks/findOutputEntity.ts
@@ -27,6 +27,6 @@ export function useFindOutputEntity(
     dataElementDependencyOrder,
     dataElementVariables,
     defaultVariableName,
-    entities,
+    findEntityAndVariable,
   ]);
 }

--- a/src/lib/core/types/visualization.ts
+++ b/src/lib/core/types/visualization.ts
@@ -27,6 +27,8 @@ export const Visualization = intersection([
   }),
   partial({
     displayName: string,
+    //DKDKDK
+    buttonConfig: unknown,
   }),
 ]);
 


### PR DESCRIPTION
During this work, I found a small bug on the hiding (toggle-on) that hides variables including the Featured Variable. The issue was that if the Featured Variable is non-existent, i.e., `allowedFeaturedFields.length === 0` (at `VariableList` component), then erroneous zero (0) character is shown (see attached screenshot). It was solved by simply adding larger than 0, i.e., `allowedFeaturedFields.length > 0`.

Anyway, I have tested several case and this implementation seems to work fine - only applied to scatter plot viz for now. However, I noticed that this had a side effect: whenever toggle the show/hide button, then plot is redrawn because I used vizualization.config to store the status of the buttons (on/off). It would be great if you (@dmfalke, @jtlong3rd, or anyone) can suggest a way to avoid this.

![variablelist-smallbug1](https://user-images.githubusercontent.com/12802305/130161524-f4493202-155f-4e1b-90f4-ccebbe0f6a55.png)
