### PR TITLE
adding axis range for both X/Y axis at Scatter plot

### DIFF
--- a/src/lib/core/utils/axis-range-margin.ts
+++ b/src/lib/core/utils/axis-range-margin.ts
@@ -1,7 +1,7 @@
 import * as DateMath from 'date-arithmetic';
 import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
 
-export function independentAxisRangeMargin(
+export function axisRangeMargin(
   axisRange?: NumberOrDateRange | undefined,
   valueType?: string | undefined
 ): NumberOrDateRange | undefined {

--- a/src/lib/core/utils/default-dependent-axis-range.ts
+++ b/src/lib/core/utils/default-dependent-axis-range.ts
@@ -1,0 +1,98 @@
+import { Variable } from '../types/study';
+import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
+
+export function defaultDependentAxisRange(
+  variable: Variable | undefined,
+  plotName: string,
+  // yMinMaxRange: NumberOrDateRange | undefined,
+  yMinMaxRange:
+    | { min: number | string | undefined; max: number | string | undefined }
+    | undefined
+): NumberOrDateRange | undefined {
+  // make universal range variable
+  if (variable != null && variable.dataShape === 'continuous') {
+    if (variable.type === 'number') {
+      return variable.displayRangeMin != null &&
+        variable.displayRangeMax != null
+        ? {
+            min:
+              yMinMaxRange != null
+                ? Math.min(
+                    variable.displayRangeMin,
+                    variable.rangeMin,
+                    yMinMaxRange.min as number
+                  )
+                : Math.min(variable.displayRangeMin, variable.rangeMin),
+            max:
+              yMinMaxRange != null
+                ? Math.max(
+                    variable.displayRangeMax,
+                    variable.rangeMax,
+                    yMinMaxRange.max as number
+                  )
+                : Math.max(variable.displayRangeMax, variable.rangeMax),
+          }
+        : {
+            min:
+              yMinMaxRange != null
+                ? Math.min(variable.rangeMin, yMinMaxRange.min as number)
+                : variable.rangeMin,
+            max:
+              yMinMaxRange != null
+                ? Math.min(variable.rangeMax, yMinMaxRange.max as number)
+                : variable.rangeMax,
+          };
+    } else if (variable.type === 'date') {
+      return variable.displayRangeMin != null &&
+        variable.displayRangeMax != null
+        ? {
+            min:
+              yMinMaxRange != null
+                ? [
+                    variable.displayRangeMin,
+                    variable.rangeMin,
+                    yMinMaxRange.min as string,
+                  ].reduce(function (a, b) {
+                    return a < b ? a : b;
+                  }) + 'T00:00:00Z'
+                : [variable.displayRangeMin, variable.rangeMin].reduce(
+                    function (a, b) {
+                      return a < b ? a : b;
+                    }
+                  ) + 'T00:00:00Z',
+            max:
+              yMinMaxRange != null
+                ? [
+                    variable.displayRangeMax,
+                    variable.rangeMax,
+                    yMinMaxRange.max as string,
+                  ].reduce(function (a, b) {
+                    return a > b ? a : b;
+                  }) + 'T00:00:00Z'
+                : [variable.displayRangeMax, variable.rangeMax].reduce(
+                    function (a, b) {
+                      return a > b ? a : b;
+                    }
+                  ) + 'T00:00:00Z',
+          }
+        : {
+            min:
+              yMinMaxRange != null
+                ? [variable.rangeMin, yMinMaxRange.min as string].reduce(
+                    function (a, b) {
+                      return a < b ? a : b;
+                    }
+                  ) + 'T00:00:00Z'
+                : variable.rangeMin + 'T00:00:00Z',
+            max:
+              yMinMaxRange != null
+                ? [variable.rangeMax, yMinMaxRange.max as string].reduce(
+                    function (a, b) {
+                      return a > b ? a : b;
+                    }
+                  ) + 'T00:00:00Z'
+                : variable.rangeMax + 'T00:00:00Z',
+          };
+    }
+  } else return undefined;
+}

--- a/src/lib/core/utils/default-independent-axis-range.ts
+++ b/src/lib/core/utils/default-independent-axis-range.ts
@@ -11,7 +11,7 @@ export function defaultIndependentAxisRange(
       return variable.displayRangeMin != null &&
         variable.displayRangeMax != null
         ? {
-            min: Math.min(variable.displayRangeMin, variable.rangeMax),
+            min: Math.min(variable.displayRangeMin, variable.rangeMin),
             max: Math.max(variable.displayRangeMax, variable.rangeMax),
           }
         : {


### PR DESCRIPTION
Added X/Y axes' ranges for Scatter plot viz. Also changed util's name concerning margin so that it can be used for both X and Y axes. 5% margin is utilized for both axes not to trim marker(s).