### PR TITLE
update analysisCache when an analysis is saved

### DIFF
--- a/src/lib/core/hooks/analysis.ts
+++ b/src/lib/core/hooks/analysis.ts
@@ -118,6 +118,7 @@ export function useAnalysis(analysisId: string): AnalysisState {
     if (analysis == null)
       throw new Error("Attempt to save an analysis that hasn't been loaded.");
     await analysisClient.updateAnalysis(analysis);
+    analysisCache[analysis.id] = analysis;
     setHasUnsavedChanges(false);
   }, [analysisClient, analysis]);
 


### PR DESCRIPTION
An in-memory cache was recently added for analyses, to prevent excessive requests for analysis objects. The cache was not being updated when an analysis is saved, which would cause changes to be lost if a user navigated between pages on the website.

This PR ensures the cached analysis is updated when saved.

fixes #366
fixes #331