### PR TITLE
Fix logic for constraining variables based on dataElementDependencyOrder

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -41,6 +41,7 @@ import {
   vocabularyWithMissingData,
 } from '../../../utils/analysis';
 import { PlotRef } from '@veupathdb/components/lib/plots/PlotlyPlot';
+import { VariablesByInputName } from '../../../utils/data-element-constraints';
 
 const plotDimensions = {
   height: 450,
@@ -125,13 +126,12 @@ function BarplotViz(props: VisualizationProps) {
 
   // TODO Handle facetVariable
   const handleInputVariableChange = useCallback(
-    (
-      values: Record<
-        string,
-        { entityId: string; variableId: string } | undefined
-      >
-    ) => {
-      const { xAxisVariable, overlayVariable, facetVariable } = values;
+    (selectedVariables: VariablesByInputName) => {
+      const {
+        xAxisVariable,
+        overlayVariable,
+        facetVariable,
+      } = selectedVariables;
       updateVizConfig({
         xAxisVariable,
         overlayVariable,
@@ -235,7 +235,7 @@ function BarplotViz(props: VisualizationProps) {
             },
           ]}
           entities={entities}
-          values={{
+          selectedVariables={{
             xAxisVariable: vizConfig.xAxisVariable,
             overlayVariable: vizConfig.overlayVariable,
             facetVariable: vizConfig.facetVariable,

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -37,6 +37,7 @@ import {
   vocabularyWithMissingData,
 } from '../../../utils/analysis';
 import { PlotRef } from '@veupathdb/components/lib/plots/PlotlyPlot';
+import { VariablesByInputName } from '../../../utils/data-element-constraints';
 
 interface PromiseBoxplotData extends CoverageStatistics {
   series: BoxplotData;
@@ -114,18 +115,13 @@ function BoxplotViz(props: VisualizationProps) {
 
   // TODO Handle facetVariable
   const handleInputVariableChange = useCallback(
-    (
-      values: Record<
-        string,
-        { entityId: string; variableId: string } | undefined
-      >
-    ) => {
+    (selectedVariables: VariablesByInputName) => {
       const {
         xAxisVariable,
         yAxisVariable,
         overlayVariable,
         facetVariable,
-      } = values;
+      } = selectedVariables;
       updateVizConfig({
         xAxisVariable,
         yAxisVariable,
@@ -258,7 +254,7 @@ function BoxplotViz(props: VisualizationProps) {
             },
           ]}
           entities={entities}
-          values={{
+          selectedVariables={{
             xAxisVariable: vizConfig.xAxisVariable,
             yAxisVariable: vizConfig.yAxisVariable,
             overlayVariable: vizConfig.overlayVariable,

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -48,6 +48,7 @@ import { PlotRef } from '@veupathdb/components/lib/plots/PlotlyPlot';
 import { useFindEntityAndVariable } from '../../../hooks/study';
 // import variable's metadata-based independent axis range utils
 import { defaultIndependentAxisRange } from '../../../utils/default-independent-axis-range';
+import { VariablesByInputName } from '../../../utils/data-element-constraints';
 
 type HistogramDataWithCoverageStatistics = HistogramData & CoverageStatistics;
 
@@ -136,13 +137,12 @@ function HistogramViz(props: VisualizationProps) {
 
   // TODO Handle facetVariable
   const handleInputVariableChange = useCallback(
-    (
-      values: Record<
-        string,
-        { entityId: string; variableId: string } | undefined
-      >
-    ) => {
-      const { xAxisVariable, overlayVariable, facetVariable } = values;
+    (selectedVariables: VariablesByInputName) => {
+      const {
+        xAxisVariable,
+        overlayVariable,
+        facetVariable,
+      } = selectedVariables;
       const keepBin = isEqual(xAxisVariable, vizConfig.xAxisVariable);
       updateVizConfig({
         xAxisVariable,
@@ -273,7 +273,7 @@ function HistogramViz(props: VisualizationProps) {
             },
           ]}
           entities={entities}
-          values={{
+          selectedVariables={{
             xAxisVariable: vizConfig.xAxisVariable,
             overlayVariable: vizConfig.overlayVariable,
           }}

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -32,6 +32,7 @@ import Tabs from '@veupathdb/components/lib/components/Tabs';
 import { axisLabelWithUnit } from '../../../utils/axis-label-unit';
 import { PlotRef } from '@veupathdb/components/lib/plots/PlotlyPlot';
 import { quantizePvalue } from '../../../utils/analysis';
+import { VariablesByInputName } from '../../../utils/data-element-constraints';
 
 const plotDimensions = {
   width: 750,
@@ -152,13 +153,8 @@ function MosaicViz(props: Props) {
 
   // TODO Handle facetVariable
   const handleInputVariableChange = useCallback(
-    (
-      values: Record<
-        string,
-        { entityId: string; variableId: string } | undefined
-      >
-    ) => {
-      const { xAxisVariable, yAxisVariable, facetVariable } = values;
+    (selectedVariables: VariablesByInputName) => {
+      const { xAxisVariable, yAxisVariable, facetVariable } = selectedVariables;
 
       updateVizConfig({
         xAxisVariable,
@@ -407,7 +403,7 @@ function MosaicViz(props: Props) {
             },
           ]}
           entities={entities}
-          values={{
+          selectedVariables={{
             xAxisVariable: vizConfig.xAxisVariable,
             yAxisVariable: vizConfig.yAxisVariable,
           }}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -60,6 +60,7 @@ import {
 // import variable's metadata-based independent axis range utils
 import { defaultIndependentAxisRange } from '../../../utils/default-independent-axis-range';
 import { independentAxisRangeMargin } from '../../../utils/independent-axis-range-margin';
+import { VariablesByInputName } from '../../../utils/data-element-constraints';
 
 const plotDimensions = {
   width: 750,
@@ -170,18 +171,13 @@ function ScatterplotViz(props: VisualizationProps) {
 
   // TODO Handle facetVariable
   const handleInputVariableChange = useCallback(
-    (
-      values: Record<
-        string,
-        { entityId: string; variableId: string } | undefined
-      >
-    ) => {
+    (selectedVariables: VariablesByInputName) => {
       const {
         xAxisVariable,
         yAxisVariable,
         overlayVariable,
         facetVariable,
-      } = values;
+      } = selectedVariables;
       updateVizConfig({
         xAxisVariable,
         yAxisVariable,
@@ -323,7 +319,7 @@ function ScatterplotViz(props: VisualizationProps) {
             },
           ]}
           entities={entities}
-          values={{
+          selectedVariables={{
             xAxisVariable: vizConfig.xAxisVariable,
             yAxisVariable: vizConfig.yAxisVariable,
             overlayVariable: vizConfig.overlayVariable,

--- a/src/lib/core/utils/data-element-constraints.ts
+++ b/src/lib/core/utils/data-element-constraints.ts
@@ -78,7 +78,7 @@ function variableConstraintPredicate(
   );
 }
 
-export type ValueByInputName = Partial<Record<string, VariableDescriptor>>;
+export type VariablesByInputName = Partial<Record<string, VariableDescriptor>>;
 export type DataElementConstraintRecord = Record<string, DataElementConstraint>;
 
 /**
@@ -104,14 +104,14 @@ export type DataElementConstraintRecord = Record<string, DataElementConstraint>;
  *
  */
 export function flattenConstraints(
-  values: ValueByInputName,
+  variables: VariablesByInputName,
   entities: StudyEntity[],
   constraints: DataElementConstraintRecord[]
 ): DataElementConstraintRecord {
   // Find all compatible constraints
   const compatibleConstraints = constraints.filter((constraintRecord) =>
     Object.entries(constraintRecord).every(([variableName, constraint]) => {
-      const value = values[variableName];
+      const value = variables[variableName];
       // If a value (variable) has not been user-selected for this constraint, then it is considered to be "in-play"
       if (value == null) return true;
       // If a constraint does not declare shapes or types and it allows multivalued variables, then any value is allowed, thus the constraint is "in-play"


### PR DESCRIPTION
The previous logic used was incorrect. Entities were not properly excluded based on ancestor lineage. The comments were also a bit off. This PR fixes the logic and comments. 

fixes #318