### PR TITLE
update @veupathdb/components version: long tick label of Mosaic

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.7.17",
+    "@veupathdb/components": "^0.7.18",
     "@veupathdb/wdk-client": "^0.4.4",
     "@veupathdb/web-common": "^0.1.6",
     "debounce-promise": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2952,10 +2952,10 @@
     react-transition-group "^4.4.1"
     shape2geohash "^1.2.5"
 
-"@veupathdb/components@^0.7.17":
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.7.17.tgz#310ed56375efbc9a2a7b7173be01780ab51cf890"
-  integrity sha512-Q8BCQJMC7PifeDiVR5q6AdwVECXuRcGE0uJg5dp25FZgM8aAuaNWztu6qgtQ9XD23TtAFNRBWxPnAs/0mletvA==
+"@veupathdb/components@^0.7.18":
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.7.18.tgz#0c19ee4bc1245ea4e22871b700f5e784c07bd698"
+  integrity sha512-SphT00KQqgDVSDhzsj6YE5c5P/Aa3f/1ovgJ0iEcoohS4zGKSoSbbKlor93hmydi7FeawfJfkbZhchvusFeghA==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
This is version update of @veupathdb/components version to house [long tick label of Mosaic work](https://github.com/VEuPathDB/web-components/pull/213)