### PR TITLE
Disable show missing data toggle when not appropriate, and don't show empty "No data" traces either

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -32,6 +32,7 @@ import { at } from 'lodash';
 import { axisLabelWithUnit } from '../../../utils/axis-label-unit';
 import {
   grayOutLastSeries,
+  omitEmptyNoDataSeries,
   vocabularyWithMissingData,
 } from '../../../utils/analysis';
 import { PlotRef } from '@veupathdb/components/lib/plots/PlotlyPlot';
@@ -204,17 +205,17 @@ function BoxplotViz(props: VisualizationProps) {
         params as BoxplotRequestParams
       );
 
-      // send visualization.type as well
-      return grayOutLastSeries(
-        reorderData(
-          boxplotResponseToData(await response),
-          xAxisVariable.vocabulary,
-          vocabularyWithMissingData(
-            overlayVariable?.vocabulary,
-            vizConfig.showMissingness
-          )
+      const showMissing = vizConfig.showMissingness && overlayVariable != null;
+      return omitEmptyNoDataSeries(
+        grayOutLastSeries(
+          reorderData(
+            boxplotResponseToData(await response),
+            xAxisVariable.vocabulary,
+            vocabularyWithMissingData(overlayVariable?.vocabulary, showMissing)
+          ),
+          showMissing
         ),
-        vizConfig.showMissingness && overlayVariable != null
+        showMissing
       );
     }, [
       studyId,
@@ -261,7 +262,11 @@ function BoxplotViz(props: VisualizationProps) {
           dataElementDependencyOrder={dataElementDependencyOrder}
           starredVariables={starredVariables}
           toggleStarredVariable={toggleStarredVariable}
-          enableShowMissingnessToggle={overlayVariable != null}
+          enableShowMissingnessToggle={
+            overlayVariable != null &&
+            data.value?.completeCasesAllVars !=
+              data.value?.completeCasesAxesVars
+          }
           showMissingness={vizConfig.showMissingness}
           onShowMissingnessChange={onShowMissingnessChange}
           outputEntity={outputEntity}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -41,6 +41,7 @@ import { axisLabelWithUnit } from '../../../utils/axis-label-unit';
 import {
   vocabularyWithMissingData,
   grayOutLastSeries,
+  omitEmptyNoDataSeries,
 } from '../../../utils/analysis';
 import { PlotRef } from '@veupathdb/components/lib/plots/PlotlyPlot';
 import { useFindEntityAndVariable } from '../../../hooks/study';
@@ -218,15 +219,16 @@ function HistogramViz(props: VisualizationProps) {
         vizConfig
       );
       const response = dataClient.getHistogram(computation.type, params);
-      return grayOutLastSeries(
-        reorderData(
-          histogramResponseToData(await response, xAxisVariable.type),
-          vocabularyWithMissingData(
-            overlayVariable?.vocabulary,
-            vizConfig.showMissingness
-          )
+      const showMissing = vizConfig.showMissingness && overlayVariable != null;
+      return omitEmptyNoDataSeries(
+        grayOutLastSeries(
+          reorderData(
+            histogramResponseToData(await response, xAxisVariable.type),
+            vocabularyWithMissingData(overlayVariable?.vocabulary, showMissing)
+          ),
+          showMissing
         ),
-        vizConfig.showMissingness && overlayVariable != null
+        showMissing
       );
     }, [
       vizConfig.xAxisVariable,
@@ -271,7 +273,11 @@ function HistogramViz(props: VisualizationProps) {
           dataElementDependencyOrder={dataElementDependencyOrder}
           starredVariables={starredVariables}
           toggleStarredVariable={toggleStarredVariable}
-          enableShowMissingnessToggle={overlayVariable != null}
+          enableShowMissingnessToggle={
+            overlayVariable != null &&
+            data.value?.completeCasesAllVars !=
+              data.value?.completeCasesAxesVars
+          }
           showMissingness={vizConfig.showMissingness}
           onShowMissingnessChange={onShowMissingnessChange}
           outputEntity={outputEntity}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -256,19 +256,16 @@ function ScatterplotViz(props: VisualizationProps) {
               params as ScatterplotRequestParams
             );
 
-      // send visualization.type, independentValueType, and dependentValueType as well
+      const showMissing = vizConfig.showMissingness && overlayVariable != null;
       return scatterplotResponseToData(
         reorderResponse(
           await response,
-          vocabularyWithMissingData(
-            overlayVariable?.vocabulary,
-            vizConfig.showMissingness
-          )
+          vocabularyWithMissingData(overlayVariable?.vocabulary, showMissing)
         ),
         visualization.type,
         independentValueType,
         dependentValueType,
-        vizConfig.showMissingness && overlayVariable != null
+        showMissing
       );
     }, [
       studyId,
@@ -645,6 +642,18 @@ function processInputData<T extends number | string>(
     }
   };
 
+  // determine conditions for not adding empty "No data" traces
+  // we want to stop at the penultimate series if showMissing is active and there is actually no missing data
+  const noMissingData =
+    dataSet.scatterplot.config.completeCasesAllVars ===
+    dataSet.scatterplot.config.completeCasesAxesVars;
+  // 'break' from the for loops (array.some(...)) if this is true
+  const breakAfterThisSeries = (index: number) => {
+    return (
+      showMissingness && noMissingData && index === plotDataSet.data.length - 2
+    );
+  };
+
   const markerSymbol = (index: number) =>
     showMissingness && index === plotDataSet.data.length - 1
       ? 'x'
@@ -654,7 +663,7 @@ function processInputData<T extends number | string>(
   let dataSetProcess: any = [];
 
   // drawing raw data (markers) at first
-  plotDataSet?.data.forEach(function (el: any, index: number) {
+  plotDataSet?.data.some(function (el: any, index: number) {
     // initialize seriesX/Y
     let seriesX = [];
     let seriesY = [];
@@ -727,11 +736,12 @@ function processInputData<T extends number | string>(
         // always use spline?
         line: { color: markerColor(index), shape: 'spline' },
       });
+      return breakAfterThisSeries(index);
     }
   });
 
   // after drawing raw data, smoothedMean and bestfitline plots are displayed
-  plotDataSet?.data.forEach(function (el: any, index: number) {
+  plotDataSet?.data.some(function (el: any, index: number) {
     // initialize variables: setting with union type for future, but this causes typescript issue in the current version
     let xIntervalLineValue: T[] = [];
     let yIntervalLineValue: number[] = [];
@@ -911,6 +921,7 @@ function processInputData<T extends number | string>(
         type: 'scattergl',
       });
     }
+    return breakAfterThisSeries(index);
   });
 
   // make some margin for y-axis range (5% of range for now)

--- a/src/lib/core/utils/analysis.ts
+++ b/src/lib/core/utils/analysis.ts
@@ -4,6 +4,7 @@ import {
   BoxplotData,
 } from '@veupathdb/components/lib/types/plots';
 import { gray } from '../components/visualizations/colors';
+import { CoverageStatistics } from '../types/visualization';
 
 export function vocabularyWithMissingData(
   vocabulary: string[] = [],
@@ -23,6 +24,20 @@ export function grayOutLastSeries<
       showMissingness && index === data.series.length - 1
         ? { ...series, color: gray }
         : series
+    ),
+  };
+}
+
+export function omitEmptyNoDataSeries<
+  T extends { series: any } & CoverageStatistics
+>(data: T, showMissingness: boolean = false) {
+  const noMissingData =
+    data.completeCasesAllVars === data.completeCasesAxesVars;
+  if (!showMissingness || !noMissingData) return data;
+  return {
+    ...data,
+    series: data.series.filter(
+      (_: any, index: number) => index !== data.series.length - 1
     ),
   };
 }


### PR DESCRIPTION
Fixes #338 

This was slightly more of a task than it seemed at first.

We only know if there is no missing data for the stratification variables AFTER the data has come back from the server.

Disabling the toggle is easy, but we also needed to remove the empty traces from the plot data.

