### PR TITLE
hide terms listed as hidden

### DIFF
--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -90,6 +90,8 @@ export function VariableTree(props: Props) {
                 ? `entity:${entity.id}`
                 : `${entity.id}/${variable.parentId}`,
           }))
+          // add condition not to include displayType === 'hidden'
+          .filter((variable) => variable.displayType !== 'hidden')
           .map(edaVariableToWdkField),
       ];
     });


### PR DESCRIPTION
Think this will address the issue #336 . Tested with `birth date` with `PRISM` and `PRISM2` data.

- before applying the fix at PRISM: searching with birth date at search bar

![PRISM-tree-birth-date-before](https://user-images.githubusercontent.com/12802305/131736341-f15a6e98-ce64-4bc3-aac5-4f040531d178.png)

- after applying the fix at PRISM

![PRISM-tree-birth-date-after](https://user-images.githubusercontent.com/12802305/131736378-f67c1e9b-dcbf-48d3-b757-f3489d25abd4.png)

- after applying the fix at PRISM2: searching with birth date at search bar

![PRISM2-tree-birth-date-after](https://user-images.githubusercontent.com/12802305/131736450-160cb225-fb31-4098-b9d8-6cf44daa427b.png)


