### PR TITLE
upgrade @veupathdb/components

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.7.8",
+    "@veupathdb/components": "^0.7.10",
     "@veupathdb/wdk-client": "^0.4.1",
     "@veupathdb/web-common": "^0.1.5",
     "debounce-promise": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2917,10 +2917,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.7.8":
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.7.8.tgz#92a3c023324aeeb1a97f6b45020b4acec3d7d806"
-  integrity sha512-jrugwW+iqQ1KElRZwuC9wvwdrduQvnt9ei2fvwXSyLReICk5ivTbTsVBIM+IYKLHv2n10Uh2uZjVe5umjz3siw==
+"@veupathdb/components@^0.7.10":
+  version "0.7.10"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.7.10.tgz#12b2df402be0e1db2d51954eae18a39bd4f5deef"
+  integrity sha512-Tyw0a1xiGBCOgwFZfXj8zO25OT6rdZe/VXsA1/E8OdT6HQpkmMZL5mOxZohws/pFmOBzjysV++EC1shA7QB9ZQ==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
The latest version of `@veupathdb/components` (via https://github.com/VEuPathDB/web-components/pull/207) addresses the recent issue described in #272.

fixes #272 
