### PR TITLE
updating web-component version for long axis tick label work

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.7.16",
+    "@veupathdb/components": "^0.7.17",
     "@veupathdb/wdk-client": "^0.4.4",
     "@veupathdb/web-common": "^0.1.6",
     "debounce-promise": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2952,10 +2952,10 @@
     react-transition-group "^4.4.1"
     shape2geohash "^1.2.5"
 
-"@veupathdb/components@^0.7.16":
-  version "0.7.16"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.7.16.tgz#3cc4e0fcb02d07b04e2e9a6cac9343ca12236108"
-  integrity sha512-5kZmALfh/podjhSlwlBvUKF4ggJ8fxDa+FUqHxhJl0iAd0mzDq7lR95o37UbF+M+aNzHRabkyBWtoejpi8qgpw==
+"@veupathdb/components@^0.7.17":
+  version "0.7.17"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.7.17.tgz#310ed56375efbc9a2a7b7173be01780ab51cf890"
+  integrity sha512-Q8BCQJMC7PifeDiVR5q6AdwVECXuRcGE0uJg5dp25FZgM8aAuaNWztu6qgtQ9XD23TtAFNRBWxPnAs/0mletvA==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
This PR is for updating web-component version for [the long axis tick label work](https://github.com/VEuPathDB/web-components/pull/211). Accordingly, this does not need to be reviewed so I will merge this PR immediately.