### PR TITLE
Fixed erroneous '0' character when no stratification vars, e.g. Mosaic

### DIFF
--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -244,7 +244,8 @@ export function InputVariables(props: Props) {
               </div>
             ))}
         </div>
-        {inputs.filter((input) => input.role === 'stratification').length && (
+        {inputs.filter((input) => input.role === 'stratification').length >
+          0 && (
           <div className={classes.inputGroup}>
             <div className={classes.fullRow}>
               <h4>Stratification variables (optional)</h4>

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -396,11 +396,6 @@ function MosaicViz(props: Props) {
               label: 'Y-axis',
               role: 'primary',
             },
-            {
-              name: 'facetVariable',
-              label: 'Facet (placeholder)',
-              role: 'stratification',
-            },
           ]}
           entities={entities}
           values={{


### PR DESCRIPTION
Very trivial fix.  My JavaScript bad!