### PR TITLE
pass MembershipField  bar colors as props

### DIFF
--- a/src/lib/core/components/filter/TableFilter.tsx
+++ b/src/lib/core/components/filter/TableFilter.tsx
@@ -14,6 +14,7 @@ import { fromEdaFilter } from '../../utils/wdk-filter-param-adapter';
 import { TableVariable } from './types';
 import { getDistribution } from './util';
 import { DistributionResponse } from '../../api/subsetting-api';
+import { gray, red } from './colors';
 
 type Props = {
   studyMetadata: StudyMetadata;
@@ -321,6 +322,8 @@ export function TableFilter({
             onMemberChangeCurrentPage={handlePagination}
             onMemberChangeRowsPerPage={handleRowsPerPage}
             selectByDefault={false}
+            fillBarColor={gray}
+            fillFilteredBarColor={red}
             // set Heading1 prefix
             filteredCountHeadingPrefix={'Subset of'}
           />

--- a/src/lib/core/components/filter/colors.ts
+++ b/src/lib/core/components/filter/colors.ts
@@ -1,3 +1,3 @@
 export const blue = 'rgb(17 119 187)';
-export const red = '#da7272';
-export const gray = '#aaaaaa';
+export const red = '#E39C9C';
+export const gray = '#cccccc';


### PR DESCRIPTION
*Depends on WDKClient [PR #151](https://github.com/VEuPathDB/WDKClient/pull/151)*

Resolves #301 

Goal: mute the colors in the histogram and table in the subsetting tab so that they match the entity diagram.

Implementation notes: Now both the table and histogram read the `red`, `gray` colors defined in `colors.ts`. For the table, we needed to pass these two colors to the `MembershipField` component. See WDKClient PR for details on updates to this component.