### PR TITLE
adding units

### DIFF
--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -36,6 +36,8 @@ import { HistogramVariable } from './types';
 import { fullISODateRange, padISODateTime } from '../../utils/date-conversion';
 import { getDistribution } from './util';
 import { DistributionResponse } from '../../api/subsetting-api';
+// import axis label unit util
+import { axisLabelWithUnit } from '../../utils/axis-label-unit';
 
 type Props = {
   studyMetadata: StudyMetadata;
@@ -355,8 +357,8 @@ export function HistogramFilter(props: Props) {
           uiState={uiState}
           defaultUIState={defaultUIState}
           updateUIState={updateUIState}
-          variableName={variable.displayName}
           showSpinner={data.pending}
+          variable={variable}
         />
       </div>
     </div>
@@ -369,8 +371,7 @@ type HistogramPlotWithControlsProps = HistogramProps & {
   defaultUIState: UIState;
   updateUIState: (uiState: Partial<UIState>) => void;
   filter?: DateRangeFilter | NumberRangeFilter;
-  // add variableName for independentAxisLabel
-  variableName: string;
+  variable?: HistogramVariable;
 };
 
 function HistogramPlotWithControls({
@@ -380,8 +381,7 @@ function HistogramPlotWithControls({
   defaultUIState,
   updateUIState,
   filter,
-  // variableName for independentAxisLabel
-  variableName,
+  variable,
   ...histogramProps
 }: HistogramPlotWithControlsProps) {
   const handleBinWidthChange = useCallback(
@@ -513,7 +513,7 @@ function HistogramPlotWithControls({
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <SelectedRangeControl
-        label={`Subset on ${variableName}`}
+        label={'Subset on ' + axisLabelWithUnit(variable)}
         valueType={data?.valueType}
         selectedRange={selectedRange}
         selectedRangeBounds={selectedRangeBounds}
@@ -530,8 +530,7 @@ function HistogramPlotWithControls({
         onSelectedRangeChange={handleSelectedRangeChange}
         barLayout={barLayout}
         dependentAxisLabel="Count"
-        // add independentAxisLabel
-        independentAxisLabel={variableName}
+        independentAxisLabel={axisLabelWithUnit(variable)}
         independentAxisRange={uiState.independentAxisRange}
         dependentAxisRange={uiState.dependentAxisRange}
         dependentAxisLogScale={uiState.dependentAxisLogScale}

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -324,12 +324,12 @@ function BarplotViz(props: Props) {
                 {
                   role: 'Main',
                   required: true,
-                  display: variable?.displayName,
+                  display: axisLabelWithUnit(variable),
                   variable: vizConfig.xAxisVariable,
                 },
                 {
                   role: 'Overlay',
-                  display: overlayVariable?.displayName,
+                  display: axisLabelWithUnit(overlayVariable),
                   variable: vizConfig.overlayVariable,
                 },
               ]}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -353,18 +353,18 @@ function BoxplotViz(props: Props) {
                 {
                   role: 'X-axis',
                   required: true,
-                  display: xAxisVariable?.displayName,
+                  display: axisLabelWithUnit(xAxisVariable),
                   variable: vizConfig.xAxisVariable,
                 },
                 {
                   role: 'Y-axis',
                   required: true,
-                  display: yAxisVariable?.displayName,
+                  display: axisLabelWithUnit(yAxisVariable),
                   variable: vizConfig.yAxisVariable,
                 },
                 {
                   role: 'Overlay',
-                  display: overlayVariable?.displayName,
+                  display: axisLabelWithUnit(overlayVariable),
                   variable: vizConfig.overlayVariable,
                 },
               ]}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -345,7 +345,7 @@ function HistogramViz(props: Props) {
             data.pending ? undefined : data.value?.completeCasesAllVars
           }
           overlayVariable={vizConfig.overlayVariable}
-          overlayLabel={overlayVariable?.displayName}
+          overlayLabel={axisLabelWithUnit(overlayVariable)}
           legendTitle={overlayVariable?.displayName}
           dependentAxisLabel={
             vizConfig.valueSpec === 'count' ? 'Count' : 'Proportion'

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -370,13 +370,13 @@ function MosaicViz(props: Props) {
             {
               role: 'X-axis',
               required: true,
-              display: xAxisVariable?.displayName,
+              display: axisLabelWithUnit(xAxisVariable),
               variable: vizConfig.xAxisVariable,
             },
             {
               role: 'Y-axis',
               required: true,
-              display: yAxisVariable?.displayName,
+              display: axisLabelWithUnit(yAxisVariable),
               variable: vizConfig.yAxisVariable,
             },
           ]}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -435,18 +435,18 @@ function ScatterplotViz(props: Props) {
                 {
                   role: 'X-axis',
                   required: true,
-                  display: xAxisVariable?.displayName,
+                  display: axisLabelWithUnit(xAxisVariable),
                   variable: vizConfig.xAxisVariable,
                 },
                 {
                   role: 'Y-axis',
                   required: true,
-                  display: yAxisVariable?.displayName,
+                  display: axisLabelWithUnit(yAxisVariable),
                   variable: vizConfig.yAxisVariable,
                 },
                 {
                   role: 'Overlay',
-                  display: overlayVariable?.displayName,
+                  display: axisLabelWithUnit(overlayVariable),
                   variable: vizConfig.overlayVariable,
                 },
               ]}

--- a/src/lib/workspace/Variable.tsx
+++ b/src/lib/workspace/Variable.tsx
@@ -8,6 +8,8 @@ import {
 } from '../core';
 import { FilterContainer } from '../core/components/filter/FilterContainer';
 import { cx } from './Utils';
+// import axis label unit util
+import { axisLabelWithUnit } from '../core/utils/axis-label-unit';
 
 interface Props {
   entity: StudyEntity;
@@ -29,7 +31,7 @@ export function VariableDetails(props: Props) {
   return (
     <ErrorBoundary>
       <div>
-        <h3>{variable.displayName}</h3>
+        <h3>{axisLabelWithUnit(variable)}</h3>
         <div className={cx('-ProviderLabel')}>
           <div className={cx('-ProviderLabelPrefix')}>
             Original variable name:


### PR DESCRIPTION
This PR addresses #340, General: add units where needed on subset & visualize tabs.

A couple of screenshots are attached:

![weight1](https://user-images.githubusercontent.com/12802305/131567239-05f358f0-7f44-40fb-b46e-024ad540e9cb.png)

![scatter-unit1](https://user-images.githubusercontent.com/12802305/131567253-31a92249-dcde-4b90-b868-12af1255b1cf.png)

![histogram-unit1](https://user-images.githubusercontent.com/12802305/131567262-7645e6b3-5fb5-49c6-b025-00b1822e1602.png)
 