### PR TITLE
Handle `integer` dataType

### DIFF
--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -29,7 +29,7 @@ import { usePromise } from '../../hooks/promise';
 import { AnalysisState } from '../../hooks/analysis';
 import { useSubsettingClient } from '../../hooks/workspace';
 import { DateRangeFilter, NumberRangeFilter } from '../../types/filter';
-import { StudyEntity, StudyMetadata } from '../../types/study';
+import { NumberVariable, StudyEntity, StudyMetadata } from '../../types/study';
 import { TimeUnit, NumberOrDateRange, NumberRange } from '../../types/general';
 import { gray, red } from './colors';
 import { HistogramVariable } from './types';
@@ -92,7 +92,7 @@ export function HistogramFilter(props: Props) {
       dependentAxisLogScale: false,
     };
 
-    if (variable.type === 'number')
+    if (NumberVariable.is(variable))
       return {
         binWidth: variable.binWidthOverride ?? variable.binWidth ?? 0.1,
         binWidthTimeUnit: undefined,
@@ -171,13 +171,12 @@ export function HistogramFilter(props: Props) {
           variable.type
         ),
       ];
-      const binWidth: NumberOrTimeDelta =
-        variable.type === 'number'
-          ? dataParams.binWidth
-          : {
-              value: dataParams.binWidth,
-              unit: dataParams.binWidthTimeUnit ?? 'year',
-            };
+      const binWidth: NumberOrTimeDelta = NumberVariable.is(variable)
+        ? dataParams.binWidth
+        : {
+            value: dataParams.binWidth,
+            unit: dataParams.binWidthTimeUnit ?? 'year',
+          };
       const { min, max, step } = computeBinSlider(
         variable.type,
         dataParams.independentAxisRange
@@ -195,7 +194,7 @@ export function HistogramFilter(props: Props) {
         distribution.background.statistics.numDistinctEntityRecords;
 
       return {
-        valueType: variable.type,
+        valueType: NumberVariable.is(variable) ? 'number' : 'date',
         series,
         binWidth,
         binWidthRange,
@@ -780,6 +779,7 @@ function computeBinSlider(
     case 'date': {
       return { min: 1, max: 60, step: 1 };
     }
+    case 'integer':
     case 'number': {
       const { min: rangeMin, max: rangeMax } = range as NumberRange;
       const rangeSize = Math.round((rangeMax - rangeMin) * 100) / 100;

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -181,7 +181,7 @@ export function HistogramFilter(props: Props) {
         variable.type,
         dataParams.independentAxisRange
       );
-      const binWidthRange = (variable.type === 'number'
+      const binWidthRange = (NumberVariable.is(variable)
         ? { min, max }
         : {
             min,

--- a/src/lib/core/components/filter/guards.ts
+++ b/src/lib/core/components/filter/guards.ts
@@ -32,6 +32,7 @@ export function isTableVariable(
       switch (variable.type) {
         case 'date':
         case 'number':
+        case 'integer':
         case 'string':
           return true;
       }
@@ -47,6 +48,7 @@ export function isScatterplotVariable(
       switch (variable.type) {
         case 'date':
         case 'number':
+        case 'integer':
           return true;
       }
   }
@@ -62,6 +64,7 @@ export function isMosaicVariable(
     case 'ordinal':
       switch (variable.type) {
         case 'number':
+        case 'integer':
         case 'string':
           return true;
       }

--- a/src/lib/core/components/filter/guards.ts
+++ b/src/lib/core/components/filter/guards.ts
@@ -15,6 +15,7 @@ export function isHistogramVariable(
       switch (variable.type) {
         case 'date':
         case 'number':
+        case 'integer':
           return true;
       }
   }

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -510,14 +510,14 @@ export function histogramResponseToData(
     throw Error(`Expected one or more data series, but got zero`);
 
   const binWidth =
-    type === 'number'
+    type === 'number' || type === 'integer'
       ? response.histogram.config.binSpec.value || 1
       : {
           value: response.histogram.config.binSpec.value || 1,
           unit: response.histogram.config.binSpec.units || 'month',
         };
   const { min, max, step } = response.histogram.config.binSlider;
-  const binWidthRange = (type === 'number'
+  const binWidthRange = (type === 'number' || type === 'integer'
     ? { min, max }
     : {
         min,
@@ -531,18 +531,18 @@ export function histogramResponseToData(
       borderColor: 'white',
       bins: data.value.map((_, index) => ({
         binStart:
-          type === 'number'
+          type === 'number' || type === 'integer'
             ? Number(data.binStart[index])
             : String(data.binStart[index]),
         binEnd:
-          type === 'number'
+          type === 'number' || type === 'integer'
             ? Number(data.binEnd[index])
             : String(data.binEnd[index]),
         binLabel: data.binLabel[index],
         count: data.value[index],
       })),
     })),
-    valueType: type,
+    valueType: type === 'integer' ? 'number' : type,
     binWidth,
     binWidthRange,
     binWidthStep,

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -50,7 +50,7 @@ import { XYPlotData } from '@veupathdb/components/lib/types/plots';
 import { CoverageStatistics } from '../../../types/visualization';
 // import axis label unit util
 import { axisLabelWithUnit } from '../../../utils/axis-label-unit';
-import { StudyEntity } from '../../../types/study';
+import { NumberVariable, StudyEntity } from '../../../types/study';
 import { vocabularyWithMissingData } from '../../../utils/analysis';
 import { gray } from '../colors';
 import {
@@ -410,8 +410,12 @@ function ScatterplotViz(props: VisualizationProps) {
               ? ['Smoothed mean with raw', 'Best fit line with raw']
               : []
           }
-          independentValueType={xAxisVariable?.type}
-          dependentValueType={yAxisVariable?.type}
+          independentValueType={
+            NumberVariable.is(xAxisVariable) ? 'number' : 'date'
+          }
+          dependentValueType={
+            NumberVariable.is(yAxisVariable) ? 'number' : 'date'
+          }
           legendTitle={axisLabelWithUnit(overlayVariable)}
         />
         <div className="viz-plot-info">

--- a/src/lib/core/types/study.ts
+++ b/src/lib/core/types/study.ts
@@ -20,6 +20,7 @@ export type StudyRecord = RecordInstance;
 export const VariableType = t.keyof({
   string: null,
   number: null,
+  integer: null,
   date: null,
   longitude: null,
 });
@@ -86,7 +87,7 @@ export type NumberVariable = t.TypeOf<typeof NumberVariable>;
 export const NumberVariable = t.intersection([
   Variable_Base,
   t.type({
-    type: t.literal('number'),
+    type: t.union([t.literal('number'), t.literal('integer')]),
     units: t.string,
     precision: t.number,
   }),

--- a/src/lib/core/types/study.ts
+++ b/src/lib/core/types/study.ts
@@ -86,11 +86,17 @@ export const StringVariable = t.intersection([
 export type NumberVariable = t.TypeOf<typeof NumberVariable>;
 export const NumberVariable = t.intersection([
   Variable_Base,
-  t.type({
-    type: t.union([t.literal('number'), t.literal('integer')]),
-    units: t.string,
-    precision: t.number,
-  }),
+  t.union([
+    t.type({
+      type: t.literal('number'),
+      units: t.string,
+      precision: t.number,
+    }),
+    t.type({
+      type: t.literal('integer'),
+      units: t.string,
+    }),
+  ]),
   t.union([
     t.type({
       dataShape: CategoryVariableDataShape,

--- a/src/lib/core/utils/axis-label-unit.ts
+++ b/src/lib/core/utils/axis-label-unit.ts
@@ -1,10 +1,10 @@
-import { VariableTreeNode } from '../types/study';
+import { NumberVariable, VariableTreeNode } from '../types/study';
 
 export function axisLabelWithUnit(
   axisVariableContent: VariableTreeNode | undefined
 ): string | undefined {
   if (
-    axisVariableContent?.type === 'number' &&
+    NumberVariable.is(axisVariableContent) &&
     axisVariableContent.units &&
     axisVariableContent.units != null
   )

--- a/src/lib/core/utils/default-independent-axis-range.ts
+++ b/src/lib/core/utils/default-independent-axis-range.ts
@@ -1,4 +1,4 @@
-import { Variable } from '../types/study';
+import { DateVariable, NumberVariable, Variable } from '../types/study';
 import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
 
 export function defaultIndependentAxisRange(
@@ -7,7 +7,7 @@ export function defaultIndependentAxisRange(
 ): NumberOrDateRange | undefined {
   // make universal range variable
   if (variable != null && variable.dataShape === 'continuous') {
-    if (variable.type === 'number') {
+    if (NumberVariable.is(variable)) {
       return variable.displayRangeMin != null &&
         variable.displayRangeMax != null
         ? {
@@ -22,7 +22,7 @@ export function defaultIndependentAxisRange(
                 : variable.rangeMin,
             max: variable.rangeMax,
           };
-    } else if (variable.type === 'date') {
+    } else if (DateVariable.is(variable)) {
       return variable.displayRangeMin != null &&
         variable.displayRangeMax != null
         ? {


### PR DESCRIPTION
For now, there is nothing special to do on the front end for integer types. They are just being treated as `NumberVariable`. We can update as needed in the future.

fixes #472 