### PR TITLE
using darker colors for scatter plot viz

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.7.3",
+    "@veupathdb/components": "^0.7.7",
     "@veupathdb/wdk-client": "^0.2.0",
     "@veupathdb/web-common": "^0.1.5",
     "debounce-promise": "^3.1.2",

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -682,6 +682,28 @@ function processInputData<T extends number | string>(
       return ColorPaletteDefault[index] ?? 'black'; // TO DO: decide on overflow behaviour
     }
   };
+
+  // darker color pallette
+  const darkerColorPalette = [
+    'rgb(115, 28, 72)',
+    'rgb(113, 194, 234)',
+    'rgb(133, 133, 44)',
+    'rgb(43, 28, 115)',
+    'rgb(60, 151, 136)',
+    'rgb(215, 196, 98)',
+    'rgb(197, 82, 102)',
+    'rgb(13, 96, 41)',
+  ];
+
+  // function to return color or gray where needed if showMissingness == true
+  const darkerColor = (index: number) => {
+    if (showMissingness && index === plotDataSet.data.length - 1) {
+      return gray;
+    } else {
+      return darkerColorPalette[index] ?? 'black'; // TO DO: decide on overflow behaviour
+    }
+  };
+
   const markerSymbol = (index: number) =>
     showMissingness && index === plotDataSet.data.length - 1
       ? 'x'
@@ -845,7 +867,8 @@ function processInputData<T extends number | string>(
           : 'Smoothed mean',
         mode: 'lines', // no data point is displayed: only line
         line: {
-          color: markerColor(index),
+          // use darker color for smoothed mean line
+          color: darkerColor(index),
           shape: 'spline',
           width: 2,
         },
@@ -888,7 +911,8 @@ function processInputData<T extends number | string>(
         // this is better to be tozeroy, not tozerox
         fill: 'tozeroy',
         opacity: 0.2,
-        fillcolor: markerColor(index),
+        // use darker color for smoothed mean's confidence interval
+        fillcolor: darkerColor(index),
         // type: 'line',
         type: 'scattergl',
         // here, line means upper and lower bounds
@@ -938,7 +962,8 @@ function processInputData<T extends number | string>(
           : 'Best fit, R² = ' + el.r2,
         mode: 'lines', // no data point is displayed: only line
         line: {
-          color: markerColor(index),
+          // use darker color for best fit line
+          color: darkerColor(index),
           shape: 'spline',
         },
         // use scattergl

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -51,7 +51,10 @@ import { axisLabelWithUnit } from '../../../utils/axis-label-unit';
 import { StudyEntity } from '../../../types/study';
 import { vocabularyWithMissingData } from '../../../utils/analysis';
 import { gray } from '../colors';
-import { ColorPaletteDefault } from '@veupathdb/components/lib/types/plots/addOns';
+import {
+  ColorPaletteDefault,
+  ColorPaletteDark,
+} from '@veupathdb/components/lib/types/plots/addOns';
 
 // define PromiseXYPlotData
 interface PromiseXYPlotData extends CoverageStatistics {
@@ -683,24 +686,12 @@ function processInputData<T extends number | string>(
     }
   };
 
-  // darker color pallette
-  const darkerColorPalette = [
-    'rgb(115, 28, 72)',
-    'rgb(113, 194, 234)',
-    'rgb(133, 133, 44)',
-    'rgb(43, 28, 115)',
-    'rgb(60, 151, 136)',
-    'rgb(215, 196, 98)',
-    'rgb(197, 82, 102)',
-    'rgb(13, 96, 41)',
-  ];
-
-  // function to return color or gray where needed if showMissingness == true
-  const darkerColor = (index: number) => {
+  // using dark color: function to return color or gray where needed if showMissingness == true
+  const markerColorDark = (index: number) => {
     if (showMissingness && index === plotDataSet.data.length - 1) {
       return gray;
     } else {
-      return darkerColorPalette[index] ?? 'black'; // TO DO: decide on overflow behaviour
+      return ColorPaletteDark[index] ?? 'black'; // TO DO: decide on overflow behaviour
     }
   };
 
@@ -868,7 +859,7 @@ function processInputData<T extends number | string>(
         mode: 'lines', // no data point is displayed: only line
         line: {
           // use darker color for smoothed mean line
-          color: darkerColor(index),
+          color: markerColorDark(index),
           shape: 'spline',
           width: 2,
         },
@@ -912,7 +903,7 @@ function processInputData<T extends number | string>(
         fill: 'tozeroy',
         opacity: 0.2,
         // use darker color for smoothed mean's confidence interval
-        fillcolor: darkerColor(index),
+        fillcolor: markerColorDark(index),
         // type: 'line',
         type: 'scattergl',
         // here, line means upper and lower bounds
@@ -963,7 +954,7 @@ function processInputData<T extends number | string>(
         mode: 'lines', // no data point is displayed: only line
         line: {
           // use darker color for best fit line
-          color: darkerColor(index),
+          color: markerColorDark(index),
           shape: 'spline',
         },
         // use scattergl

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,10 +2889,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.7.3.tgz#664fce29ca7b95530141007f50ea147ecd510992"
-  integrity sha512-gxedmoIuBLTZv3XOPmtZz6U4NWvCgGqXuckOm7pa4YKnNjFvxsRZWy67yslA3Locol0/UtGuTp1PxUUdZZFyrw==
+"@veupathdb/components@^0.7.7":
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.7.7.tgz#ea25652b503cdae3e77d70d00601c73b3631df9d"
+  integrity sha512-a+x7m6IDm+TsKFlSU01x5Z47l1f5zEIAonTJa+HCQmhQVFGMolto3HZmIS82d4ow21P6r4Z7iW+treIrjUfvUw==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
This would address https://github.com/VEuPathDB/web-components/issues/183.

Darker color palette suggested at https://github.com/VEuPathDB/web-components/issues/183#issuecomment-903996686 is utilized. One issue is that darker colors are not that distinguishable as compared to default color palette. I have checked that the new darker color palette was correctly applied though. Please see the screenshots below. (I am asking @asizemore as well)

a) using default color palette
![scatter-before-darker-color](https://user-images.githubusercontent.com/12802305/131526840-417ac9af-c711-4cde-8d49-e2fe70a154cf.png)

b) using darker color palette
![scatter-after-darker-color](https://user-images.githubusercontent.com/12802305/131526893-ba2c9a65-d5f5-4a77-8f26-1c72eed540b9.png)
