### PR TITLE
variable metadata-based independent axis range

### DIFF
--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -82,7 +82,7 @@ export function HistogramFilter(props: Props) {
 
   // compute default independent range from meta-data based util
   const defaultIndependentRange: NumberOrDateRange | undefined = useMemo(
-    () => defaultIndependentAxisRange(variable),
+    () => defaultIndependentAxisRange(variable, 'histogram'),
     [variable]
   );
 

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -42,6 +42,8 @@ import { truncationConfig } from '../../utils/truncation-config-utils';
 import Notification from '@veupathdb/components/lib/components/widgets//Notification';
 // import axis label unit util
 import { axisLabelWithUnit } from '../../utils/axis-label-unit';
+// import variable's metadata-based independent axis range utils
+import { defaultIndependentAxisRange } from '../../utils/default-independent-axis-range';
 
 type Props = {
   studyMetadata: StudyMetadata;
@@ -78,6 +80,12 @@ export function HistogramFilter(props: Props) {
   const filters = analysisState.analysis?.filters;
   const uiStateKey = `${entity.id}/${variable.id}`;
 
+  // compute default independent range from meta-data based util
+  const defaultIndependentRange: NumberOrDateRange | undefined = useMemo(
+    () => defaultIndependentAxisRange(variable),
+    [variable]
+  );
+
   // get as much default UI state from variable annotations as possible
   const defaultUIState: UIState = useMemo(() => {
     const otherDefaults = {
@@ -88,10 +96,7 @@ export function HistogramFilter(props: Props) {
       return {
         binWidth: variable.binWidthOverride ?? variable.binWidth ?? 0.1,
         binWidthTimeUnit: undefined,
-        independentAxisRange:
-          variable.displayRangeMin != null && variable.displayRangeMax != null
-            ? { min: variable.displayRangeMin, max: variable.displayRangeMax }
-            : { min: Math.min(0, variable.rangeMin), max: variable.rangeMax },
+        independentAxisRange: defaultIndependentRange as NumberRange,
         ...otherDefaults,
       };
 
@@ -102,17 +107,7 @@ export function HistogramFilter(props: Props) {
     return {
       binWidth: binWidth ?? 1,
       binWidthTimeUnit: binUnits ?? variable.binUnits!, // bit nasty!
-      independentAxisRange:
-        // use Zulu time here to be consistent with uiState.independentAxisRange
-        variable.displayRangeMin != null && variable.displayRangeMax != null
-          ? {
-              min: variable.displayRangeMin + 'T00:00:00Z',
-              max: variable.displayRangeMax + 'T00:00:00Z',
-            }
-          : {
-              min: variable.rangeMin + 'T00:00:00Z',
-              max: variable.rangeMax + 'T00:00:00Z',
-            },
+      independentAxisRange: defaultIndependentRange as DateRange,
       ...otherDefaults,
     };
   }, [variable]);

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -251,21 +251,9 @@ function HistogramViz(props: VisualizationProps) {
   );
 
   // variable's metadata-based independent axis range with margin
-  const defaultIndependentRange = defaultIndependentAxisRange(xAxisVariable);
-  const independentAxisRange = useMemo(
-    () =>
-      defaultIndependentRange && defaultIndependentRange != null
-        ? xAxisVariable?.type === 'date'
-          ? {
-              min: defaultIndependentRange.min as string,
-              max: defaultIndependentRange.max as string,
-            }
-          : {
-              min: defaultIndependentRange.min as number,
-              max: defaultIndependentRange.max as number,
-            }
-        : undefined,
-    [xAxisVariable, defaultIndependentRange]
+  const defaultIndependentRange = useMemo(
+    () => defaultIndependentAxisRange(xAxisVariable),
+    [xAxisVariable]
   );
 
   return (
@@ -345,8 +333,8 @@ function HistogramViz(props: VisualizationProps) {
         outputEntity={outputEntity}
         independentAxisVariable={vizConfig.xAxisVariable}
         independentAxisLabel={axisLabelWithUnit(xAxisVariable) ?? 'Main'}
-        // variable's metadata-based independent axis range with margin
-        independentAxisRange={independentAxisRange}
+        // variable's metadata-based independent axis range
+        independentAxisRange={defaultIndependentRange}
         interactive
         showSpinner={data.pending}
         filters={filters}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -252,6 +252,21 @@ function HistogramViz(props: VisualizationProps) {
 
   // variable's metadata-based independent axis range with margin
   const defaultIndependentRange = defaultIndependentAxisRange(xAxisVariable);
+  const independentAxisRange = useMemo(
+    () =>
+      defaultIndependentRange && defaultIndependentRange != null
+        ? xAxisVariable?.type === 'date'
+          ? {
+              min: defaultIndependentRange.min as string,
+              max: defaultIndependentRange.max as string,
+            }
+          : {
+              min: defaultIndependentRange.min as number,
+              max: defaultIndependentRange.max as number,
+            }
+        : undefined,
+    [xAxisVariable, defaultIndependentRange]
+  );
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -331,19 +346,7 @@ function HistogramViz(props: VisualizationProps) {
         independentAxisVariable={vizConfig.xAxisVariable}
         independentAxisLabel={axisLabelWithUnit(xAxisVariable) ?? 'Main'}
         // variable's metadata-based independent axis range with margin
-        independentAxisRange={
-          defaultIndependentRange && defaultIndependentRange != null
-            ? xAxisVariable?.type === 'date'
-              ? {
-                  min: defaultIndependentRange.min as string,
-                  max: defaultIndependentRange.max as string,
-                }
-              : {
-                  min: defaultIndependentRange.min as number,
-                  max: defaultIndependentRange.max as number,
-                }
-            : undefined
-        }
+        independentAxisRange={independentAxisRange}
         interactive
         showSpinner={data.pending}
         filters={filters}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -46,6 +46,8 @@ import {
 } from '../../../utils/analysis';
 import { PlotRef } from '@veupathdb/components/lib/plots/PlotlyPlot';
 import { useFindEntityAndVariable } from '../../../hooks/study';
+// import variable's metadata-based independent axis range utils
+import { defaultIndependentAxisRange } from '../../../utils/default-independent-axis-range';
 
 type HistogramDataWithCoverageStatistics = HistogramData & CoverageStatistics;
 
@@ -248,6 +250,9 @@ function HistogramViz(props: VisualizationProps) {
     ])
   );
 
+  // variable's metadata-based independent axis range with margin
+  const defaultIndependentRange = defaultIndependentAxisRange(xAxisVariable);
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
@@ -325,6 +330,20 @@ function HistogramViz(props: VisualizationProps) {
         outputEntity={outputEntity}
         independentAxisVariable={vizConfig.xAxisVariable}
         independentAxisLabel={axisLabelWithUnit(xAxisVariable) ?? 'Main'}
+        // variable's metadata-based independent axis range with margin
+        independentAxisRange={
+          defaultIndependentRange && defaultIndependentRange != null
+            ? xAxisVariable?.type === 'date'
+              ? {
+                  min: defaultIndependentRange.min as string,
+                  max: defaultIndependentRange.max as string,
+                }
+              : {
+                  min: defaultIndependentRange.min as number,
+                  max: defaultIndependentRange.max as number,
+                }
+            : undefined
+        }
         interactive
         showSpinner={data.pending}
         filters={filters}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -252,7 +252,7 @@ function HistogramViz(props: VisualizationProps) {
 
   // variable's metadata-based independent axis range with margin
   const defaultIndependentRange = useMemo(
-    () => defaultIndependentAxisRange(xAxisVariable),
+    () => defaultIndependentAxisRange(xAxisVariable, 'histogram'),
     [xAxisVariable]
   );
 

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -291,7 +291,10 @@ function ScatterplotViz(props: VisualizationProps) {
 
   // variable's metadata-based independent axis range with margin
   const defaultIndependentRangeMargin = useMemo(() => {
-    const defaultIndependentRange = defaultIndependentAxisRange(xAxisVariable);
+    const defaultIndependentRange = defaultIndependentAxisRange(
+      xAxisVariable,
+      'scatterplot'
+    );
     return independentAxisRangeMargin(
       defaultIndependentRange,
       xAxisVariable?.type

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -57,6 +57,9 @@ import {
   ColorPaletteDefault,
   ColorPaletteDark,
 } from '@veupathdb/components/lib/types/plots/addOns';
+// import variable's metadata-based independent axis range utils
+import { defaultIndependentAxisRange } from '../../../utils/default-independent-axis-range';
+import { independentAxisRangeMargin } from '../../../utils/independent-axis-range-margin';
 
 const plotDimensions = {
   width: 750,
@@ -286,6 +289,13 @@ function ScatterplotViz(props: VisualizationProps) {
       ? data.value?.completeCasesAllVars
       : data.value?.completeCasesAxesVars;
 
+  // variable's metadata-based independent axis range with margin
+  const defaultIndependentRange = defaultIndependentAxisRange(xAxisVariable);
+  const defaultIndependentRangeMargin = independentAxisRangeMargin(
+    defaultIndependentRange,
+    xAxisVariable?.type
+  );
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
@@ -371,6 +381,21 @@ function ScatterplotViz(props: VisualizationProps) {
           }
           independentAxisLabel={axisLabelWithUnit(xAxisVariable) ?? 'X-Axis'}
           dependentAxisLabel={axisLabelWithUnit(yAxisVariable) ?? 'Y-Axis'}
+          // variable's metadata-based independent axis range with margin
+          independentAxisRange={
+            defaultIndependentRangeMargin &&
+            defaultIndependentRangeMargin != null
+              ? xAxisVariable?.type === 'date'
+                ? {
+                    min: defaultIndependentRangeMargin.min as string,
+                    max: defaultIndependentRangeMargin.max as string,
+                  }
+                : {
+                    min: defaultIndependentRangeMargin.min as number,
+                    max: defaultIndependentRangeMargin.max as number,
+                  }
+              : undefined
+          }
           dependentAxisRange={
             data.value && !data.pending
               ? { min: data.value.yMin, max: data.value.yMax }

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -290,26 +290,13 @@ function ScatterplotViz(props: VisualizationProps) {
       : data.value?.completeCasesAxesVars;
 
   // variable's metadata-based independent axis range with margin
-  const defaultIndependentRange = defaultIndependentAxisRange(xAxisVariable);
-  const defaultIndependentRangeMargin = independentAxisRangeMargin(
-    defaultIndependentRange,
-    xAxisVariable?.type
-  );
-  const independentAxisRange = useMemo(
-    () =>
-      defaultIndependentRangeMargin && defaultIndependentRangeMargin != null
-        ? xAxisVariable?.type === 'date'
-          ? {
-              min: defaultIndependentRangeMargin.min as string,
-              max: defaultIndependentRangeMargin.max as string,
-            }
-          : {
-              min: defaultIndependentRangeMargin.min as number,
-              max: defaultIndependentRangeMargin.max as number,
-            }
-        : undefined,
-    [xAxisVariable, defaultIndependentRangeMargin]
-  );
+  const defaultIndependentRangeMargin = useMemo(() => {
+    const defaultIndependentRange = defaultIndependentAxisRange(xAxisVariable);
+    return independentAxisRangeMargin(
+      defaultIndependentRange,
+      xAxisVariable?.type
+    );
+  }, [xAxisVariable]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -397,7 +384,7 @@ function ScatterplotViz(props: VisualizationProps) {
           independentAxisLabel={axisLabelWithUnit(xAxisVariable) ?? 'X-Axis'}
           dependentAxisLabel={axisLabelWithUnit(yAxisVariable) ?? 'Y-Axis'}
           // variable's metadata-based independent axis range with margin
-          independentAxisRange={independentAxisRange}
+          independentAxisRange={defaultIndependentRangeMargin}
           dependentAxisRange={
             data.value && !data.pending
               ? { min: data.value.yMin, max: data.value.yMax }

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -295,6 +295,21 @@ function ScatterplotViz(props: VisualizationProps) {
     defaultIndependentRange,
     xAxisVariable?.type
   );
+  const independentAxisRange = useMemo(
+    () =>
+      defaultIndependentRangeMargin && defaultIndependentRangeMargin != null
+        ? xAxisVariable?.type === 'date'
+          ? {
+              min: defaultIndependentRangeMargin.min as string,
+              max: defaultIndependentRangeMargin.max as string,
+            }
+          : {
+              min: defaultIndependentRangeMargin.min as number,
+              max: defaultIndependentRangeMargin.max as number,
+            }
+        : undefined,
+    [xAxisVariable, defaultIndependentRangeMargin]
+  );
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -382,20 +397,7 @@ function ScatterplotViz(props: VisualizationProps) {
           independentAxisLabel={axisLabelWithUnit(xAxisVariable) ?? 'X-Axis'}
           dependentAxisLabel={axisLabelWithUnit(yAxisVariable) ?? 'Y-Axis'}
           // variable's metadata-based independent axis range with margin
-          independentAxisRange={
-            defaultIndependentRangeMargin &&
-            defaultIndependentRangeMargin != null
-              ? xAxisVariable?.type === 'date'
-                ? {
-                    min: defaultIndependentRangeMargin.min as string,
-                    max: defaultIndependentRangeMargin.max as string,
-                  }
-                : {
-                    min: defaultIndependentRangeMargin.min as number,
-                    max: defaultIndependentRangeMargin.max as number,
-                  }
-              : undefined
-          }
+          independentAxisRange={independentAxisRange}
           dependentAxisRange={
             data.value && !data.pending
               ? { min: data.value.yMin, max: data.value.yMax }

--- a/src/lib/core/utils/default-independent-axis-range.ts
+++ b/src/lib/core/utils/default-independent-axis-range.ts
@@ -1,0 +1,26 @@
+import { Variable } from '../types/study';
+import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
+
+export function defaultIndependentAxisRange(
+  variable: Variable | undefined
+): NumberOrDateRange | undefined {
+  if (variable != null && variable.dataShape === 'continuous') {
+    if (variable.type === 'number') {
+      return variable.displayRangeMin != null &&
+        variable.displayRangeMax != null
+        ? { min: variable.displayRangeMin, max: variable.displayRangeMax }
+        : { min: Math.min(0, variable.rangeMin), max: variable.rangeMax };
+    } else if (variable.type === 'date') {
+      return variable.displayRangeMin != null &&
+        variable.displayRangeMax != null
+        ? {
+            min: variable.displayRangeMin + 'T00:00:00Z',
+            max: variable.displayRangeMax + 'T00:00:00Z',
+          }
+        : {
+            min: variable.rangeMin + 'T00:00:00Z',
+            max: variable.rangeMax + 'T00:00:00Z',
+          };
+    }
+  } else return undefined;
+}

--- a/src/lib/core/utils/default-independent-axis-range.ts
+++ b/src/lib/core/utils/default-independent-axis-range.ts
@@ -4,18 +4,34 @@ import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
 export function defaultIndependentAxisRange(
   variable: Variable | undefined
 ): NumberOrDateRange | undefined {
+  // make universal range variable
   if (variable != null && variable.dataShape === 'continuous') {
     if (variable.type === 'number') {
       return variable.displayRangeMin != null &&
         variable.displayRangeMax != null
-        ? { min: variable.displayRangeMin, max: variable.displayRangeMax }
+        ? {
+            min: Math.min(variable.displayRangeMin, variable.rangeMax),
+            max: Math.max(variable.displayRangeMax, variable.rangeMax),
+          }
         : { min: Math.min(0, variable.rangeMin), max: variable.rangeMax };
     } else if (variable.type === 'date') {
       return variable.displayRangeMin != null &&
         variable.displayRangeMax != null
         ? {
-            min: variable.displayRangeMin + 'T00:00:00Z',
-            max: variable.displayRangeMax + 'T00:00:00Z',
+            min:
+              [variable.displayRangeMin, variable.rangeMin].reduce(function (
+                a,
+                b
+              ) {
+                return a < b ? a : b;
+              }) + 'T00:00:00Z',
+            max:
+              [variable.displayRangeMax, variable.rangeMax].reduce(function (
+                a,
+                b
+              ) {
+                return a > b ? a : b;
+              }) + 'T00:00:00Z',
           }
         : {
             min: variable.rangeMin + 'T00:00:00Z',

--- a/src/lib/core/utils/default-independent-axis-range.ts
+++ b/src/lib/core/utils/default-independent-axis-range.ts
@@ -2,7 +2,8 @@ import { Variable } from '../types/study';
 import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
 
 export function defaultIndependentAxisRange(
-  variable: Variable | undefined
+  variable: Variable | undefined,
+  plotName: string
 ): NumberOrDateRange | undefined {
   // make universal range variable
   if (variable != null && variable.dataShape === 'continuous') {
@@ -13,7 +14,14 @@ export function defaultIndependentAxisRange(
             min: Math.min(variable.displayRangeMin, variable.rangeMax),
             max: Math.max(variable.displayRangeMax, variable.rangeMax),
           }
-        : { min: Math.min(0, variable.rangeMin), max: variable.rangeMax };
+        : {
+            // separate histogram following the criterion at histogram filter
+            min:
+              plotName === 'histogram'
+                ? Math.min(0, variable.rangeMin)
+                : variable.rangeMin,
+            max: variable.rangeMax,
+          };
     } else if (variable.type === 'date') {
       return variable.displayRangeMin != null &&
         variable.displayRangeMax != null

--- a/src/lib/core/utils/independent-axis-range-margin.ts
+++ b/src/lib/core/utils/independent-axis-range-margin.ts
@@ -1,0 +1,45 @@
+import * as DateMath from 'date-arithmetic';
+import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
+
+export function independentAxisRangeMargin(
+  axisRange?: NumberOrDateRange | undefined,
+  valueType?: string | undefined
+): NumberOrDateRange | undefined {
+  // compute truncated axis with 5 % area from the range of min and max
+  if (valueType != null && valueType === 'date') {
+    // find date diff (days) between range.min and range.max, take 5 % of range, and round up!
+    const dateRangeDiff = Math.round(
+      DateMath.diff(
+        new Date(axisRange?.min as string),
+        new Date(axisRange?.max as string),
+        'day'
+      ) * 0.05
+    ); // unit in days
+
+    const axisLowerExtensionStart = DateMath.subtract(
+      new Date(axisRange?.min as string),
+      dateRangeDiff,
+      'day'
+    ).toISOString();
+    const axisUpperExtensionEnd = DateMath.add(
+      new Date(axisRange?.max as string),
+      dateRangeDiff,
+      'day'
+    ).toISOString();
+
+    return {
+      min: axisLowerExtensionStart,
+      max: axisUpperExtensionEnd,
+    };
+  } else {
+    const axisLowerExtensionStart =
+      (axisRange?.min as number) * 1.05 - (axisRange?.max as number) * 0.05;
+    const axisUpperExtensionEnd =
+      (axisRange?.max as number) * 1.05 - (axisRange?.min as number) * 0.05;
+
+    return {
+      min: axisLowerExtensionStart,
+      max: axisUpperExtensionEnd,
+    };
+  }
+}


### PR DESCRIPTION
This is for visualization plots, especially histogram and scatter/line plots: continuous data. Now, they use variable's metadata-based independent axis range: either displayRangeMin/Man or rangeMin/Max defined at each variable. That is, regardless of filtering, deselection by legend item click, etc., the independent axis range remains the same. Both numeric and date type are handled. Note that for scatter plot, additional 5% margin (like its y-axis range) is added to prevent from marker clipping at boundaries. To this end, I have introduced a function, independentAxisRangeMargin: this may only be used for Scatter plot but just made it as a util function for now.

Here are several screenshots I have captured: Before = no specific axis range; After = after setting axis range

- Histogram at Browse and Subset: Histogram filter plot (for comparison purpose with Histogram viz)
![histogramfilter-displayRange](https://user-images.githubusercontent.com/12802305/132718671-29bc654f-9c85-47ee-8303-7046ba4fe80a.png)

- Histogram visualization: now it is almost identical range with Histogram filter plot. Some differences in tick labels are probably due to the difference in plot size each other
![histogramViz-enrollmentDate](https://user-images.githubusercontent.com/12802305/132718733-e2c3cc6e-694a-45a9-aa42-01527ceb4215.png)

- Scatter plot number type: Before
![scatter-old-range1](https://user-images.githubusercontent.com/12802305/132718918-1f3522c3-f350-4add-bb93-f78d8608e46a.png)

- Scatter plot number type: After - some legend item was disabled by clicking it in order to show no changes at independent axis range
![scatter-new-range1](https://user-images.githubusercontent.com/12802305/132718955-3d278905-0a55-4837-a92a-0e642bdd587d.png)

- Scatter plot date type: Before
![scatter-date-old-range1](https://user-images.githubusercontent.com/12802305/132719167-4562fdac-9c72-4acd-acf1-fe1661163dec.png)

- Scatter plot date type: After - not that obvious but the upper bounds are slightly different each other: this shows slightly higher upper bound regardless of legend filtering
![scatter-date-new-range1](https://user-images.githubusercontent.com/12802305/132719176-835a5219-c0ef-4577-82b2-e230c586ffbd.png)
