### PR TITLE
multifilter assign colors to distribution bars

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
     "@veupathdb/components": "^0.7.12",
-    "@veupathdb/wdk-client": "^0.4.3",
+    "@veupathdb/wdk-client": "^0.4.4",
     "@veupathdb/web-common": "^0.1.5",
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/filter/MultiFilter.tsx
+++ b/src/lib/core/components/filter/MultiFilter.tsx
@@ -30,6 +30,7 @@ import {
   isFilterField,
   isMulti,
 } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/AttributeFilterUtils';
+import { gray, red } from './colors';
 
 export interface Props {
   analysisState: AnalysisState;
@@ -338,6 +339,8 @@ export function MultiFilter(props: Props) {
         onFiltersChange={handleFiltereChange}
         onMemberSort={onMemberSort}
         onMemberSearch={onMemberSearch}
+        fillBarColor={gray}
+        fillFilteredBarColor={red}
       />
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3013,10 +3013,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/tsconfig/-/tsconfig-1.0.1.tgz#a2b748b46838af1337ca9f23d969993fb952def4"
   integrity sha512-i6gq7mgnyEN8/xW5EaI9RiWCwS1oB8cgWqx9h5w4vZtnb10oiyyepD640l9x/gZf6IWecjynRs7weDgSRs7l0Q==
 
-"@veupathdb/wdk-client@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.4.3.tgz#28773bc0b76956366bc429d24a73ca587f42b3f8"
-  integrity sha512-wlD/Laxom2KTAywUQkhQCzd32tHGofJ07DVy+679CdTR7FGrDBVHcCo6Jn6TXkjSdUDpamK9el/+LBWPLJad0g==
+"@veupathdb/wdk-client@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.4.4.tgz#357e9bad6c82250acf251bdc873c39379905e482"
+  integrity sha512-PvF2YsRVTyI+D+8EsHGyILpM5tCJMcPeOvqIraVKl1WzaPD6cC+pxT+zgQqkyUC1xoyYpAD+st4BVfS/M/uE9Q==
   dependencies:
     "@types/datatables.net" "^1.10.5"
     "@types/flot" "^0.0.31"


### PR DESCRIPTION
With WDKClient [PR #153](https://github.com/VEuPathDB/WDKClient/pull/153) , specifies colors for the stacked bars in multifilter subsetting tab table. 

Previous PR #377  updated the above for numeric and categorical variables, but not for multifilter. See also issue #301 for more details.