### PR TITLE
rename 'proportional' radio buttons to 'proportion'

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -402,12 +402,10 @@ function BarplotWithControls({
             onStateChange={onDependentAxisLogScaleChange}
           />
           <RadioButtonGroup
-            selectedOption={
-              valueSpec === 'proportion' ? 'proportional' : 'count'
-            }
-            options={['count', 'proportional']}
+            selectedOption={valueSpec === 'proportion' ? 'proportion' : 'count'}
+            options={['count', 'proportion']}
             onOptionSelected={(newOption) => {
-              if (newOption === 'proportional') {
+              if (newOption === 'proportion') {
                 onValueSpecChange('proportion');
               } else {
                 onValueSpecChange('count');

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -402,7 +402,7 @@ function BarplotWithControls({
             onStateChange={onDependentAxisLogScaleChange}
           />
           <RadioButtonGroup
-            selectedOption={valueSpec === 'proportion' ? 'proportion' : 'count'}
+            selectedOption={valueSpec}
             options={['count', 'proportion']}
             onOptionSelected={(newOption) => {
               if (newOption === 'proportion') {

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -457,7 +457,7 @@ function HistogramPlotWithControls({
             onStateChange={onDependentAxisLogScaleChange}
           />
           <RadioButtonGroup
-            selectedOption={valueSpec === 'proportion' ? 'proportion' : 'count'}
+            selectedOption={valueSpec}
             options={['count', 'proportion']}
             onOptionSelected={(newOption) => {
               if (newOption === 'proportion') {

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -457,12 +457,10 @@ function HistogramPlotWithControls({
             onStateChange={onDependentAxisLogScaleChange}
           />
           <RadioButtonGroup
-            selectedOption={
-              valueSpec === 'proportion' ? 'proportional' : 'count'
-            }
-            options={['count', 'proportional']}
+            selectedOption={valueSpec === 'proportion' ? 'proportion' : 'count'}
+            options={['count', 'proportion']}
             onOptionSelected={(newOption) => {
-              if (newOption === 'proportional') {
+              if (newOption === 'proportion') {
                 onValueSpecChange('proportion');
               } else {
                 onValueSpecChange('count');


### PR DESCRIPTION
Resolves issue #300 

Both bar and histogram have the option to display the y-axis as count or proportion. Originally the text next to the choice for proportion was labelled "Proportional". This PR changes this text to "Proportion" in both vizs (see below for example).

<img width="834" alt="Screen Shot 2021-08-26 at 4 09 43 PM" src="https://user-images.githubusercontent.com/11710234/131030565-d977f254-3181-447e-8854-bca2c4f20da9.png">
