### PR TITLE
using useContext for remembering show/hide variable toggle at variable selector

### DIFF
--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -10,6 +10,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  useContext,
 } from 'react';
 import { Link } from 'react-router-dom';
 //correct paths as this is a copy of FieldList component at @veupathdb/
@@ -40,6 +41,8 @@ import { cx } from '../../workspace/Utils';
 import { Tooltip } from '@material-ui/core';
 import { HtmlTooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+// import ShowHideVariableContext
+import { ShowHideVariableContext } from '../utils/show-hide-variable-context';
 
 //defining types - some are not used (need cleanup later)
 interface VariableField {
@@ -355,6 +358,12 @@ export default function VariableList(props: VariableListProps) {
     </>
   );
 
+  // useContext is used here with ShowHideVariableContext
+  const {
+    toggleShowHideVariable,
+    setToggleShowHideVariableHandler,
+  } = useContext(ShowHideVariableContext);
+
   return (
     <div className={cx('-VariableList')}>
       {disabledFields.size > 0 && (
@@ -379,6 +388,9 @@ export default function VariableList(props: VariableListProps) {
               type="button"
               onClick={() => {
                 setHideDisabledFields(!hideDisabledFields);
+                // store !hideDisabledFields boolean using ShowHideVariableContext
+                if (setToggleShowHideVariableHandler)
+                  setToggleShowHideVariableHandler(!hideDisabledFields);
               }}
             >
               <Toggle on={hideDisabledFields} /> Only show compatible variables
@@ -386,7 +398,8 @@ export default function VariableList(props: VariableListProps) {
           </HtmlTooltip>
         </div>
       )}
-      {allowedFeaturedFields.length && (
+      {/* minor bug fix, not to show 0 character for empty allowedFeaturedFields */}
+      {allowedFeaturedFields.length > 0 && (
         <div className="FeaturedVariables">
           <details
             open={Options.featuredVariablesOpen}

--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -85,8 +85,6 @@ interface VariableListProps {
   starredVariables?: string[];
   toggleStarredVariable: (targetVariableId: string) => void;
   disabledFieldIds?: string[];
-  hideDisabledFields: boolean;
-  setHideDisabledFields: (hide: boolean) => void;
   featuredFields: VariableField[];
 }
 
@@ -116,9 +114,14 @@ export default function VariableList(props: VariableListProps) {
     autoFocus,
     starredVariables,
     toggleStarredVariable,
-    hideDisabledFields,
-    setHideDisabledFields,
   } = props;
+
+  // useContext is used here with ShowHideVariableContext
+  const {
+    showOnlyCompatibleVariables,
+    setShowOnlyCompatibleVariablesHandler,
+  } = useContext(ShowHideVariableContext);
+
   const [searchTerm, setSearchTerm] = useState<string>('');
   const getPathToField = useCallback(
     (field?: Field) => {
@@ -306,7 +309,7 @@ export default function VariableList(props: VariableListProps) {
 
   const isAdditionalFilterApplied = showOnlyStarredVariables;
 
-  const allowedFeaturedFields = hideDisabledFields
+  const allowedFeaturedFields = showOnlyCompatibleVariables
     ? featuredFields.filter((field) => !disabledFields.has(field.term))
     : featuredFields;
 
@@ -321,7 +324,7 @@ export default function VariableList(props: VariableListProps) {
               visibleStarredVariablesSet.has(node.field.term.split('/')[1]),
             fieldTree
           );
-    return hideDisabledFields
+    return showOnlyCompatibleVariables
       ? pruneDescendantNodes((node) => {
           if (disabledFields.size === 0) return true;
           if (node.field.type == null) return node.children.length > 0;
@@ -332,7 +335,7 @@ export default function VariableList(props: VariableListProps) {
     showOnlyStarredVariables,
     starredVariableToggleDisabled,
     fieldTree,
-    hideDisabledFields,
+    showOnlyCompatibleVariables,
     visibleStarredVariablesSet,
     disabledFields,
   ]);
@@ -358,12 +361,6 @@ export default function VariableList(props: VariableListProps) {
     </>
   );
 
-  // useContext is used here with ShowHideVariableContext
-  const {
-    toggleShowHideVariable,
-    setToggleShowHideVariableHandler,
-  } = useContext(ShowHideVariableContext);
-
   return (
     <div className={cx('-VariableList')}>
       {disabledFields.size > 0 && (
@@ -387,13 +384,14 @@ export default function VariableList(props: VariableListProps) {
               className="link"
               type="button"
               onClick={() => {
-                setHideDisabledFields(!hideDisabledFields);
-                // store !hideDisabledFields boolean using ShowHideVariableContext
-                if (setToggleShowHideVariableHandler)
-                  setToggleShowHideVariableHandler(!hideDisabledFields);
+                // useContext
+                setShowOnlyCompatibleVariablesHandler(
+                  !showOnlyCompatibleVariables
+                );
               }}
             >
-              <Toggle on={hideDisabledFields} /> Only show compatible variables
+              <Toggle on={showOnlyCompatibleVariables} /> Only show compatible
+              variables
             </button>
           </HtmlTooltip>
         </div>

--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -11,8 +11,6 @@ import { edaVariableToWdkField } from '../utils/wdk-filter-param-adapter';
 import VariableList from './VariableList';
 import './VariableTree.scss';
 import { useStudyEntities } from '../hooks/study';
-// import ShowHideVariableContext
-import { ShowHideVariableContext } from '../utils/show-hide-variable-context';
 
 export interface Props {
   rootEntity: StudyEntity;
@@ -23,8 +21,6 @@ export interface Props {
   disabledVariables?: VariableDescriptor[];
   /** term string is of format "entityId/variableId"  e.g. "PCO_0000024/EUPATH_0000714" */
   onChange: (variable?: VariableDescriptor) => void;
-  hideDisabledFields?: boolean;
-  setHideDisabledFields?: (hide: boolean) => void;
 }
 export function VariableTree(props: Props) {
   const {
@@ -35,8 +31,6 @@ export function VariableTree(props: Props) {
     entityId,
     variableId,
     onChange,
-    hideDisabledFields = false,
-    setHideDisabledFields = () => {},
   } = props;
   const entities = useStudyEntities(rootEntity);
 
@@ -163,23 +157,12 @@ export function VariableTree(props: Props) {
       autoFocus={false}
       starredVariables={starredVariables}
       toggleStarredVariable={toggleStarredVariable}
-      hideDisabledFields={hideDisabledFields}
-      setHideDisabledFields={setHideDisabledFields}
     />
   );
 }
 
 export function VariableTreeDropdown(props: Props) {
   const { rootEntity, entityId, variableId, onChange } = props;
-
-  // use ShowHideVariableContext for setting initial hideDisabledFields boolean
-  const {
-    toggleShowHideVariable,
-    setToggleShowHideVariableHandler,
-  } = useContext(ShowHideVariableContext);
-  const [hideDisabledFields, setHideDisabledFields] = useState(
-    toggleShowHideVariable
-  );
 
   const entities = useStudyEntities(rootEntity);
   const variable = entities
@@ -204,11 +187,7 @@ export function VariableTreeDropdown(props: Props) {
           </div>
         )}
         <div className={cx('-VariableTreeDropdownTreeContainer')}>
-          <VariableTree
-            {...props}
-            hideDisabledFields={hideDisabledFields}
-            setHideDisabledFields={setHideDisabledFields}
-          />
+          <VariableTree {...props} />
         </div>
       </PopoverButton>
     </div>

--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -3,7 +3,7 @@ import { Button } from '@material-ui/core';
 import { getTree } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/AttributeFilterUtils';
 import { pruneDescendantNodes } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { keyBy } from 'lodash';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, useContext } from 'react';
 import { cx } from '../../workspace/Utils';
 import { StudyEntity } from '../types/study';
 import { VariableDescriptor } from '../types/variable';
@@ -11,6 +11,8 @@ import { edaVariableToWdkField } from '../utils/wdk-filter-param-adapter';
 import VariableList from './VariableList';
 import './VariableTree.scss';
 import { useStudyEntities } from '../hooks/study';
+// import ShowHideVariableContext
+import { ShowHideVariableContext } from '../utils/show-hide-variable-context';
 
 export interface Props {
   rootEntity: StudyEntity;
@@ -169,7 +171,16 @@ export function VariableTree(props: Props) {
 
 export function VariableTreeDropdown(props: Props) {
   const { rootEntity, entityId, variableId, onChange } = props;
-  const [hideDisabledFields, setHideDisabledFields] = useState(false);
+
+  // use ShowHideVariableContext for setting initial hideDisabledFields boolean
+  const {
+    toggleShowHideVariable,
+    setToggleShowHideVariableHandler,
+  } = useContext(ShowHideVariableContext);
+  const [hideDisabledFields, setHideDisabledFields] = useState(
+    toggleShowHideVariable
+  );
+
   const entities = useStudyEntities(rootEntity);
   const variable = entities
     .find((e) => e.id === entityId)

--- a/src/lib/core/utils/show-hide-variable-context.tsx
+++ b/src/lib/core/utils/show-hide-variable-context.tsx
@@ -1,20 +1,29 @@
 import React, { createContext, useState } from 'react';
 
 export const ShowHideVariableContext = createContext({
-  toggleShowHideVariable: false,
-  setToggleShowHideVariableHandler: (toggleShowHideVariable: boolean) => {},
+  showOnlyCompatibleVariables: false,
+  setShowOnlyCompatibleVariablesHandler: (
+    showOnlyCompatibleVariables: boolean
+  ) => {},
 });
 
 const ShowHideVariableContextProvider: React.FC<React.ReactNode> = ({
   children,
 }) => {
-  const [toggleShowHideVariable, setToggleShowHideVariable] = useState(false);
-  const setToggleShowHideVariableHandler = (toggleShowHideVariable: boolean) =>
-    setToggleShowHideVariable(toggleShowHideVariable);
+  const [
+    showOnlyCompatibleVariables,
+    setShowOnlyCompatibleVariables,
+  ] = useState(false);
+  const setShowOnlyCompatibleVariablesHandler = (
+    showOnlyCompatibleVariables: boolean
+  ) => setShowOnlyCompatibleVariables(showOnlyCompatibleVariables);
 
   return (
     <ShowHideVariableContext.Provider
-      value={{ toggleShowHideVariable, setToggleShowHideVariableHandler }}
+      value={{
+        showOnlyCompatibleVariables,
+        setShowOnlyCompatibleVariablesHandler,
+      }}
     >
       {children}
     </ShowHideVariableContext.Provider>

--- a/src/lib/core/utils/show-hide-variable-context.tsx
+++ b/src/lib/core/utils/show-hide-variable-context.tsx
@@ -1,0 +1,24 @@
+import React, { createContext, useState } from 'react';
+
+export const ShowHideVariableContext = createContext({
+  toggleShowHideVariable: false,
+  setToggleShowHideVariableHandler: (toggleShowHideVariable: boolean) => {},
+});
+
+const ShowHideVariableContextProvider: React.FC<React.ReactNode> = ({
+  children,
+}) => {
+  const [toggleShowHideVariable, setToggleShowHideVariable] = useState(false);
+  const setToggleShowHideVariableHandler = (toggleShowHideVariable: boolean) =>
+    setToggleShowHideVariable(toggleShowHideVariable);
+
+  return (
+    <ShowHideVariableContext.Provider
+      value={{ toggleShowHideVariable, setToggleShowHideVariableHandler }}
+    >
+      {children}
+    </ShowHideVariableContext.Provider>
+  );
+};
+
+export default ShowHideVariableContextProvider;

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -74,116 +74,117 @@ export function AnalysisPanel(props: Props) {
     );
   if (analysis == null) return <Loading />;
   return (
-    <div className={cx('-Analysis')}>
-      <AnalysisSummary
-        analysis={analysis}
-        setAnalysisName={setName}
-        copyAnalysis={hideCopyAndSave ? undefined : copyAnalysis}
-        saveAnalysis={saveAnalysis}
-        deleteAnalysis={hideCopyAndSave ? undefined : deleteAnalysis}
-        onFilterIconClick={() =>
-          setGlobalFiltersDialogOpen(!globalFiltersDialogOpen)
-        }
-        globalFiltersDialogOpen={globalFiltersDialogOpen}
-      />
-      <GlobalFiltersDialog
-        open={globalFiltersDialogOpen}
-        setOpen={setGlobalFiltersDialogOpen}
-        entities={entities}
-        filters={analysis.filters}
-        setFilters={setFilters}
-        removeFilter={(filter) =>
-          setFilters(analysis.filters.filter((f) => f !== filter))
-        }
-      />
-      <Route
-        path={[
-          `${routeBase}/variables/:entityId?/:variableId?`,
-          `${routeBase}`,
-        ]}
-        render={(
-          props: RouteComponentProps<{
-            entityId?: string;
-            variableId?: string;
-          }>
-        ) => (
-          <div className="Entities">
-            <EntityDiagram
-              expanded
-              orientation="horizontal"
-              selectedEntity={props.match.params.entityId}
-              selectedVariable={props.match.params.variableId}
-              entityCounts={totalCounts.value}
-              filteredEntityCounts={filteredCounts.value}
-              filteredEntities={filteredEntities}
+    <ShowHideVariableContextProvider>
+      <div className={cx('-Analysis')}>
+        <AnalysisSummary
+          analysis={analysis}
+          setAnalysisName={setName}
+          copyAnalysis={hideCopyAndSave ? undefined : copyAnalysis}
+          saveAnalysis={saveAnalysis}
+          deleteAnalysis={hideCopyAndSave ? undefined : deleteAnalysis}
+          onFilterIconClick={() =>
+            setGlobalFiltersDialogOpen(!globalFiltersDialogOpen)
+          }
+          globalFiltersDialogOpen={globalFiltersDialogOpen}
+        />
+        <GlobalFiltersDialog
+          open={globalFiltersDialogOpen}
+          setOpen={setGlobalFiltersDialogOpen}
+          entities={entities}
+          filters={analysis.filters}
+          setFilters={setFilters}
+          removeFilter={(filter) =>
+            setFilters(analysis.filters.filter((f) => f !== filter))
+          }
+        />
+        <Route
+          path={[
+            `${routeBase}/variables/:entityId?/:variableId?`,
+            `${routeBase}`,
+          ]}
+          render={(
+            props: RouteComponentProps<{
+              entityId?: string;
+              variableId?: string;
+            }>
+          ) => (
+            <div className="Entities">
+              <EntityDiagram
+                expanded
+                orientation="horizontal"
+                selectedEntity={props.match.params.entityId}
+                selectedVariable={props.match.params.variableId}
+                entityCounts={totalCounts.value}
+                filteredEntityCounts={filteredCounts.value}
+                filteredEntities={filteredEntities}
+              />
+            </div>
+          )}
+        />
+        <WorkspaceNavigation
+          heading={<></>}
+          routeBase={routeBase}
+          items={[
+            {
+              display: 'View study details',
+              route: `/details`,
+              exact: false,
+              replace: true,
+            },
+            {
+              display: 'Browse and subset',
+              route: `/variables${lastVarPath}`,
+              exact: false,
+              replace: true,
+            },
+            {
+              display: 'Visualize',
+              // check whether user is at viz
+              route: location.pathname
+                .replace(routeBase, '')
+                .startsWith('/visualizations')
+                ? '/visualizations'
+                : `/visualizations${lastVizPath}`,
+              exact: false,
+              replace: true,
+            },
+          ]}
+        />
+        <Route
+          path={routeBase}
+          exact
+          render={() => <Redirect to={`${routeBase}/variables`} />}
+        />
+        <Route
+          path={`${routeBase}/details`}
+          render={() => (
+            <RecordController
+              recordClass="dataset"
+              primaryKey={studyRecord.id.map((p) => p.value).join('/')}
             />
-          </div>
-        )}
-      />
-      <WorkspaceNavigation
-        heading={<></>}
-        routeBase={routeBase}
-        items={[
-          {
-            display: 'View study details',
-            route: `/details`,
-            exact: false,
-            replace: true,
-          },
-          {
-            display: 'Browse and subset',
-            route: `/variables${lastVarPath}`,
-            exact: false,
-            replace: true,
-          },
-          {
-            display: 'Visualize',
-            // check whether user is at viz
-            route: location.pathname
-              .replace(routeBase, '')
-              .startsWith('/visualizations')
-              ? '/visualizations'
-              : `/visualizations${lastVizPath}`,
-            exact: false,
-            replace: true,
-          },
-        ]}
-      />
-      <Route
-        path={routeBase}
-        exact
-        render={() => <Redirect to={`${routeBase}/variables`} />}
-      />
-      <Route
-        path={`${routeBase}/details`}
-        render={() => (
-          <RecordController
-            recordClass="dataset"
-            primaryKey={studyRecord.id.map((p) => p.value).join('/')}
-          />
-        )}
-      />
-      <Route
-        path={`${routeBase}/variables/:entityId?`}
-        exact
-        render={(props) => <DefaultVariableRedirect {...props.match.params} />}
-      />
-      <Route
-        path={`${routeBase}/variables/:entityId/:variableId`}
-        exact
-        render={(
-          props: RouteComponentProps<{ entityId: string; variableId: string }>
-        ) => (
-          <Subsetting {...props.match.params} analysisState={analysisState} />
-        )}
-      />
-      {/* use ShowHideVariableContextProvider here for handling the state of show/hide variable toggle */}
-      <ShowHideVariableContextProvider>
+          )}
+        />
+        <Route
+          path={`${routeBase}/variables/:entityId?`}
+          exact
+          render={(props) => (
+            <DefaultVariableRedirect {...props.match.params} />
+          )}
+        />
+        <Route
+          path={`${routeBase}/variables/:entityId/:variableId`}
+          exact
+          render={(
+            props: RouteComponentProps<{ entityId: string; variableId: string }>
+          ) => (
+            <Subsetting {...props.match.params} analysisState={analysisState} />
+          )}
+        />
         <Route
           path={`${routeBase}/visualizations`}
           render={() => <ComputationRoute analysisState={analysisState} />}
         />
-      </ShowHideVariableContextProvider>
-    </div>
+      </div>
+    </ShowHideVariableContextProvider>
   );
 }

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -25,6 +25,8 @@ import { RecordController } from '@veupathdb/wdk-client/lib/Controllers';
 import GlobalFiltersDialog from '../core/components/GlobalFiltersDialog';
 import { useStudyEntities } from '../core/hooks/study';
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
+// import ShowHideVariableContextProvider
+import ShowHideVariableContextProvider from '../core/utils/show-hide-variable-context';
 
 interface Props {
   analysisState: AnalysisState;
@@ -175,10 +177,13 @@ export function AnalysisPanel(props: Props) {
           <Subsetting {...props.match.params} analysisState={analysisState} />
         )}
       />
-      <Route
-        path={`${routeBase}/visualizations`}
-        render={() => <ComputationRoute analysisState={analysisState} />}
-      />
+      {/* use ShowHideVariableContextProvider here for handling the state of show/hide variable toggle */}
+      <ShowHideVariableContextProvider>
+        <Route
+          path={`${routeBase}/visualizations`}
+          render={() => <ComputationRoute analysisState={analysisState} />}
+        />
+      </ShowHideVariableContextProvider>
     </div>
   );
 }


### PR DESCRIPTION
After discussing with @dmfalke at the previous PR, #321, we have decided to simplify the behavior. In this PR, useContext is used to remember the state of show/hide variable toggle at variable selector. Now the behavior is: a) at a plot viz, show/hide toggle is reserved for each variable (X, Y, Overlay variables etc.); b) but if leaving a plot viz, only the last state of show/hide toggle is reserved via useState and it would be used as a new state for a new plot viz: i.e., all true or all false regardless of variable selectors (X, Y, Overlay variables etc.).