### PR TITLE
Increase viz name size

### DIFF
--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -110,6 +110,7 @@
       color: #444;
       font-weight: 500;
       text-align: center;
+      font-size: 16px;
     }
   }
   &-FullScreenContainer {

--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -110,7 +110,7 @@
       color: #444;
       font-weight: 500;
       text-align: center;
-      font-size: 16px;
+      font-size: 1.2em;
     }
   }
   &-FullScreenContainer {

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -229,7 +229,14 @@ function NewVisualizationPicker(props: Props) {
                 </button>
               </Tooltip>
               <div className={cx('-PickerEntryName')}>
-                <div>{vizOverview.displayName}</div>
+                {vizOverview.displayName?.includes(', ') ? (
+                  <div>
+                    {vizOverview.displayName.split(', ')[0]} <br />{' '}
+                    {vizOverview.displayName.split(', ')[1]}
+                  </div>
+                ) : (
+                  <div>{vizOverview.displayName}</div>
+                )}
               </div>
             </div>
           );

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -231,7 +231,7 @@ function NewVisualizationPicker(props: Props) {
               <div className={cx('-PickerEntryName')}>
                 {vizOverview.displayName?.includes(', ') ? (
                   <div>
-                    {vizOverview.displayName.split(', ')[0]} <br />{' '}
+                    {vizOverview.displayName.split(', ')[0]} <br />
                     {vizOverview.displayName.split(', ')[1]}
                   </div>
                 ) : (


### PR DESCRIPTION
With data service [PR #81](https://github.com/VEuPathDB/EdaDataService/pull/81) , addresses issue #325.

This PR makes the following updates:
- In the viz display name contains a comma, split into two lines in the create a new viz view (see screenshot using updated names)
- Increase viz display name from 13pt to 16pt.

Note: The data service PR renames the vizs, this PR affects how the names are displayed. 
<img width="1765" alt="Screen Shot 2021-09-06 at 4 49 22 PM" src="https://user-images.githubusercontent.com/11710234/132259981-b3c97b7c-2d39-483b-aff8-edf89004bf38.png">
