### PR TITLE
"Quantized" P-value formatting

### DIFF
--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -31,6 +31,7 @@ import Tabs from '@veupathdb/components/lib/components/Tabs';
 // import axis label unit util
 import { axisLabelWithUnit } from '../../../utils/axis-label-unit';
 import { PlotRef } from '@veupathdb/components/lib/plots/PlotlyPlot';
+import { quantizePvalue } from '../../../utils/analysis';
 
 const plotDimensions = {
   width: 750,
@@ -258,7 +259,11 @@ function MosaicViz(props: Props) {
             </tr>
             <tr>
               <th>P-value</th>
-              <td>{twoByTwoData?.pValue ?? 'N/A'}</td>
+              <td>
+                {twoByTwoData?.pValue != null
+                  ? quantizePvalue(twoByTwoData.pValue)
+                  : 'N/A'}
+              </td>
               <td>N/A</td>
             </tr>
             <tr>
@@ -284,7 +289,11 @@ function MosaicViz(props: Props) {
           <tbody>
             <tr>
               <th>P-value</th>
-              <td>{contTableData?.pValue ?? 'N/A'}</td>
+              <td>
+                {contTableData?.pValue != null
+                  ? quantizePvalue(contTableData.pValue)
+                  : 'N/A'}
+              </td>
             </tr>
             <tr>
               <th>Degrees of freedom</th>

--- a/src/lib/core/utils/analysis.ts
+++ b/src/lib/core/utils/analysis.ts
@@ -41,3 +41,22 @@ export function omitEmptyNoDataSeries<
     ),
   };
 }
+
+/**
+ * Convert pvalue number into '< 0.001' or '< 0.01' or single digit precision string.
+ *
+ * If provided a string, just return the string, no questions asked.
+ *
+ */
+
+export function quantizePvalue(pvalue: number | string): string {
+  if (typeof pvalue === 'string') {
+    return pvalue;
+  } else if (pvalue < 0.001) {
+    return '< 0.001';
+  } else if (pvalue < 0.01) {
+    return '< 0.01';
+  } else {
+    return pvalue.toPrecision(1);
+  }
+}


### PR DESCRIPTION
Fixes #410 

Ready for code review.

Question for @chowington and @d-callan 
I notice in the [client's data-api](https://github.com/VEuPathDB/web-eda/blob/main/src/lib/core/api/data-api.ts#L365), that the expected type for pvalue responses from the back end is `number | string` - I can't find any information about why/when it might return a string.  In my tests it has always been a number. I've kept the option of a string response, but the new quantize function will not attempt to process a string value - and it will be displayed to the user as-is.  Is this satisfactory, or should we update the client's data-api rules (to number-only)?

![image](https://user-images.githubusercontent.com/308639/133083586-aabe72b2-9b80-4557-9a93-f4f0392c6981.png)
