### PR TITLE
set variabe tree width

### DIFF
--- a/src/lib/workspace/EDAWorkspace.scss
+++ b/src/lib/workspace/EDAWorkspace.scss
@@ -191,7 +191,7 @@
     grid:
       [row1-start] '.             filter-chips tabular-download' auto [row1-end]
       [row2-start] 'variables     filter       filter' 1fr [row2-end]
-      / auto 1fr auto;
+      / 20% 1fr auto;
     gap: 1em 3em;
     padding-top: 1em;
     .Variables {


### PR DESCRIPTION
Previously the variable tree is set to have the automatic width per length of contents (e.g., variable name). Thus, I think the best and simplest solution is to set fixed width of 20 % which seems to be a good number for me. In this manner, lengthy variable name is automatically wrapped. Here is an example being similar to the screenshot shown in the corresponding issue, #326 .

![variable-tree-width](https://user-images.githubusercontent.com/12802305/131388796-32a38d53-df19-497c-aa24-1b180e35647e.png)
