### PR TITLE
Use EDA User Service to persist analysis configs and preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following environment variables are used by the `yarn start` script:
 | `WDK_SERVICE_URL`                     | Full url to a running WDK REST Service            |
 | `EDA_SUBSETTING_SERVICE_URL`          | Full url to a running EDA Subsetting Service      |
 | `EDA_DATA_SERVICE_URL`                | Full url to a running EDA Data Service            |
+| `EDA_USER_SERVICE_URL`                | Full url to a running EDA User Service            |
 | `DATASET_ACCESS_SERVICE_URL`          | Full url to a running Dataset Access Service      |
 | `REACT_APP_DISABLE_DATA_RESTRICTIONS` | If present and `true`, disables data restrictions |
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,14 @@ The following environment variables are used by the `yarn start` script:
 
 | Variable name                         | Description                                       |
 | ------------------------------------- | ------------------------------------------------- |
+| `VEUPATHDB_LOGIN_USER`                | VEuPathDB BRC prerelease user name                |
+| `VEUPATHDB_LOGIN_PASS`                | VEuPathDB BRC prerelease user password            |
 | `WDK_SERVICE_URL`                     | Full url to a running WDK REST Service            |
 | `EDA_SUBSETTING_SERVICE_URL`          | Full url to a running EDA Subsetting Service      |
 | `EDA_DATA_SERVICE_URL`                | Full url to a running EDA Data Service            |
 | `EDA_USER_SERVICE_URL`                | Full url to a running EDA User Service            |
 | `DATASET_ACCESS_SERVICE_URL`          | Full url to a running Dataset Access Service      |
+| `WDK_CHECK_AUTH`                      | An optional auth key for a registered WDK user    |
 | `REACT_APP_DISABLE_DATA_RESTRICTIONS` | If present and `true`, disables data restrictions |
 
 ## Learn More

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@types/debounce-promise": "^3.1.3",
     "@veupathdb/components": "^0.7.17",
     "@veupathdb/wdk-client": "^0.4.4",
-    "@veupathdb/web-common": "^0.1.6",
+    "@veupathdb/web-common": "^0.1.7",
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",
     "io-ts": "^2.2.13",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "fp-ts": "^2.9.3",
     "io-ts": "^2.2.13",
     "lodash": "^4.17.20",
+    "monocle-ts": "^2.3.11",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-draggable": "^4.4.3",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,7 @@ import './index.css';
 
 const subsettingServiceUrl = '/eda-subsetting-service';
 const dataServiceUrl = '/eda-data-service';
+const userServiceUrl = '/eda-user-service';
 
 initialize({
   rootUrl,
@@ -55,6 +56,7 @@ initialize({
         <WorkspaceRouter
           subsettingServiceUrl={subsettingServiceUrl}
           dataServiceUrl={dataServiceUrl}
+          userServiceUrl={userServiceUrl}
         />
       ),
     },

--- a/src/lib/core/Mocks.ts
+++ b/src/lib/core/Mocks.ts
@@ -1,0 +1,118 @@
+import { isLeft, isRight } from 'fp-ts/lib/Either';
+import { PathReporter } from 'io-ts/lib/PathReporter';
+import {
+  Analysis,
+  AnalysisClient,
+  AnalysisDescriptor,
+  AnalysisPreferences,
+  AnalysisSummary,
+  NewAnalysis,
+  SingleAnalysisPatchRequest,
+} from '../core';
+import { max } from 'lodash';
+
+export function makeMockAnalysisStore(
+  analysisStore: LocalForage,
+  preferenceStore: LocalForage
+): AnalysisClient {
+  return {
+    async getPreferences() {
+      const prefs = await preferenceStore.getItem('preferences');
+      const result = AnalysisPreferences.decode(prefs);
+      if (isRight(result)) return result.right;
+      throw new Error(PathReporter.report(result).join('\n'));
+    },
+    async setPreferences(preferences: AnalysisPreferences) {
+      await preferenceStore.setItem<AnalysisPreferences>(
+        'preferences',
+        preferences
+      );
+    },
+    async getAnalyses() {
+      const records: AnalysisSummary[] = [];
+      await analysisStore.iterate((value) => {
+        const result = Analysis.decode(value);
+        if (isLeft(result)) {
+          throw new Error(PathReporter.report(result).join('\n'));
+        }
+        const { descriptor, ...analysisSummary } = result.right;
+        records.push(analysisSummary);
+      });
+      return records;
+    },
+    async createAnalysis(newAnalysis: NewAnalysis) {
+      const usedIds = await analysisStore.keys();
+      const analysisId = String((max(usedIds.map((x) => Number(x))) ?? 0) + 1);
+      const now = new Date().toISOString();
+      await analysisStore.setItem<Analysis>(analysisId, {
+        ...newAnalysis,
+        ...computeSummaryCounts(newAnalysis.descriptor),
+        analysisId,
+        creationTime: now,
+        modificationTime: now,
+      });
+      return { analysisId };
+    },
+    async getAnalysis(id: string) {
+      const analysis = await analysisStore.getItem(id);
+      if (analysis) {
+        const result = Analysis.decode(analysis);
+        if (isRight(result)) return result.right;
+        throw new Error(PathReporter.report(result).join('\n'));
+      }
+      throw new Error(`Could not find analysis with id "${id}".`);
+    },
+    async updateAnalysis(
+      analysisId: string,
+      analysisPatch: SingleAnalysisPatchRequest
+    ) {
+      const analysis = await analysisStore.getItem(analysisId);
+      if (analysis == null) {
+        throw new Error(
+          `Tried to update a nonexistent analysis with id "${analysisId}".`
+        );
+      }
+
+      const result = Analysis.decode(analysis);
+      if (isLeft(result)) {
+        throw new Error(PathReporter.report(result).join('\n'));
+      }
+
+      const decodedAnalysis = result.right;
+      const now = new Date().toISOString();
+      await analysisStore.setItem<Analysis>(analysisId, {
+        ...decodedAnalysis,
+        ...analysisPatch,
+        ...(analysisPatch.descriptor == null
+          ? {}
+          : computeSummaryCounts(analysisPatch.descriptor)),
+        modificationTime: now,
+      });
+    },
+    async deleteAnalysis(id: string) {
+      await analysisStore.removeItem(id);
+    },
+    async deleteAnalyses(ids: Iterable<string>) {
+      const deletionPromises = Array.from(ids).map((id) =>
+        analysisStore.removeItem(id)
+      );
+
+      await Promise.allSettled(deletionPromises);
+    },
+  } as AnalysisClient;
+}
+
+export function computeSummaryCounts(
+  descriptor: AnalysisDescriptor
+): Pick<
+  AnalysisSummary,
+  'numComputations' | 'numFilters' | 'numVisualizations'
+> {
+  return {
+    numFilters: descriptor.subset.descriptor.length,
+    numComputations: descriptor.computations.length,
+    numVisualizations: descriptor.computations
+      .map(({ visualizations }) => visualizations.length)
+      .reduce((memo, visualizationCount) => memo + visualizationCount, 0),
+  };
+}

--- a/src/lib/core/__test__/hooks/useAnalysis.test.tsx
+++ b/src/lib/core/__test__/hooks/useAnalysis.test.tsx
@@ -1,5 +1,6 @@
 import { omit } from 'lodash';
 import { act, renderHook } from '@testing-library/react-hooks';
+import { computeSummaryCounts } from '../../Mocks';
 import { useAnalysis, Status } from '../../hooks/analysis';
 import { Analysis, NewAnalysis, makeNewAnalysis } from '../../types/analysis';
 import {
@@ -59,6 +60,9 @@ const analysisClient: AnalysisClient = {
     records[analysisId] = {
       ...records[analysisId],
       ...analysisPatch,
+      ...(analysisPatch.descriptor == null
+        ? {}
+        : computeSummaryCounts(analysisPatch.descriptor)),
       modificationTime: new Date().toISOString(),
     };
   },
@@ -150,8 +154,8 @@ describe('useAnalysis', () => {
     const newAnalysis = analyses.find(
       (analysis) => analysis.analysisId === res.analysisId
     );
-    expect(omit(result.current.analysis, 'id')).toEqual(
-      omit(newAnalysis, 'id')
+    expect(omit(result.current.analysis, 'analysisId')).toEqual(
+      omit(newAnalysis, 'analysisId')
     );
     expect(result.current.analysis).not.toBe(newAnalysis);
   });

--- a/src/lib/core/__test__/hooks/useAnalysis.test.tsx
+++ b/src/lib/core/__test__/hooks/useAnalysis.test.tsx
@@ -37,14 +37,10 @@ const analysisClient: AnalysisClient = {
     const analysisId = String(nextId++);
     records[analysisId] = {
       ...newAnalysis,
+      ...computeSummaryCounts(newAnalysis.descriptor),
       analysisId,
       creationTime: new Date().toISOString(),
       modificationTime: new Date().toISOString(),
-      numFilters: newAnalysis.descriptor.subset.descriptor.length,
-      numComputations: newAnalysis.descriptor.computations.length,
-      numVisualizations: newAnalysis.descriptor.computations
-        .map(({ visualizations }) => visualizations.length)
-        .reduce((memo, visualizationCount) => memo + visualizationCount, 0),
     };
     return { analysisId };
   },

--- a/src/lib/core/__test__/hooks/useAnalysis.test.tsx
+++ b/src/lib/core/__test__/hooks/useAnalysis.test.tsx
@@ -87,15 +87,15 @@ const wrapper: React.ComponentType = ({ children }) => (
 );
 
 beforeEach(() => {
+  const now = new Date().toISOString();
+
   records = {
     123: {
       ...stubAnalysis,
+      ...computeSummaryCounts(stubAnalysis.descriptor),
       analysisId: key,
-      creationTime: new Date().toISOString(),
-      modificationTime: new Date().toISOString(),
-      numComputations: 0,
-      numFilters: 0,
-      numVisualizations: 0,
+      creationTime: now,
+      modificationTime: now,
     },
   };
   nextId = 1;

--- a/src/lib/core/__test__/hooks/useAnalysis.test.tsx
+++ b/src/lib/core/__test__/hooks/useAnalysis.test.tsx
@@ -1,8 +1,11 @@
 import { omit } from 'lodash';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { useAnalysis, Status } from '../../hooks/analysis';
-import { Analysis, NewAnalysis } from '../../types/analysis';
-import { AnalysisClient } from '../../api/analysis-api';
+import { Analysis, NewAnalysis, makeNewAnalysis } from '../../types/analysis';
+import {
+  AnalysisClient,
+  SingleAnalysisPatchRequest,
+} from '../../api/analysis-api';
 import { DataClient } from '../../api/data-api';
 import {
   StudyMetadata,
@@ -12,42 +15,52 @@ import {
 } from '../..';
 import { SubsettingClient } from '../../api/subsetting-api';
 
-const stubAnalysis: NewAnalysis = {
-  name: 'My Analysis',
-  studyId: '123',
-  filters: [],
-  derivedVariables: [],
-  starredVariables: [],
-  variableUISettings: {},
-  visualizations: [],
-  computations: [],
-};
-
 const key = '123';
+
+const stubAnalysis: NewAnalysis = makeNewAnalysis(key);
 
 let records: Record<string, Analysis>;
 let nextId: number;
 
 const analysisClient: AnalysisClient = {
   async getAnalyses() {
-    return Object.values(records);
+    return Object.values(records).map(
+      ({ descriptor, ...analysisSummary }) => analysisSummary
+    );
   },
   async getAnalysis(id: string) {
     if (id in records) return records[id];
     throw new Error('Could not find analysis for id ' + id);
   },
   async createAnalysis(newAnalysis: NewAnalysis) {
-    const id = String(nextId++);
-    records[id] = {
+    const analysisId = String(nextId++);
+    records[analysisId] = {
       ...newAnalysis,
-      id,
-      created: new Date().toISOString(),
-      modified: new Date().toISOString(),
+      analysisId,
+      creationTime: new Date().toISOString(),
+      modificationTime: new Date().toISOString(),
+      numFilters: newAnalysis.descriptor.subset.descriptor.length,
+      numComputations: newAnalysis.descriptor.computations.length,
+      numVisualizations: newAnalysis.descriptor.computations
+        .map(({ visualizations }) => visualizations.length)
+        .reduce((memo, visualizationCount) => memo + visualizationCount, 0),
     };
-    return { id };
+    return { analysisId };
   },
-  async updateAnalysis(analysis: Analysis) {
-    records[analysis.id] = analysis;
+  async updateAnalysis(
+    analysisId: string,
+    analysisPatch: SingleAnalysisPatchRequest
+  ) {
+    if (!(analysisId in records))
+      throw new Error(
+        'Tried to update a nonexistent analysis with id ' + analysisId
+      );
+
+    records[analysisId] = {
+      ...records[analysisId],
+      ...analysisPatch,
+      modificationTime: new Date().toISOString(),
+    };
   },
   async deleteAnalysis(id: string) {
     delete records[id];
@@ -73,9 +86,12 @@ beforeEach(() => {
   records = {
     123: {
       ...stubAnalysis,
-      id: key,
-      created: new Date().toISOString(),
-      modified: new Date().toISOString(),
+      analysisId: key,
+      creationTime: new Date().toISOString(),
+      modificationTime: new Date().toISOString(),
+      numComputations: 0,
+      numFilters: 0,
+      numVisualizations: 0,
     },
   };
   nextId = 1;
@@ -102,7 +118,7 @@ describe('useAnalysis', () => {
     const { result, waitFor } = render();
     await waitFor(() => result.current.status === Status.Loaded);
     expect(result.current.analysis).toBeDefined();
-    expect(result.current.analysis?.name).toBe('My Analysis');
+    expect(result.current.analysis?.displayName).toBe('My Analysis');
   });
 
   it('should allow updates', async () => {
@@ -111,7 +127,7 @@ describe('useAnalysis', () => {
     act(() => {
       result.current.setName('New Name');
     });
-    expect(result.current.analysis?.name).toBe('New Name');
+    expect(result.current.analysis?.displayName).toBe('New Name');
   });
 
   it('should update store on save', async () => {
@@ -121,8 +137,8 @@ describe('useAnalysis', () => {
     expect(result.current.hasUnsavedChanges).toBeTruthy();
     await act(() => result.current.saveAnalysis());
     const analyses = await analysisClient.getAnalyses();
-    const analysis = analyses.find((analysis) => analysis.id === key);
-    expect(analysis?.name).toBe('New Name');
+    const analysis = analyses.find((analysis) => analysis.analysisId === key);
+    expect(analysis?.displayName).toBe('New Name');
     expect(result.current.hasUnsavedChanges).toBeFalsy();
   });
 
@@ -131,7 +147,9 @@ describe('useAnalysis', () => {
     await waitFor(() => result.current.status === Status.Loaded);
     const res = await result.current.copyAnalysis();
     const analyses = await analysisClient.getAnalyses();
-    const newAnalysis = analyses.find((analysis) => analysis.id === res.id);
+    const newAnalysis = analyses.find(
+      (analysis) => analysis.analysisId === res.analysisId
+    );
     expect(omit(result.current.analysis, 'id')).toEqual(
       omit(newAnalysis, 'id')
     );
@@ -143,7 +161,7 @@ describe('useAnalysis', () => {
     await waitFor(() => result.current.status === Status.Loaded);
     await result.current.deleteAnalysis();
     const analyses = await analysisClient.getAnalyses();
-    const analysis = analyses.find((analysis) => analysis.id === key);
+    const analysis = analyses.find((analysis) => analysis.analysisId === key);
     expect(analysis).toBeUndefined();
   });
 });

--- a/src/lib/core/api/analysis-api.ts
+++ b/src/lib/core/api/analysis-api.ts
@@ -1,10 +1,22 @@
-import { Analysis, AnalysisPreferences, NewAnalysis } from '../types/analysis';
+import { type, voidType, string, array } from 'io-ts';
+import { memoize } from 'lodash';
+
 import {
   createJsonRequest,
   FetchClient,
 } from '@veupathdb/web-common/lib/util/api';
-import { type, voidType, string, array } from 'io-ts';
+
+import {
+  Analysis,
+  AnalysisDetails,
+  AnalysisPreferences,
+  AnalysisSummary,
+  NewAnalysis,
+  NewAnalysisDetails,
+} from '../types/analysis';
+
 import { ioTransformer } from './ioTransformer';
+
 export class AnalysisClient extends FetchClient {
   getPreferences(): Promise<AnalysisPreferences> {
     return this.fetch(
@@ -82,6 +94,102 @@ export class AnalysisClient extends FetchClient {
           op: 'delete',
           id,
         })),
+        transformResponse: ioTransformer(voidType),
+      })
+    );
+  }
+}
+
+export class NewAnalysisClient extends FetchClient {
+  static getClient = memoize(
+    (baseUrl: string, authKey: string): NewAnalysisClient =>
+      new NewAnalysisClient({
+        baseUrl,
+        init: { headers: { 'Auth-Key': authKey } },
+      }),
+    (baseUrl, authKey) => JSON.stringify({ baseUrl, authKey })
+  );
+
+  getPreferences(): Promise<AnalysisPreferences> {
+    return this.fetch(
+      createJsonRequest({
+        path: '/preferences',
+        method: 'GET',
+        transformResponse: ioTransformer(AnalysisPreferences),
+      })
+    );
+  }
+  setPreferences(preferences: AnalysisPreferences): Promise<void> {
+    return this.fetch(
+      createJsonRequest({
+        path: '/preferences',
+        method: 'PUT',
+        body: preferences,
+        transformResponse: ioTransformer(voidType),
+      })
+    );
+  }
+  getAnalyses(): Promise<AnalysisSummary[]> {
+    return this.fetch(
+      createJsonRequest({
+        path: '/analyses',
+        method: 'GET',
+        transformResponse: ioTransformer(array(AnalysisSummary)),
+      })
+    );
+  }
+  getAnalysis(analysisId: string): Promise<AnalysisDetails> {
+    return this.fetch(
+      createJsonRequest({
+        path: `/analyses/${analysisId}`,
+        method: 'GET',
+        transformResponse: ioTransformer(AnalysisDetails),
+      })
+    );
+  }
+  createAnalysis(
+    analysis: NewAnalysisDetails
+  ): Promise<{ analysisId: string }> {
+    return this.fetch(
+      createJsonRequest({
+        path: `/analyses`,
+        method: 'POST',
+        body: analysis,
+        transformResponse: ioTransformer(type({ analysisId: string })),
+      })
+    );
+  }
+  updateAnalysis(
+    analysisId: string,
+    analysisPatch: Partial<NewAnalysisDetails>
+  ): Promise<void> {
+    return this.fetch(
+      createJsonRequest({
+        path: `/analyses/${analysisId}`,
+        method: 'PUT',
+        body: analysisPatch,
+        transformResponse: ioTransformer(voidType),
+      })
+    );
+  }
+  deleteAnalysis(analysisId: string): Promise<void> {
+    return this.fetch(
+      createJsonRequest({
+        path: `/analyses/${analysisId}`,
+        method: 'DELETE',
+        body: { analysisId },
+        transformResponse: ioTransformer(voidType),
+      })
+    );
+  }
+  deleteAnalyses(analysisIds: Iterable<string>): Promise<void> {
+    return this.fetch(
+      createJsonRequest({
+        path: '/analyses',
+        method: 'PATCH',
+        body: {
+          analysisIdsToDelete: [...analysisIds],
+        },
         transformResponse: ioTransformer(voidType),
       })
     );

--- a/src/lib/core/api/analysis-api.ts
+++ b/src/lib/core/api/analysis-api.ts
@@ -172,7 +172,7 @@ export class NewAnalysisClient extends FetchClient {
     return this.fetch(
       createJsonRequest({
         path: `/analyses/${analysisId}`,
-        method: 'PUT',
+        method: 'PATCH',
         body: analysisPatch,
         transformResponse: ioTransformer(voidType),
       })

--- a/src/lib/core/api/analysis-api.ts
+++ b/src/lib/core/api/analysis-api.ts
@@ -100,14 +100,20 @@ export class AnalysisClient extends FetchClient {
   }
 }
 
+interface AnalysisClientConfiguration {
+  userServiceUrl: string;
+  userId: number;
+  authKey: string;
+}
+
 export class NewAnalysisClient extends FetchClient {
   static getClient = memoize(
-    (baseUrl: string, authKey: string): NewAnalysisClient =>
+    (config: AnalysisClientConfiguration): NewAnalysisClient =>
       new NewAnalysisClient({
-        baseUrl,
-        init: { headers: { 'Auth-Key': authKey } },
+        baseUrl: `${config.userServiceUrl}/${config.userId}`,
+        init: { headers: { 'Auth-Key': config.authKey } },
       }),
-    (baseUrl, authKey) => JSON.stringify({ baseUrl, authKey })
+    JSON.stringify
   );
 
   getPreferences(): Promise<AnalysisPreferences> {

--- a/src/lib/core/api/analysis-api.ts
+++ b/src/lib/core/api/analysis-api.ts
@@ -179,14 +179,11 @@ export class NewAnalysisClient extends FetchClient {
     );
   }
   deleteAnalysis(analysisId: string): Promise<void> {
-    return this.fetch(
-      createJsonRequest({
-        path: `/analyses/${analysisId}`,
-        method: 'DELETE',
-        body: { analysisId },
-        transformResponse: ioTransformer(voidType),
-      })
-    );
+    return this.fetch({
+      path: `/analyses/${analysisId}`,
+      method: 'DELETE',
+      transformResponse: ioTransformer(voidType),
+    });
   }
   deleteAnalyses(analysisIds: Iterable<string>): Promise<void> {
     return this.fetch(

--- a/src/lib/core/api/analysis-api.ts
+++ b/src/lib/core/api/analysis-api.ts
@@ -77,7 +77,15 @@ export class AnalysisClient extends FetchClient {
       createJsonRequest({
         path: `/analyses`,
         method: 'POST',
-        body: analysis,
+        body: pick(analysis, [
+          'displayName',
+          'description',
+          'descriptor',
+          'isPublic',
+          'studyId',
+          'apiVersion',
+          'studyVersion',
+        ]),
         transformResponse: ioTransformer(type({ analysisId: string })),
       })
     );

--- a/src/lib/core/api/analysis-api.ts
+++ b/src/lib/core/api/analysis-api.ts
@@ -73,19 +73,21 @@ export class AnalysisClient extends FetchClient {
     );
   }
   createAnalysis(analysis: NewAnalysis): Promise<{ analysisId: string }> {
+    const body: NewAnalysis = pick(analysis, [
+      'displayName',
+      'description',
+      'descriptor',
+      'isPublic',
+      'studyId',
+      'apiVersion',
+      'studyVersion',
+    ]);
+
     return this.fetch(
       createJsonRequest({
         path: `/analyses`,
         method: 'POST',
-        body: pick(analysis, [
-          'displayName',
-          'description',
-          'descriptor',
-          'isPublic',
-          'studyId',
-          'apiVersion',
-          'studyVersion',
-        ]),
+        body,
         transformResponse: ioTransformer(type({ analysisId: string })),
       })
     );
@@ -94,16 +96,18 @@ export class AnalysisClient extends FetchClient {
     analysisId: string,
     analysisPatch: SingleAnalysisPatchRequest
   ): Promise<void> {
+    const body: SingleAnalysisPatchRequest = pick(analysisPatch, [
+      'displayName',
+      'description',
+      'descriptor',
+      'isPublic',
+    ]);
+
     return this.fetch(
       createJsonRequest({
         path: `/analyses/${analysisId}`,
         method: 'PATCH',
-        body: pick(analysisPatch, [
-          'displayName',
-          'description',
-          'descriptor',
-          'isPublic',
-        ]),
+        body,
         transformResponse: ioTransformer(voidType),
       })
     );

--- a/src/lib/core/components/EDAAnalysisListContainer.tsx
+++ b/src/lib/core/components/EDAAnalysisListContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useWdkStudyRecord, useStudyMetadata } from '../hooks/study';
 import { AnalysisClient } from '../api/analysis-api';
 import { SubsettingClient } from '../api/subsetting-api';

--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -16,8 +16,8 @@ import { useStudyEntities } from '../hooks/study';
 
 export interface Props {
   rootEntity: StudyEntity;
-  starredVariables?: string[];
-  toggleStarredVariable: (targetVariableId: string) => void;
+  starredVariables?: VariableDescriptor[];
+  toggleStarredVariable: (targetVariableId: VariableDescriptor) => void;
   entityId?: string;
   variableId?: string;
   disabledVariables?: VariableDescriptor[];

--- a/src/lib/core/components/VariableTree.tsx
+++ b/src/lib/core/components/VariableTree.tsx
@@ -1,7 +1,7 @@
 import PopoverButton from '@veupathdb/components/lib/components/widgets/PopoverButton';
 import { Button } from '@material-ui/core';
 import { keyBy } from 'lodash';
-import { useCallback, useMemo, useState, useContext } from 'react';
+import { useCallback, useMemo } from 'react';
 import { cx } from '../../workspace/Utils';
 import { StudyEntity } from '../types/study';
 import { VariableDescriptor } from '../types/variable';

--- a/src/lib/core/components/computations/PassThroughComputation.tsx
+++ b/src/lib/core/components/computations/PassThroughComputation.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useMemo } from 'react';
+
 import { AnalysisState } from '../../hooks/analysis';
 import { useToggleStarredVariable } from '../../hooks/starredVariables';
 import {
-  Visualization,
   ComputationAppOverview,
+  Visualization,
 } from '../../types/visualization';
 import { testVisualization } from '../visualizations/implementations/TestVisualization';
 import { histogramVisualization } from '../visualizations/implementations/HistogramVisualization';

--- a/src/lib/core/components/computations/PassThroughComputation.tsx
+++ b/src/lib/core/components/computations/PassThroughComputation.tsx
@@ -38,33 +38,71 @@ const visualizationTypes: Record<string, VisualizationType> = {
   boxplot: boxplotVisualization,
 };
 
-const computations = [
-  {
-    id: 'pass-through',
-    type: 'pass',
-    displayName: 'Passthrough',
-    configuration: undefined,
-  },
-];
-
 export function PassThroughComputation(props: Props) {
   const { analysisState, computationAppOverview } = props;
-  const { analysis, setVisualizations } = analysisState;
-  const filters = useMemo(() => analysis?.filters ?? [], [analysis?.filters]);
+  const { analysis, setComputations } = analysisState;
+  const filters = useMemo(() => analysis?.descriptor.subset.descriptor ?? [], [
+    analysis?.descriptor.subset.descriptor,
+  ]);
 
   const toggleStarredVariable = useToggleStarredVariable(analysisState);
 
+  const computationLocation = useMemo(() => {
+    const computations = analysis?.descriptor.computations;
+
+    if (computations == null) {
+      return undefined;
+    }
+
+    const computationIndex = computations.findIndex(
+      ({ computationId }) => computationId === 'pass-through'
+    );
+
+    return computationIndex === -1
+      ? undefined
+      : {
+          computationIndex,
+          computation: computations[computationIndex],
+        };
+  }, [analysis?.descriptor.computations]);
+
+  const updateVisualizations = useCallback(
+    (
+      visualizations:
+        | Visualization[]
+        | ((visualizations: Visualization[]) => Visualization[])
+    ) => {
+      if (computationLocation == null) {
+        throw new Error('Computation not found');
+      }
+
+      const { computationIndex } = computationLocation;
+
+      setComputations((computations) => [
+        ...computations.slice(0, computationIndex),
+        {
+          ...computations[computationIndex],
+          visualizations:
+            typeof visualizations === 'function'
+              ? visualizations(computations[computationIndex].visualizations)
+              : visualizations,
+        },
+        ...computations.slice(computationIndex + 1),
+      ]);
+    },
+    [setComputations, computationLocation]
+  );
+
   if (analysis == null) return <div>Analysis not found</div>;
+  if (computationLocation == null) return <div>Computation not found</div>;
   return (
     <VisualizationsContainer
-      computationId="pass-through"
-      computations={computations}
-      visualizations={analysis.visualizations}
+      computation={computationLocation.computation}
       visualizationsOverview={computationAppOverview.visualizations!}
-      updateVisualizations={setVisualizations}
+      updateVisualizations={updateVisualizations}
       visualizationTypes={visualizationTypes}
       filters={filters}
-      starredVariables={analysis.starredVariables}
+      starredVariables={analysis.descriptor.starredVariables}
       toggleStarredVariable={toggleStarredVariable}
     />
   );

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -77,7 +77,7 @@ export function HistogramFilter(props: Props) {
     totalEntityCount,
   } = props;
   const { setFilters } = analysisState;
-  const filters = analysisState.analysis?.filters;
+  const filters = analysisState.analysis?.descriptor.subset.descriptor;
   const uiStateKey = `${entity.id}/${variable.id}`;
 
   // compute default independent range from meta-data based util
@@ -112,12 +112,15 @@ export function HistogramFilter(props: Props) {
     };
   }, [variable]);
 
+  const variableUISettings =
+    analysisState.analysis?.descriptor.subset.uiSettings;
+
   const uiState = useMemo(() => {
     return pipe(
-      UIState.decode(analysisState.analysis?.variableUISettings[uiStateKey]),
+      UIState.decode(variableUISettings?.[uiStateKey]),
       getOrElse((): UIState => defaultUIState)
     );
-  }, [analysisState.analysis?.variableUISettings, uiStateKey, defaultUIState]);
+  }, [variableUISettings, uiStateKey, defaultUIState]);
   const subsettingClient = useSubsettingClient();
   const getData = useCallback(
     async (
@@ -133,7 +136,7 @@ export function HistogramFilter(props: Props) {
         {
           entityId: entity.id,
           variableId: variable.id,
-          filters: analysisState.analysis?.filters,
+          filters,
         },
         (filters) => {
           return subsettingClient.getDistribution(
@@ -206,7 +209,7 @@ export function HistogramFilter(props: Props) {
       };
     },
     [
-      analysisState.analysis?.filters,
+      filters,
       entity.displayName,
       entity.displayNamePlural,
       entity.id,

--- a/src/lib/core/components/filter/MultiFilter.tsx
+++ b/src/lib/core/components/filter/MultiFilter.tsx
@@ -18,7 +18,6 @@ import {
   StudyMetadata,
 } from '../../types/study';
 import {
-  edaVariableToWdkField,
   entitiesToFields,
   fromEdaFilter,
   makeFieldTree,

--- a/src/lib/core/components/filter/MultiFilter.tsx
+++ b/src/lib/core/components/filter/MultiFilter.tsx
@@ -144,20 +144,22 @@ export function MultiFilter(props: Props) {
     _thisFilter
   );
 
+  const filters = analysisState.analysis?.descriptor.subset.descriptor;
+
   // Use a JSON string here so that we don't udpate counts for every render.
   // array.filter will always return a _new_ array, but strings are immutable,
   // so this trick will cause same-valued arrays to be referentially equal.
   const otherFiltersJson = useMemo(
     () =>
       JSON.stringify(
-        analysisState.analysis?.filters.filter(
+        filters?.filter(
           (filter) =>
             !(
               filter.entityId === entity.id && filter.variableId === variable.id
             )
         )
       ),
-    [analysisState.analysis?.filters, entity.id, variable.id]
+    [filters, entity.id, variable.id]
   );
 
   // State used to control if the "Update counts" button is disabled.
@@ -300,10 +302,7 @@ export function MultiFilter(props: Props) {
   );
 
   // Convert EDA filters to WDK filters.
-  const wdkFilters = useMemo(
-    () => analysisState.analysis?.filters.map(fromEdaFilter),
-    [analysisState.analysis?.filters]
-  );
+  const wdkFilters = useMemo(() => filters?.map(fromEdaFilter), [filters]);
 
   // Prevent table from displaying "no data" message
   if (leafSummariesPromise.pending && leafSummariesPromise.value == null)
@@ -376,7 +375,7 @@ function findThisFilter(
         })
       | undefined)
   | undefined {
-  return analysisState.analysis?.filters.find(
+  return analysisState.analysis?.descriptor.subset.descriptor.find(
     (filter): filter is MultiFilterType =>
       filter.entityId === entity.id &&
       filter.variableId === variable.id &&

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -53,13 +53,13 @@ export interface Props {
    */
   dataElementDependencyOrder?: string[];
   /**
-   * An array of variable IDs for the user's "My Variables"
+   * An array of VariableDescriptors for the user's "My Variables"
    */
-  starredVariables: string[];
+  starredVariables: VariableDescriptor[];
   /**
    * A callback for toggling the starred state of a variable with a given ID
    */
-  toggleStarredVariable: (targetVariableId: string) => void;
+  toggleStarredVariable: (targetVariableId: VariableDescriptor) => void;
   /** When false, disable (gray out) the showMissingness toggle */
   enableShowMissingnessToggle?: boolean;
   /** controlled state of stratification variables' showMissingness toggle switch (optional) */

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -54,7 +54,7 @@ export interface Props {
    */
   starredVariables: VariableDescriptor[];
   /**
-   * A callback for toggling the starred state of a variable with a given ID
+   * A callback for toggling the starred state of a variable
    */
   toggleStarredVariable: (targetVariableId: VariableDescriptor) => void;
   /** When false, disable (gray out) the showMissingness toggle */

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -1,4 +1,5 @@
 import { Filter } from '../../types/filter';
+import { VariableDescriptor } from '../../types/variable';
 import {
   Computation,
   DataElementConstraint,
@@ -17,8 +18,8 @@ export interface VisualizationProps {
   updateThumbnail: (source: string) => void;
   computation: Computation;
   filters?: Filter[];
-  starredVariables: string[];
-  toggleStarredVariable: (targetVariableId: string) => void;
+  starredVariables: VariableDescriptor[];
+  toggleStarredVariable: (targetVariableId: VariableDescriptor) => void;
 }
 
 export type SelectorProps = VisualizationOverview;

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -77,6 +77,23 @@ function ConfiguredVisualizations(props: Props) {
   const { computation, updateVisualizations, visualizationsOverview } = props;
   const { url } = useRouteMatch();
 
+  const clearThumbnail = useCallback(
+    (targetIndex) => {
+      updateVisualizations((oldVisualizations) => [
+        ...oldVisualizations.slice(0, targetIndex),
+        {
+          ...oldVisualizations[targetIndex],
+          descriptor: {
+            ...oldVisualizations[targetIndex].descriptor,
+            thumbnail: undefined,
+          },
+        },
+        ...oldVisualizations.slice(targetIndex + 1),
+      ]);
+    },
+    [updateVisualizations]
+  );
+
   return (
     <Grid>
       <Link replace to={`${url}/new`} className={cx('-NewVisualization')}>
@@ -84,7 +101,7 @@ function ConfiguredVisualizations(props: Props) {
         Select a visualization
       </Link>
       {computation.visualizations
-        .map((viz) => {
+        .map((viz, vizIndex) => {
           const meta = visualizationsOverview.find(
             (v) => v.name === viz.descriptor.type
           );
@@ -139,7 +156,13 @@ function ConfiguredVisualizations(props: Props) {
                   </div>
                 </div>
                 {viz.descriptor.thumbnail ? (
-                  <img alt={viz.displayName} src={viz.descriptor.thumbnail} />
+                  <img
+                    alt={viz.displayName}
+                    src={viz.descriptor.thumbnail}
+                    onError={() => {
+                      clearThumbnail(vizIndex);
+                    }}
+                  />
                 ) : (
                   <div className={cx('-ConfiguredVisualizationNoPreview')}>
                     Preview unavaiable

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -77,23 +77,6 @@ function ConfiguredVisualizations(props: Props) {
   const { computation, updateVisualizations, visualizationsOverview } = props;
   const { url } = useRouteMatch();
 
-  const clearThumbnail = useCallback(
-    (targetIndex) => {
-      updateVisualizations((oldVisualizations) => [
-        ...oldVisualizations.slice(0, targetIndex),
-        {
-          ...oldVisualizations[targetIndex],
-          descriptor: {
-            ...oldVisualizations[targetIndex].descriptor,
-            thumbnail: undefined,
-          },
-        },
-        ...oldVisualizations.slice(targetIndex + 1),
-      ]);
-    },
-    [updateVisualizations]
-  );
-
   return (
     <Grid>
       <Link replace to={`${url}/new`} className={cx('-NewVisualization')}>
@@ -101,7 +84,7 @@ function ConfiguredVisualizations(props: Props) {
         Select a visualization
       </Link>
       {computation.visualizations
-        .map((viz, vizIndex) => {
+        .map((viz) => {
           const meta = visualizationsOverview.find(
             (v) => v.name === viz.descriptor.type
           );
@@ -156,13 +139,7 @@ function ConfiguredVisualizations(props: Props) {
                   </div>
                 </div>
                 {viz.descriptor.thumbnail ? (
-                  <img
-                    alt={viz.displayName}
-                    src={viz.descriptor.thumbnail}
-                    onError={() => {
-                      clearThumbnail(vizIndex);
-                    }}
-                  />
+                  <img alt={viz.displayName} src={viz.descriptor.thumbnail} />
                 ) : (
                   <div className={cx('-ConfiguredVisualizationNoPreview')}>
                     Preview unavaiable

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -11,6 +11,7 @@ import { v4 as uuid } from 'uuid';
 import { Link, SaveableTextEditor } from '@veupathdb/wdk-client/lib/Components';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { Filter } from '../../types/filter';
+import { VariableDescriptor } from '../../types/variable';
 import {
   Computation,
   Visualization,
@@ -38,8 +39,8 @@ interface Props {
   visualizationTypes: Partial<Record<string, VisualizationType>>;
   visualizationsOverview: VisualizationOverview[];
   filters: Filter[];
-  starredVariables: string[];
-  toggleStarredVariable: (targetVariableId: string) => void;
+  starredVariables: VariableDescriptor[];
+  toggleStarredVariable: (targetVariable: VariableDescriptor) => void;
 }
 
 /**

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -28,9 +28,7 @@ import { Tooltip } from '@material-ui/core';
 const cx = makeClassNameHelper('VisualizationsContainer');
 
 interface Props {
-  computationId: string;
-  visualizations: Visualization[];
-  computations: Computation[];
+  computation: Computation;
   updateVisualizations: (
     visualizations:
       | Visualization[]
@@ -76,23 +74,8 @@ export function VisualizationsContainer(props: Props) {
 }
 
 function ConfiguredVisualizations(props: Props) {
-  const {
-    computationId,
-    computations,
-    updateVisualizations,
-    visualizations,
-    visualizationsOverview,
-  } = props;
+  const { computation, updateVisualizations, visualizationsOverview } = props;
   const { url } = useRouteMatch();
-  const computation = useMemo(
-    () => computations.find((computation) => computation.id === computationId),
-    [computationId, computations]
-  );
-  const scopedVisualizations = useMemo(
-    () => visualizations.filter((viz) => viz.computationId === computationId),
-    [computationId, visualizations]
-  );
-  if (computation == null) return <div>Computation not found</div>;
 
   return (
     <Grid>
@@ -100,11 +83,13 @@ function ConfiguredVisualizations(props: Props) {
         <i className="fa fa-plus"></i>
         Select a visualization
       </Link>
-      {scopedVisualizations
+      {computation.visualizations
         .map((viz) => {
-          const meta = visualizationsOverview.find((v) => v.name === viz.type);
+          const meta = visualizationsOverview.find(
+            (v) => v.name === viz.descriptor.type
+          );
           return (
-            <div key={viz.id}>
+            <div key={viz.visualizationId}>
               <div className={cx('-ConfiguredVisualization')}>
                 <div className={cx('-ConfiguredVisualizationActions')}>
                   <div>
@@ -114,7 +99,9 @@ function ConfiguredVisualizations(props: Props) {
                         className="link"
                         onClick={() =>
                           updateVisualizations((visualizations) =>
-                            visualizations.filter((v) => v.id !== viz.id)
+                            visualizations.filter(
+                              (v) => v.visualizationId !== viz.visualizationId
+                            )
                           )
                         }
                       >
@@ -134,7 +121,7 @@ function ConfiguredVisualizations(props: Props) {
                               displayName: `Copy of ${
                                 viz.displayName ?? 'visualization'
                               }`,
-                              id: uuid(),
+                              visualizationId: uuid(),
                             })
                           )
                         }
@@ -145,14 +132,14 @@ function ConfiguredVisualizations(props: Props) {
                   </div>
                   <div>
                     <Tooltip title="View fullscreen">
-                      <Link replace to={`${url}/${viz.id}`}>
+                      <Link replace to={`${url}/${viz.visualizationId}`}>
                         <i className="fa fa-arrows-alt"></i>
                       </Link>
                     </Tooltip>
                   </div>
                 </div>
-                {viz.thumbnail ? (
-                  <img alt={viz.displayName} src={viz.thumbnail} />
+                {viz.descriptor.thumbnail ? (
+                  <img alt={viz.displayName} src={viz.descriptor.thumbnail} />
                 ) : (
                   <div className={cx('-ConfiguredVisualizationNoPreview')}>
                     Preview unavaiable
@@ -178,15 +165,10 @@ function NewVisualizationPicker(props: Props) {
     visualizationTypes,
     visualizationsOverview,
     updateVisualizations,
-    computationId,
-    computations,
+    computation,
   } = props;
-  const computation = useMemo(
-    () => computations.find((computation) => computationId === computation.id),
-    [computations, computationId]
-  );
   const history = useHistory();
-  if (computation == null) return <div>Computation not found</div>;
+  const { computationId } = computation;
   return (
     <div className={cx('-PickerContainer')}>
       <div className={cx('-PickerActions')}>
@@ -209,17 +191,18 @@ function NewVisualizationPicker(props: Props) {
                   type="button"
                   disabled={vizType == null}
                   onClick={async () => {
-                    const id = uuid();
+                    const visualizationId = uuid();
                     updateVisualizations((visualizations) =>
                       visualizations.concat({
-                        id,
-                        computationId: computationId,
-                        type: vizOverview.name!,
+                        visualizationId,
                         displayName: 'Unnamed visualization',
-                        configuration: vizType?.createDefaultConfig(),
+                        descriptor: {
+                          type: vizOverview.name!,
+                          configuration: vizType?.createDefaultConfig(),
+                        },
                       })
                     );
-                    history.replace(`../${computationId}/${id}`);
+                    history.replace(`../${computationId}/${visualizationId}`);
                   }}
                 >
                   {vizType ? (
@@ -252,27 +235,28 @@ function FullScreenVisualization(props: Props & { id: string }) {
     visualizationTypes,
     visualizationsOverview,
     id,
-    computationId,
-    visualizations,
     updateVisualizations,
-    computations,
+    computation,
     filters,
     starredVariables,
     toggleStarredVariable,
   } = props;
   const history = useHistory();
-  const viz = visualizations.find(
-    (v) => v.id === id && v.computationId === computationId
+  const viz = computation.visualizations.find((v) => v.visualizationId === id);
+  const vizType = viz && visualizationTypes[viz.descriptor.type];
+  const overview = visualizationsOverview.find(
+    (v) => v.name === viz?.descriptor.type
   );
-  const computation = computations.find((a) => a.id === computationId);
-  const vizType = viz && visualizationTypes[viz.type];
-  const overview = visualizationsOverview.find((v) => v.name === viz?.type);
   const constraints = overview?.dataElementConstraints;
   const dataElementDependencyOrder = overview?.dataElementDependencyOrder;
   const updateConfiguration = useCallback(
     (configuration: unknown) => {
       updateVisualizations((visualizations) =>
-        visualizations.map((v) => (v.id !== id ? v : { ...v, configuration }))
+        visualizations.map((v) =>
+          v.visualizationId !== id
+            ? v
+            : { ...v, descriptor: { ...v.descriptor, configuration } }
+        )
       );
     },
     [updateVisualizations, id]
@@ -281,14 +265,19 @@ function FullScreenVisualization(props: Props & { id: string }) {
   const updateThumbnail = useCallback(
     (thumbnail: string) => {
       updateVisualizations((visualizations) =>
-        visualizations.map((v) => (v.id !== id ? v : { ...v, thumbnail }))
+        visualizations.map((v) =>
+          v.visualizationId !== id
+            ? v
+            : { ...v, descriptor: { ...v.descriptor, thumbnail } }
+        )
       );
     },
     [updateVisualizations, id]
   );
   if (viz == null) return <div>Visualization not found.</div>;
-  if (computation == null) return <div>Computation not found.</div>;
   if (vizType == null) return <div>Visualization type not implemented.</div>;
+
+  const { computationId } = computation;
 
   return (
     <div className={cx('-FullScreenContainer')}>
@@ -301,7 +290,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
               onClick={() => {
                 if (viz == null) return;
                 updateVisualizations((visualizations) =>
-                  visualizations.filter((v) => v.id !== id)
+                  visualizations.filter((v) => v.visualizationId !== id)
                 );
                 history.replace(Path.resolve(history.location.pathname, '..'));
               }}
@@ -317,11 +306,11 @@ function FullScreenVisualization(props: Props & { id: string }) {
               className="link"
               onClick={() => {
                 if (viz == null) return;
-                const id = uuid();
+                const visualizationId = uuid();
                 updateVisualizations((visualizations) =>
                   visualizations.concat({
                     ...viz,
-                    id,
+                    visualizationId,
                     displayName:
                       'Copy of ' + (viz.displayName || 'unnamed visualization'),
                   })
@@ -347,7 +336,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
         <ContentError>Computation not found.</ContentError>
       ) : vizType == null ? (
         <ContentError>
-          <>Visualization type not implemented: {viz.type}</>
+          <>Visualization type not implemented: {viz.descriptor.type}</>
         </ContentError>
       ) : (
         <div>
@@ -357,7 +346,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
               onSave={(value) =>
                 updateVisualizations((visualizations) =>
                   visualizations.map((v) =>
-                    v.id !== id ? v : { ...v, displayName: value }
+                    v.visualizationId !== id ? v : { ...v, displayName: value }
                   )
                 )
               }

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import {
   Route,
   Switch,

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -112,10 +112,10 @@ function BarplotViz(props: VisualizationProps) {
 
   const vizConfig = useMemo(() => {
     return pipe(
-      BarplotConfig.decode(visualization.configuration),
+      BarplotConfig.decode(visualization.descriptor.configuration),
       getOrElse((): t.TypeOf<typeof BarplotConfig> => createDefaultConfig())
     );
-  }, [visualization.configuration]);
+  }, [visualization.descriptor.configuration]);
 
   const updateVizConfig = useCallback(
     (newConfig: Partial<BarplotConfig>) => {
@@ -182,7 +182,7 @@ function BarplotViz(props: VisualizationProps) {
       const params = getRequestParams(studyId, filters ?? [], vizConfig);
 
       const response = dataClient.getBarplot(
-        computation.type,
+        computation.descriptor.type,
         params as BarplotRequestParams
       );
 
@@ -209,7 +209,7 @@ function BarplotViz(props: VisualizationProps) {
       vizConfig.showMissingness,
       variable,
       overlayVariable,
-      computation.type,
+      computation.descriptor.type,
     ])
   );
 

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -359,17 +359,24 @@ function BarplotWithControls({
   updateThumbnail,
   ...barPlotProps
 }: BarplotWithControlsProps) {
-  const ref = useRef<PlotRef>(null);
+  const plotRef = useRef<PlotRef>(null);
+
+  const updateThumbnailRef = useRef(updateThumbnail);
   useEffect(() => {
-    ref.current
+    updateThumbnailRef.current = updateThumbnail;
+  });
+
+  useEffect(() => {
+    plotRef.current
       ?.toImage({ format: 'svg', ...plotDimensions })
-      .then((src) => updateThumbnail(src));
-  }, [data, updateThumbnail, dependentAxisLogScale]);
+      .then(updateThumbnailRef.current);
+  }, [data, dependentAxisLogScale]);
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <Barplot
         {...barPlotProps}
-        ref={ref}
+        ref={plotRef}
         dependentAxisLogScale={dependentAxisLogScale}
         data={data}
         // add controls

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -101,10 +101,10 @@ function BoxplotViz(props: VisualizationProps) {
 
   const vizConfig = useMemo(() => {
     return pipe(
-      BoxplotConfig.decode(visualization.configuration),
+      BoxplotConfig.decode(visualization.descriptor.configuration),
       getOrElse((): t.TypeOf<typeof BoxplotConfig> => createDefaultConfig())
     );
-  }, [visualization.configuration]);
+  }, [visualization.descriptor.configuration]);
 
   const updateVizConfig = useCallback(
     (newConfig: Partial<BoxplotConfig>) => {
@@ -198,7 +198,7 @@ function BoxplotViz(props: VisualizationProps) {
 
       // boxplot
       const response = dataClient.getBoxplot(
-        computation.type,
+        computation.descriptor.type,
         params as BoxplotRequestParams
       );
 
@@ -222,8 +222,8 @@ function BoxplotViz(props: VisualizationProps) {
       xAxisVariable,
       yAxisVariable,
       overlayVariable,
-      computation.type,
-      visualization.type,
+      computation.descriptor.type,
+      visualization.descriptor.type,
     ])
   );
 

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -376,17 +376,24 @@ function BoxplotWithControls({
   updateThumbnail,
   ...boxplotComponentProps
 }: BoxplotWithControlsProps) {
-  const ref = useRef<PlotRef>(null);
+  const plotRef = useRef<PlotRef>(null);
+
+  const updateThumbnailRef = useRef(updateThumbnail);
   useEffect(() => {
-    ref.current
+    updateThumbnailRef.current = updateThumbnail;
+  });
+
+  useEffect(() => {
+    plotRef.current
       ?.toImage({ format: 'svg', ...plotDimensions })
-      .then(updateThumbnail);
-  }, [data, updateThumbnail]);
+      .then(updateThumbnailRef.current);
+  }, [data]);
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <Boxplot
         {...boxplotComponentProps}
-        ref={ref}
+        ref={plotRef}
         data={data}
         // add controls
         displayLibraryControls={false}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -401,13 +401,18 @@ function HistogramPlotWithControls({
       ? completeCasesAllVars
       : completeCasesAxesVars;
 
-  const ref = useRef<PlotRef>(null);
+  const plotRef = useRef<PlotRef>(null);
+
+  const updateThumbnailRef = useRef(updateThumbnail);
+  useEffect(() => {
+    updateThumbnailRef.current = updateThumbnail;
+  });
 
   useEffect(() => {
-    ref.current
+    plotRef.current
       ?.toImage({ format: 'svg', ...plotDimensions })
-      .then(updateThumbnail);
-  }, [updateThumbnail, data, histogramProps.dependentAxisLogScale]);
+      .then(updateThumbnailRef.current);
+  }, [data, histogramProps.dependentAxisLogScale]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -421,7 +426,7 @@ function HistogramPlotWithControls({
       >
         <Histogram
           {...histogramProps}
-          ref={ref}
+          ref={plotRef}
           data={data}
           opacity={opacity}
           displayLibraryControls={displayLibraryControls}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -123,10 +123,10 @@ function HistogramViz(props: VisualizationProps) {
 
   const vizConfig = useMemo(() => {
     return pipe(
-      HistogramConfig.decode(visualization.configuration),
+      HistogramConfig.decode(visualization.descriptor.configuration),
       getOrElse((): t.TypeOf<typeof HistogramConfig> => createDefaultConfig())
     );
-  }, [visualization.configuration]);
+  }, [visualization.descriptor.configuration]);
 
   const updateVizConfig = useCallback(
     (newConfig: Partial<HistogramConfig>) => {
@@ -221,7 +221,10 @@ function HistogramViz(props: VisualizationProps) {
         valueType,
         vizConfig
       );
-      const response = dataClient.getHistogram(computation.type, params);
+      const response = dataClient.getHistogram(
+        computation.descriptor.type,
+        params
+      );
       const showMissing = vizConfig.showMissingness && overlayVariable != null;
       return omitEmptyNoDataSeries(
         grayOutLastSeries(
@@ -244,7 +247,7 @@ function HistogramViz(props: VisualizationProps) {
       studyId,
       filters,
       dataClient,
-      computation.type,
+      computation.descriptor.type,
       xAxisVariable,
       overlayVariable,
     ])

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -457,19 +457,25 @@ function MosaicPlotWithControls({
   ...mosaicProps
 }: MosaicPlotWithControlsProps) {
   const displayLibraryControls = false;
-  const ref = useRef<PlotRef>(null);
+
+  const plotRef = useRef<PlotRef>(null);
+
+  const updateThumbnailRef = useRef(updateThumbnail);
+  useEffect(() => {
+    updateThumbnailRef.current = updateThumbnail;
+  });
 
   useEffect(() => {
-    ref.current
+    plotRef.current
       ?.toImage({ format: 'svg', ...plotDimensions })
-      .then(updateThumbnail);
-  }, [updateThumbnail, data]);
+      .then(updateThumbnailRef.current);
+  }, [data]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <Mosaic
         {...mosaicProps}
-        ref={ref}
+        ref={plotRef}
         data={data}
         displayLibraryControls={displayLibraryControls}
       />

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -139,10 +139,10 @@ function MosaicViz(props: Props) {
 
   const vizConfig = useMemo(() => {
     return pipe(
-      MosaicConfig.decode(visualization.configuration),
+      MosaicConfig.decode(visualization.descriptor.configuration),
       getOrElse((): t.TypeOf<typeof MosaicConfig> => createDefaultConfig())
     );
-  }, [visualization.configuration]);
+  }, [visualization.descriptor.configuration]);
 
   const updateVizConfig = useCallback(
     (newConfig: Partial<MosaicConfig>) => {
@@ -210,7 +210,10 @@ function MosaicViz(props: Props) {
       );
 
       if (isTwoByTwo) {
-        const response = dataClient.getTwoByTwo(computation.type, params);
+        const response = dataClient.getTwoByTwo(
+          computation.descriptor.type,
+          params
+        );
 
         return reorderData(
           twoByTwoResponseToData(await response),
@@ -218,7 +221,10 @@ function MosaicViz(props: Props) {
           yAxisVariable.vocabulary
         );
       } else {
-        const response = dataClient.getContTable(computation.type, params);
+        const response = dataClient.getContTable(
+          computation.descriptor.type,
+          params
+        );
 
         return reorderData(
           contTableResponseToData(await response),
@@ -233,7 +239,7 @@ function MosaicViz(props: Props) {
       vizConfig,
       xAxisVariable,
       yAxisVariable,
-      computation.type,
+      computation.descriptor.type,
       isTwoByTwo,
       outputEntity?.id,
     ])

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -137,10 +137,10 @@ function ScatterplotViz(props: VisualizationProps) {
 
   const vizConfig = useMemo(() => {
     return pipe(
-      ScatterplotConfig.decode(visualization.configuration),
+      ScatterplotConfig.decode(visualization.descriptor.configuration),
       getOrElse((): t.TypeOf<typeof ScatterplotConfig> => createDefaultConfig())
     );
-  }, [visualization.configuration]);
+  }, [visualization.descriptor.configuration]);
 
   const updateVizConfig = useCallback(
     (newConfig: Partial<ScatterplotConfig>) => {
@@ -240,19 +240,19 @@ function ScatterplotViz(props: VisualizationProps) {
         filters ?? [],
         vizConfig,
         outputEntity,
-        visualization.type
+        visualization.descriptor.type
       );
 
       // scatterplot, lineplot
       const response =
-        visualization.type === 'lineplot'
+        visualization.descriptor.type === 'lineplot'
           ? dataClient.getLineplot(
-              computation.type,
+              computation.descriptor.type,
               params as LineplotRequestParams
             )
           : // set default as scatterplot/getScatterplot
             dataClient.getScatterplot(
-              computation.type,
+              computation.descriptor.type,
               params as ScatterplotRequestParams
             );
 
@@ -262,7 +262,7 @@ function ScatterplotViz(props: VisualizationProps) {
           await response,
           vocabularyWithMissingData(overlayVariable?.vocabulary, showMissing)
         ),
-        visualization.type,
+        visualization.descriptor.type,
         independentValueType,
         dependentValueType,
         showMissing
@@ -275,8 +275,8 @@ function ScatterplotViz(props: VisualizationProps) {
       xAxisVariable,
       yAxisVariable,
       overlayVariable,
-      computation.type,
-      visualization.type,
+      computation.descriptor.type,
+      visualization.descriptor.type,
     ])
   );
 
@@ -395,7 +395,7 @@ function ScatterplotViz(props: VisualizationProps) {
           }
           onValueSpecChange={onValueSpecChange}
           // send visualization.type here
-          vizType={visualization.type}
+          vizType={visualization.descriptor.type}
           interactive={true}
           showSpinner={data.pending}
           // add plotOptions to control the list of plot options

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -494,19 +494,24 @@ function ScatterplotWithControls({
   //   };
   // }, []);
 
-  const ref = useRef<PlotRef>(null);
+  const plotRef = useRef<PlotRef>(null);
+
+  const updateThumbnailRef = useRef(updateThumbnail);
+  useEffect(() => {
+    updateThumbnailRef.current = updateThumbnail;
+  });
 
   useEffect(() => {
-    ref.current
+    plotRef.current
       ?.toImage({ format: 'svg', ...plotDimensions })
-      .then(updateThumbnail);
-  }, [data, updateThumbnail]);
+      .then(updateThumbnailRef.current);
+  }, [data]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <XYPlot
         {...scatterplotProps}
-        ref={ref}
+        ref={plotRef}
         data={data}
         // add controls
         displayLibraryControls={false}

--- a/src/lib/core/hooks/analysis.ts
+++ b/src/lib/core/hooks/analysis.ts
@@ -100,7 +100,7 @@ export function useAnalysis(analysisId: string): AnalysisState {
         setCurrent((_a) => {
           const newNestedValue =
             typeof nestedValue === 'function'
-              ? (nestedValue as (nestedValue: T) => T)(nestedValueLens.get(_a))
+              ? nestedValueLens.get(_a)
               : nestedValue;
 
           return nestedValueLens.set(newNestedValue)(_a);

--- a/src/lib/core/hooks/analysis.ts
+++ b/src/lib/core/hooks/analysis.ts
@@ -100,7 +100,7 @@ export function useAnalysis(analysisId: string): AnalysisState {
         setCurrent((_a) => {
           const newNestedValue =
             typeof nestedValue === 'function'
-              ? nestedValueLens.get(_a)
+              ? (nestedValue as (nestedValue: T) => T)(nestedValueLens.get(_a))
               : nestedValue;
 
           return nestedValueLens.set(newNestedValue)(_a);

--- a/src/lib/core/hooks/analysisClient.ts
+++ b/src/lib/core/hooks/analysisClient.ts
@@ -2,11 +2,11 @@ import { useMemo } from 'react';
 
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 
-import { NewAnalysisClient } from '../api/analysis-api';
+import { AnalysisClient } from '../api/analysis-api';
 
 export function useConfiguredAnalysisClient(
   userServiceUrl: string
-): NewAnalysisClient | undefined {
+): AnalysisClient | undefined {
   const user = useWdkService((wdkService) => wdkService.getCurrentUser(), []);
 
   const authKey = useMemo(() => {
@@ -33,5 +33,5 @@ export function useConfiguredAnalysisClient(
 
   return user == null || authKey == null
     ? undefined
-    : NewAnalysisClient.getClient({ userServiceUrl, userId: user.id, authKey });
+    : AnalysisClient.getClient({ userServiceUrl, userId: user.id, authKey });
 }

--- a/src/lib/core/hooks/analysisClient.ts
+++ b/src/lib/core/hooks/analysisClient.ts
@@ -1,37 +1,10 @@
-import { useMemo } from 'react';
-
-import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
+import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
+import { WdkDepdendenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
 
 import { AnalysisClient } from '../api/analysis-api';
 
-export function useConfiguredAnalysisClient(
-  userServiceUrl: string
-): AnalysisClient | undefined {
-  const user = useWdkService((wdkService) => wdkService.getCurrentUser(), []);
+export function useConfiguredAnalysisClient(userServiceUrl: string) {
+  const { wdkService } = useNonNullableContext(WdkDepdendenciesContext);
 
-  const authKey = useMemo(() => {
-    if (user == null) {
-      return undefined;
-    }
-
-    if (user.isGuest) {
-      return String(user.id);
-    }
-
-    const wdkCheckAuth = document.cookie
-      .split('; ')
-      .find((x) => x.startsWith('wdk_check_auth='));
-
-    if (wdkCheckAuth == null) {
-      throw new Error(
-        `Tried to retrieve a non-existent WDK auth key for user ${user.id}`
-      );
-    }
-
-    return wdkCheckAuth.replace(/^wdk_check_auth=/, '');
-  }, [user]);
-
-  return user == null || authKey == null
-    ? undefined
-    : AnalysisClient.getClient({ userServiceUrl, userId: user.id, authKey });
+  return AnalysisClient.getClient(userServiceUrl, wdkService);
 }

--- a/src/lib/core/hooks/analysisClient.ts
+++ b/src/lib/core/hooks/analysisClient.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
-import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 
 import { NewAnalysisClient } from '../api/analysis-api';
 
@@ -32,7 +31,7 @@ export function useConfiguredAnalysisClient(
     return wdkCheckAuth;
   }, [user]);
 
-  return user == undefined || authKey == undefined
+  return user == null || authKey == null
     ? undefined
     : NewAnalysisClient.getClient({ userServiceUrl, userId: user.id, authKey });
 }

--- a/src/lib/core/hooks/analysisClient.ts
+++ b/src/lib/core/hooks/analysisClient.ts
@@ -1,11 +1,16 @@
 import { useMemo } from 'react';
 
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
+import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 
-export function useAuthKey() {
+import { NewAnalysisClient } from '../api/analysis-api';
+
+export function useConfiguredAnalysisClient(
+  userServiceUrl: string
+): NewAnalysisClient | undefined {
   const user = useWdkService((wdkService) => wdkService.getCurrentUser(), []);
 
-  return useMemo(() => {
+  const authKey = useMemo(() => {
     if (user == null) {
       return undefined;
     }
@@ -26,4 +31,8 @@ export function useAuthKey() {
 
     return wdkCheckAuth;
   }, [user]);
+
+  return user == undefined || authKey == undefined
+    ? undefined
+    : NewAnalysisClient.getClient({ userServiceUrl, userId: user.id, authKey });
 }

--- a/src/lib/core/hooks/analysisClient.ts
+++ b/src/lib/core/hooks/analysisClient.ts
@@ -28,7 +28,7 @@ export function useConfiguredAnalysisClient(
       );
     }
 
-    return wdkCheckAuth;
+    return wdkCheckAuth.replace(/^wdk_check_auth=/, '');
   }, [user]);
 
   return user == null || authKey == null

--- a/src/lib/core/hooks/auth.ts
+++ b/src/lib/core/hooks/auth.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+
+import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
+
+export function useAuthKey() {
+  const user = useWdkService((wdkService) => wdkService.getCurrentUser(), []);
+
+  return useMemo(() => {
+    if (user == null) {
+      return undefined;
+    }
+
+    if (user.isGuest) {
+      return String(user.id);
+    }
+
+    const wdkCheckAuth = document.cookie
+      .split('; ')
+      .find((x) => x.startsWith('wdk_check_auth='));
+
+    if (wdkCheckAuth == null) {
+      throw new Error(
+        `Tried to retrieve a non-existent WDK auth key for user ${user.id}`
+      );
+    }
+
+    return wdkCheckAuth;
+  }, [user]);
+}

--- a/src/lib/core/hooks/starredVariables.ts
+++ b/src/lib/core/hooks/starredVariables.ts
@@ -1,4 +1,9 @@
 import { useCallback } from 'react';
+
+import { isEqual, negate } from 'lodash/fp';
+
+import { VariableDescriptor } from '../types/variable';
+
 import { AnalysisState } from './analysis';
 
 export function useToggleStarredVariable({
@@ -6,20 +11,20 @@ export function useToggleStarredVariable({
   setStarredVariables,
 }: AnalysisState) {
   return useCallback(
-    (targetVariableId: string) => {
+    (targetVariable: VariableDescriptor) => {
       if (analysis == null) {
         return;
       }
 
       const oldStarredVariables = analysis.starredVariables;
 
-      const newStarredVariables = !oldStarredVariables.includes(
-        targetVariableId
-      )
-        ? [...oldStarredVariables, targetVariableId]
-        : oldStarredVariables.filter(
-            (variableId) => variableId !== targetVariableId
-          );
+      const targetVariablePresent = oldStarredVariables.some(
+        isEqual(targetVariable)
+      );
+
+      const newStarredVariables = !targetVariablePresent
+        ? [...oldStarredVariables, targetVariable]
+        : oldStarredVariables.filter(negate(isEqual(targetVariable)));
 
       setStarredVariables(newStarredVariables);
     },

--- a/src/lib/core/hooks/starredVariables.ts
+++ b/src/lib/core/hooks/starredVariables.ts
@@ -16,7 +16,7 @@ export function useToggleStarredVariable({
         return;
       }
 
-      const oldStarredVariables = analysis.starredVariables;
+      const oldStarredVariables = analysis.descriptor.starredVariables;
 
       const targetVariablePresent = oldStarredVariables.some(
         isEqual(targetVariable)

--- a/src/lib/core/hooks/variableCoverage.ts
+++ b/src/lib/core/hooks/variableCoverage.ts
@@ -1,8 +1,6 @@
 import { useMemo } from 'react';
 
-import { keyBy, mapValues } from 'lodash';
-
-import { CompleteCasesTable, CompleteCasesTableRow } from '../api/data-api';
+import { CompleteCasesTable } from '../api/data-api';
 import {
   VariableCoverageTableRow,
   VariableSpec,

--- a/src/lib/core/types/analysis.ts
+++ b/src/lib/core/types/analysis.ts
@@ -29,7 +29,7 @@ export const AnalysisBase = t.intersection([
   }),
 ]);
 
-export type AnalysisSummary = t.TypeOf<typeof AnalysisBase>;
+export type AnalysisSummary = t.TypeOf<typeof AnalysisSummary>;
 export const AnalysisSummary = t.intersection([
   AnalysisBase,
   t.type({

--- a/src/lib/core/types/analysis.ts
+++ b/src/lib/core/types/analysis.ts
@@ -2,15 +2,15 @@
 import * as t from 'io-ts';
 import { Filter } from './filter';
 import { VariableDescriptor } from './variable';
-import { Computation, Visualization } from './visualization';
+import { Computation, NewComputation, Visualization } from './visualization';
 
 export type AnalysisPreferences = t.TypeOf<typeof AnalysisPreferences>;
 export const AnalysisPreferences = t.partial({
   pinnedAnalyses: t.array(t.string),
 });
 
-export type DerviedVariable = t.TypeOf<typeof DerviedVariable>;
-export const DerviedVariable = t.unknown;
+export type DerivedVariable = t.TypeOf<typeof DerivedVariable>;
+export const DerivedVariable = t.unknown;
 
 export type VariableUISetting = t.TypeOf<typeof VariableUISetting>;
 export const VariableUISetting = t.UnknownRecord;
@@ -47,7 +47,7 @@ export const NewAnalysis = t.type({
   name: t.string,
   studyId: t.string,
   filters: t.array(Filter),
-  derivedVariables: t.array(DerviedVariable),
+  derivedVariables: t.array(DerivedVariable),
   starredVariables: t.array(VariableDescriptor),
   variableUISettings: t.record(t.string, VariableUISetting),
   visualizations: t.array(Visualization),
@@ -61,6 +61,39 @@ export const Analysis = t.intersection([
     id: t.string,
     created: t.string,
     modified: t.string,
+  }),
+]);
+
+export type AnalysisDescriptor = t.TypeOf<typeof AnalysisDescriptor>;
+export const AnalysisDescriptor = t.type({
+  subset: t.type({
+    descriptor: t.array(Filter),
+    uiSettings: t.record(t.string, VariableUISetting),
+  }),
+  computations: t.array(NewComputation),
+  starredVariables: t.array(VariableDescriptor),
+  dataTableColumns: t.array(VariableDescriptor),
+  derivedVariables: t.array(DerivedVariable),
+});
+
+export type NewAnalysisDetails = t.TypeOf<typeof NewAnalysisDetails>;
+export const NewAnalysisDetails = t.intersection([
+  AnalysisBase,
+  t.type({
+    descriptor: AnalysisDescriptor,
+  }),
+]);
+
+export type AnalysisDetails = t.TypeOf<typeof AnalysisDetails>;
+export const AnalysisDetails = t.intersection([
+  NewAnalysisDetails,
+  t.type({
+    analysisId: t.string,
+    creationTime: t.string,
+    modificationTime: t.string,
+    numFilters: t.number,
+    numComputations: t.number,
+    numVisualizations: t.number,
   }),
 ]);
 

--- a/src/lib/core/types/analysis.ts
+++ b/src/lib/core/types/analysis.ts
@@ -15,6 +15,33 @@ export const DerviedVariable = t.unknown;
 export type VariableUISetting = t.TypeOf<typeof VariableUISetting>;
 export const VariableUISetting = t.UnknownRecord;
 
+export type AnalysisBase = t.TypeOf<typeof AnalysisBase>;
+export const AnalysisBase = t.intersection([
+  t.type({
+    studyId: t.string,
+    studyVersion: t.string,
+    apiVersion: t.string,
+    isPublic: t.boolean,
+  }),
+  t.partial({
+    displayName: t.string,
+    description: t.string,
+  }),
+]);
+
+export type AnalysisSummary = t.TypeOf<typeof AnalysisBase>;
+export const AnalysisSummary = t.intersection([
+  AnalysisBase,
+  t.type({
+    analysisId: t.string,
+    creationTime: t.string,
+    modificationTime: t.string,
+    numFilters: t.number,
+    numComputations: t.number,
+    numVisualizations: t.number,
+  }),
+]);
+
 export type NewAnalysis = t.TypeOf<typeof NewAnalysis>;
 export const NewAnalysis = t.type({
   name: t.string,

--- a/src/lib/core/types/analysis.ts
+++ b/src/lib/core/types/analysis.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 import * as t from 'io-ts';
 import { Filter } from './filter';
+import { VariableDescriptor } from './variable';
 import { Computation, Visualization } from './visualization';
 
 export type AnalysisPreferences = t.TypeOf<typeof AnalysisPreferences>;
@@ -20,7 +21,7 @@ export const NewAnalysis = t.type({
   studyId: t.string,
   filters: t.array(Filter),
   derivedVariables: t.array(DerviedVariable),
-  starredVariables: t.array(t.string),
+  starredVariables: t.array(VariableDescriptor),
   variableUISettings: t.record(t.string, VariableUISetting),
   visualizations: t.array(Visualization),
   computations: t.array(Computation),

--- a/src/lib/core/types/analysis.ts
+++ b/src/lib/core/types/analysis.ts
@@ -2,7 +2,7 @@
 import * as t from 'io-ts';
 import { Filter } from './filter';
 import { VariableDescriptor } from './variable';
-import { Computation, NewComputation, Visualization } from './visualization';
+import { Computation } from './visualization';
 
 export type AnalysisPreferences = t.TypeOf<typeof AnalysisPreferences>;
 export const AnalysisPreferences = t.partial({
@@ -22,9 +22,9 @@ export const AnalysisBase = t.intersection([
     studyVersion: t.string,
     apiVersion: t.string,
     isPublic: t.boolean,
+    displayName: t.string,
   }),
   t.partial({
-    displayName: t.string,
     description: t.string,
   }),
 ]);
@@ -42,51 +42,29 @@ export const AnalysisSummary = t.intersection([
   }),
 ]);
 
-export type NewAnalysis = t.TypeOf<typeof NewAnalysis>;
-export const NewAnalysis = t.type({
-  name: t.string,
-  studyId: t.string,
-  filters: t.array(Filter),
-  derivedVariables: t.array(DerivedVariable),
-  starredVariables: t.array(VariableDescriptor),
-  variableUISettings: t.record(t.string, VariableUISetting),
-  visualizations: t.array(Visualization),
-  computations: t.array(Computation),
-});
-
-export type Analysis = t.TypeOf<typeof Analysis>;
-export const Analysis = t.intersection([
-  NewAnalysis,
-  t.type({
-    id: t.string,
-    created: t.string,
-    modified: t.string,
-  }),
-]);
-
 export type AnalysisDescriptor = t.TypeOf<typeof AnalysisDescriptor>;
 export const AnalysisDescriptor = t.type({
   subset: t.type({
     descriptor: t.array(Filter),
     uiSettings: t.record(t.string, VariableUISetting),
   }),
-  computations: t.array(NewComputation),
+  computations: t.array(Computation),
   starredVariables: t.array(VariableDescriptor),
   dataTableColumns: t.array(VariableDescriptor),
   derivedVariables: t.array(DerivedVariable),
 });
 
-export type NewAnalysisDetails = t.TypeOf<typeof NewAnalysisDetails>;
-export const NewAnalysisDetails = t.intersection([
+export type NewAnalysis = t.TypeOf<typeof NewAnalysis>;
+export const NewAnalysis = t.intersection([
   AnalysisBase,
   t.type({
     descriptor: AnalysisDescriptor,
   }),
 ]);
 
-export type AnalysisDetails = t.TypeOf<typeof AnalysisDetails>;
-export const AnalysisDetails = t.intersection([
-  NewAnalysisDetails,
+export type Analysis = t.TypeOf<typeof Analysis>;
+export const Analysis = t.intersection([
+  NewAnalysis,
   t.type({
     analysisId: t.string,
     creationTime: t.string,
@@ -99,13 +77,30 @@ export const AnalysisDetails = t.intersection([
 
 export function makeNewAnalysis(studyId: string): NewAnalysis {
   return {
-    name: 'Unnamed Analysis',
+    displayName: 'Unnamed Analysis',
     studyId,
-    filters: [],
-    starredVariables: [],
-    derivedVariables: [],
-    visualizations: [],
-    computations: [],
-    variableUISettings: {},
+    isPublic: false,
+    studyVersion: '',
+    apiVersion: '',
+    descriptor: {
+      subset: {
+        descriptor: [],
+        uiSettings: {},
+      },
+      starredVariables: [],
+      dataTableColumns: [],
+      derivedVariables: [],
+      computations: [
+        {
+          computationId: 'pass-through',
+          displayName: 'Passthrough',
+          descriptor: {
+            type: 'pass',
+            configuration: undefined,
+          },
+          visualizations: [],
+        },
+      ],
+    },
   };
 }

--- a/src/lib/core/types/visualization.ts
+++ b/src/lib/core/types/visualization.ts
@@ -15,55 +15,27 @@ import { VariableDataShape, VariableType } from './study';
 import { CompleteCasesTable } from '../api/data-api';
 
 /**
- * Visualization object stored in user's analysis
+ * Metadata for the visualization object stored in user's analysis
  */
-export type Visualization = TypeOf<typeof Visualization>;
-export const Visualization = intersection([
+export type VisualizationDescriptor = TypeOf<typeof VisualizationDescriptor>;
+export const VisualizationDescriptor = intersection([
   type({
-    id: string,
-    computationId: string,
     type: string,
     configuration: unknown,
   }),
   partial({
-    displayName: string,
     thumbnail: string,
   }),
 ]);
 
 /**
- * Metadata for the visualization object stored in user's analysis
- */
-export type VisualizationDescriptor = TypeOf<typeof VisualizationDescriptor>;
-export const VisualizationDescriptor = type({
-  type: string,
-  configuration: unknown,
-  thumbnail: string,
-});
-
-/**
  * Visualization object stored in user's analysis
  */
-export type NewVisualization = TypeOf<typeof NewVisualization>;
-export const NewVisualization = intersection([
+export type Visualization = TypeOf<typeof Visualization>;
+export const Visualization = intersection([
   type({
     visualizationId: string,
     descriptor: VisualizationDescriptor,
-  }),
-  partial({
-    displayName: string,
-  }),
-]);
-
-/**
- * App object stored in user's analysis
- */
-export type Computation = TypeOf<typeof Computation>;
-export const Computation = intersection([
-  type({
-    id: string,
-    type: string,
-    configuration: unknown,
   }),
   partial({
     displayName: string,
@@ -82,12 +54,12 @@ export const ComputationDescriptor = type({
 /**
  * App object stored in user's analysis
  */
-export type NewComputation = TypeOf<typeof NewComputation>;
-export const NewComputation = intersection([
+export type Computation = TypeOf<typeof Computation>;
+export const Computation = intersection([
   type({
     computationId: string,
     descriptor: ComputationDescriptor,
-    visualizations: array(NewVisualization),
+    visualizations: array(Visualization),
   }),
   partial({
     displayName: string,

--- a/src/lib/core/types/visualization.ts
+++ b/src/lib/core/types/visualization.ts
@@ -32,6 +32,30 @@ export const Visualization = intersection([
 ]);
 
 /**
+ * Metadata for the visualization object stored in user's analysis
+ */
+export type VisualizationDescriptor = TypeOf<typeof VisualizationDescriptor>;
+export const VisualizationDescriptor = type({
+  type: string,
+  configuration: unknown,
+  thumbnail: string,
+});
+
+/**
+ * Visualization object stored in user's analysis
+ */
+export type NewVisualization = TypeOf<typeof NewVisualization>;
+export const NewVisualization = intersection([
+  type({
+    visualizationId: string,
+    descriptor: VisualizationDescriptor,
+  }),
+  partial({
+    displayName: string,
+  }),
+]);
+
+/**
  * App object stored in user's analysis
  */
 export type Computation = TypeOf<typeof Computation>;
@@ -40,6 +64,30 @@ export const Computation = intersection([
     id: string,
     type: string,
     configuration: unknown,
+  }),
+  partial({
+    displayName: string,
+  }),
+]);
+
+/**
+ * Type and configuration of the app object stored in user's analysis
+ */
+export type ComputationDescriptor = TypeOf<typeof ComputationDescriptor>;
+export const ComputationDescriptor = type({
+  type: string,
+  configuration: unknown,
+});
+
+/**
+ * App object stored in user's analysis
+ */
+export type NewComputation = TypeOf<typeof NewComputation>;
+export const NewComputation = intersection([
+  type({
+    computationId: string,
+    descriptor: ComputationDescriptor,
+    visualizations: array(NewVisualization),
   }),
   partial({
     displayName: string,

--- a/src/lib/core/utils/analysis.ts
+++ b/src/lib/core/utils/analysis.ts
@@ -3,7 +3,6 @@ import {
   BarplotData,
   BoxplotData,
 } from '@veupathdb/components/lib/types/plots';
-import { gray } from '../components/visualizations/colors';
 import { CoverageStatistics } from '../types/visualization';
 
 export function vocabularyWithMissingData(

--- a/src/lib/mapveu/MapVeuAnalysis.tsx
+++ b/src/lib/mapveu/MapVeuAnalysis.tsx
@@ -32,7 +32,7 @@ export function MapVeuAnalysis(props: Props) {
       <dl>
         {' '}
         <dt>Name</dt>
-        <dd>{analysis?.name}</dd>
+        <dd>{analysis?.displayName}</dd>
         {/* <dt>Created</dt>
         <dd>{analysis.created}</dd> */}
       </dl>

--- a/src/lib/mapveu/MapVeuAnalysisList.tsx
+++ b/src/lib/mapveu/MapVeuAnalysisList.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useStudyRecord } from '../core';
+import { makeNewAnalysis, useStudyRecord } from '../core';
 import { useRouteMatch, Link, useHistory } from 'react-router-dom';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { AnalysisClient } from '../core/api/analysis-api';
@@ -17,23 +17,16 @@ export function AnalysisList(props: Props) {
   const list = usePromise(
     useCallback(async () => {
       const studies = await analysisStore.getAnalyses();
-      return studies.filter((study) => study.id === studyId);
+      return studies.filter((study) => study.analysisId === studyId);
     }, [studyId, analysisStore])
   );
   const { url } = useRouteMatch();
   const history = useHistory();
   const createAnalysis = useCallback(async () => {
-    const { id } = await analysisStore.createAnalysis({
-      name: 'Unnamed analysis',
-      studyId,
-      visualizations: [],
-      variableUISettings: {},
-      derivedVariables: [],
-      starredVariables: [],
-      filters: [],
-      computations: [],
-    });
-    history.push(`${url}/${id}`);
+    const { analysisId } = await analysisStore.createAnalysis(
+      makeNewAnalysis(studyId)
+    );
+    history.push(`${url}/${analysisId}`);
   }, [analysisStore, history, studyId, url]);
   return (
     <>
@@ -52,8 +45,8 @@ export function AnalysisList(props: Props) {
         <ul>
           {list.value?.map((analysis) => (
             <li>
-              <Link to={`${url}/${analysis.id}`}>
-                {safeHtml(analysis.name)}
+              <Link to={`${url}/${analysis.analysisId}`}>
+                {safeHtml(analysis.displayName)}
               </Link>
             </li>
           ))}

--- a/src/lib/mapveu/MapVeuContainer.tsx
+++ b/src/lib/mapveu/MapVeuContainer.tsx
@@ -1,5 +1,3 @@
-import { EDAAnalysisListContainer, EDAWorkspaceContainer } from '../core';
-import { SubsettingClient } from '../core/api/subsetting-api';
 import React from 'react';
 import {
   Route,
@@ -7,10 +5,16 @@ import {
   Switch,
   useRouteMatch,
 } from 'react-router';
+
+import { Loading } from '@veupathdb/wdk-client/lib/Components';
+
+import { EDAAnalysisListContainer, EDAWorkspaceContainer } from '../core';
+import { DataClient } from '../core/api/data-api';
+import { SubsettingClient } from '../core/api/subsetting-api';
+import { useConfiguredAnalysisClient } from '../core/hooks/analysisClient';
+
 import { AnalysisList } from './MapVeuAnalysisList';
 import { MapVeuAnalysis } from './MapVeuAnalysis';
-import { mockAnalysisStore } from './Mocks';
-import { DataClient } from '../core/api/data-api';
 import { StudyList } from './StudyList';
 
 const edaClient = new (class extends SubsettingClient {
@@ -28,6 +32,7 @@ export function MapVeuContainer() {
   // This will get the matched path of the active parent route.
   // This is useful so we don't have to hardcode the path root.
   const { path } = useRouteMatch();
+  const analysisClient = useConfiguredAnalysisClient('/eda-user-service');
   return (
     <>
       <h1>MapVEu</h1>
@@ -36,32 +41,40 @@ export function MapVeuContainer() {
           path={`${path}/:studyId/:analysisId`}
           render={(
             props: RouteComponentProps<{ studyId: string; analysisId: string }>
-          ) => (
-            <EDAWorkspaceContainer
-              studyId={props.match.params.studyId}
-              subsettingClient={edaClient}
-              analysisClient={mockAnalysisStore}
-              dataClient={dataClient}
-            >
-              <MapVeuAnalysis analysisId={props.match.params.analysisId} />
-            </EDAWorkspaceContainer>
-          )}
+          ) =>
+            analysisClient == null ? (
+              <Loading />
+            ) : (
+              <EDAWorkspaceContainer
+                studyId={props.match.params.studyId}
+                subsettingClient={edaClient}
+                analysisClient={analysisClient}
+                dataClient={dataClient}
+              >
+                <MapVeuAnalysis analysisId={props.match.params.analysisId} />
+              </EDAWorkspaceContainer>
+            )
+          }
         />
         <Route
           path={`${path}/:studyId`}
-          render={(props: RouteComponentProps<{ studyId: string }>) => (
-            <EDAAnalysisListContainer
-              studyId={props.match.params.studyId}
-              analysisClient={mockAnalysisStore}
-              subsettingClient={edaClient}
-              dataClient={dataClient}
-            >
-              <AnalysisList
+          render={(props: RouteComponentProps<{ studyId: string }>) =>
+            analysisClient == null ? (
+              <Loading />
+            ) : (
+              <EDAAnalysisListContainer
                 studyId={props.match.params.studyId}
-                analysisStore={mockAnalysisStore}
-              />
-            </EDAAnalysisListContainer>
-          )}
+                analysisClient={analysisClient}
+                subsettingClient={edaClient}
+                dataClient={dataClient}
+              >
+                <AnalysisList
+                  studyId={props.match.params.studyId}
+                  analysisStore={analysisClient}
+                />
+              </EDAAnalysisListContainer>
+            )
+          }
         />
         <Route path={path} component={StudyList} />
       </Switch>

--- a/src/lib/mapveu/MapVeuContainer.tsx
+++ b/src/lib/mapveu/MapVeuContainer.tsx
@@ -6,8 +6,6 @@ import {
   useRouteMatch,
 } from 'react-router';
 
-import { Loading } from '@veupathdb/wdk-client/lib/Components';
-
 import { EDAAnalysisListContainer, EDAWorkspaceContainer } from '../core';
 import { DataClient } from '../core/api/data-api';
 import { SubsettingClient } from '../core/api/subsetting-api';
@@ -41,40 +39,32 @@ export function MapVeuContainer() {
           path={`${path}/:studyId/:analysisId`}
           render={(
             props: RouteComponentProps<{ studyId: string; analysisId: string }>
-          ) =>
-            analysisClient == null ? (
-              <Loading />
-            ) : (
-              <EDAWorkspaceContainer
-                studyId={props.match.params.studyId}
-                subsettingClient={edaClient}
-                analysisClient={analysisClient}
-                dataClient={dataClient}
-              >
-                <MapVeuAnalysis analysisId={props.match.params.analysisId} />
-              </EDAWorkspaceContainer>
-            )
-          }
+          ) => (
+            <EDAWorkspaceContainer
+              studyId={props.match.params.studyId}
+              subsettingClient={edaClient}
+              analysisClient={analysisClient}
+              dataClient={dataClient}
+            >
+              <MapVeuAnalysis analysisId={props.match.params.analysisId} />
+            </EDAWorkspaceContainer>
+          )}
         />
         <Route
           path={`${path}/:studyId`}
-          render={(props: RouteComponentProps<{ studyId: string }>) =>
-            analysisClient == null ? (
-              <Loading />
-            ) : (
-              <EDAAnalysisListContainer
+          render={(props: RouteComponentProps<{ studyId: string }>) => (
+            <EDAAnalysisListContainer
+              studyId={props.match.params.studyId}
+              analysisClient={analysisClient}
+              subsettingClient={edaClient}
+              dataClient={dataClient}
+            >
+              <AnalysisList
                 studyId={props.match.params.studyId}
-                analysisClient={analysisClient}
-                subsettingClient={edaClient}
-                dataClient={dataClient}
-              >
-                <AnalysisList
-                  studyId={props.match.params.studyId}
-                  analysisStore={analysisClient}
-                />
-              </EDAAnalysisListContainer>
-            )
-          }
+                analysisStore={analysisClient}
+              />
+            </EDAAnalysisListContainer>
+          )}
         />
         <Route path={path} component={StudyList} />
       </Switch>

--- a/src/lib/mapveu/Mocks.ts
+++ b/src/lib/mapveu/Mocks.ts
@@ -1,25 +1,39 @@
-import { Analysis, NewAnalysis } from '../core';
-import localforage from 'localforage';
-import { AnalysisClient } from '../core/api/analysis-api';
-import { isRight } from 'fp-ts/lib/Either';
+import { isLeft, isRight } from 'fp-ts/lib/Either';
 import { PathReporter } from 'io-ts/lib/PathReporter';
+import localforage from 'localforage';
+import {
+  Analysis,
+  NewAnalysis,
+  AnalysisClient,
+  AnalysisPreferences,
+  NewAnalysisClient,
+  AnalysisSummary,
+  AnalysisDetails,
+  NewAnalysisDetails,
+  AnalysisDescriptor,
+} from '../core';
+import { max } from 'lodash';
 
-const localStore = localforage.createInstance({
+const analysisStore = localforage.createInstance({
   name: 'mockAnalysisStore',
+});
+
+const preferenceStore = localforage.createInstance({
+  name: 'mockPreferencesStore',
 });
 
 export const mockAnalysisStore: AnalysisClient = {
   async getAnalyses() {
     const records: Analysis[] = [];
-    await localStore.iterate((value) => {
+    await analysisStore.iterate((value) => {
       records.push(value as Analysis);
     });
     return records;
   },
   async createAnalysis(newAnalysis: NewAnalysis) {
-    const id = String((await localStore.keys()).length + 1);
+    const id = String((await analysisStore.keys()).length + 1);
     const now = new Date().toISOString();
-    await localStore.setItem<Analysis>(id, {
+    await analysisStore.setItem<Analysis>(id, {
       ...newAnalysis,
       id,
       created: now,
@@ -28,7 +42,7 @@ export const mockAnalysisStore: AnalysisClient = {
     return { id };
   },
   async getAnalysis(id: string) {
-    const analysis = await localStore.getItem(id);
+    const analysis = await analysisStore.getItem(id);
     if (analysis) {
       const result = Analysis.decode(analysis);
       if (isRight(result)) return result.right;
@@ -38,9 +52,107 @@ export const mockAnalysisStore: AnalysisClient = {
   },
   async updateAnalysis(analysis: Analysis) {
     const now = new Date().toISOString();
-    await localStore.setItem(analysis.id, { ...analysis, modified: now });
+    await analysisStore.setItem(analysis.id, { ...analysis, modified: now });
   },
   async deleteAnalysis(id: string) {
-    await localStore.removeItem(id);
+    await analysisStore.removeItem(id);
   },
 } as AnalysisClient;
+
+export const newMockAnalysisStore: NewAnalysisClient = {
+  async getPreferences() {
+    const prefs = await preferenceStore.getItem('preferences');
+    const result = AnalysisPreferences.decode(prefs);
+    if (isRight(result)) return result.right;
+    throw new Error(PathReporter.report(result).join('\n'));
+  },
+  async setPreferences(preferences: AnalysisPreferences) {
+    await preferenceStore.setItem<AnalysisPreferences>(
+      'preferences',
+      preferences
+    );
+  },
+  async getAnalyses() {
+    const records: AnalysisSummary[] = [];
+    await analysisStore.iterate((value) => {
+      const result = AnalysisDetails.decode(value);
+      if (isLeft(result)) {
+        throw new Error(PathReporter.report(result).join('\n'));
+      }
+      const { descriptor, ...analysisSummary } = result.right;
+      records.push(analysisSummary);
+    });
+    return records;
+  },
+  async createAnalysis(newAnalysis: NewAnalysisDetails) {
+    const usedIds = await analysisStore.keys();
+    const analysisId = String((max(usedIds.map((x) => Number(x))) ?? 0) + 1);
+    const now = new Date().toISOString();
+    await analysisStore.setItem<AnalysisDetails>(analysisId, {
+      ...newAnalysis,
+      ...computeSummaryCounts(newAnalysis.descriptor),
+      analysisId,
+      creationTime: now,
+      modificationTime: now,
+    });
+    return { analysisId };
+  },
+  async getAnalysis(id: string) {
+    const analysis = await analysisStore.getItem(id);
+    if (analysis) {
+      const result = AnalysisDetails.decode(analysis);
+      if (isRight(result)) return result.right;
+      throw new Error(PathReporter.report(result).join('\n'));
+    }
+    throw new Error(`Could not find analysis with id "${id}".`);
+  },
+  async updateAnalysis(
+    analysisId: string,
+    analysisPatch: Partial<NewAnalysisDetails>
+  ) {
+    const analysis = await analysisStore.getItem(analysisId);
+    if (analysis == null) {
+      throw new Error(
+        `Tried to update a nonexistent analysis with id "${analysisId}".`
+      );
+    }
+
+    const result = AnalysisDetails.decode(analysis);
+    if (isLeft(result)) {
+      throw new Error(PathReporter.report(result).join('\n'));
+    }
+
+    const decodedAnalysis = result.right;
+    const now = new Date().toISOString();
+    await analysisStore.setItem<AnalysisDetails>(analysisId, {
+      ...decodedAnalysis,
+      ...analysisPatch,
+      modificationTime: now,
+    });
+  },
+  async deleteAnalysis(id: string) {
+    await analysisStore.removeItem(id);
+  },
+  async deleteAnalyses(ids: Iterable<string>) {
+    const deletionPromises = Array.from(ids).map((id) =>
+      analysisStore.removeItem(id)
+    );
+
+    await Promise.allSettled(deletionPromises);
+  },
+} as NewAnalysisClient;
+
+function computeSummaryCounts(
+  descriptor: AnalysisDescriptor
+): Pick<
+  AnalysisSummary,
+  'numComputations' | 'numFilters' | 'numVisualizations'
+> {
+  return {
+    numFilters: descriptor.subset.descriptor.length,
+    numComputations: descriptor.computations.length,
+    numVisualizations: descriptor.computations
+      .map(({ visualizations }) => visualizations.length)
+      .reduce((memo, visualizationCount) => memo + visualizationCount, 0),
+  };
+}

--- a/src/lib/mapveu/Mocks.ts
+++ b/src/lib/mapveu/Mocks.ts
@@ -1,119 +1,16 @@
-import { isLeft, isRight } from 'fp-ts/lib/Either';
-import { PathReporter } from 'io-ts/lib/PathReporter';
 import localforage from 'localforage';
-import {
-  Analysis,
-  AnalysisClient,
-  AnalysisDescriptor,
-  AnalysisPreferences,
-  AnalysisSummary,
-  NewAnalysis,
-  SingleAnalysisPatchRequest,
-} from '../core';
-import { max } from 'lodash';
+
+import { makeMockAnalysisStore } from '../core/Mocks';
 
 const analysisStore = localforage.createInstance({
   name: 'mockAnalysisStore',
 });
 
 const preferenceStore = localforage.createInstance({
-  name: 'mockPreferencesStore',
+  name: 'mockPreferenceStore',
 });
 
-export const mockAnalysisStore: AnalysisClient = {
-  async getPreferences() {
-    const prefs = await preferenceStore.getItem('preferences');
-    const result = AnalysisPreferences.decode(prefs);
-    if (isRight(result)) return result.right;
-    throw new Error(PathReporter.report(result).join('\n'));
-  },
-  async setPreferences(preferences: AnalysisPreferences) {
-    await preferenceStore.setItem<AnalysisPreferences>(
-      'preferences',
-      preferences
-    );
-  },
-  async getAnalyses() {
-    const records: AnalysisSummary[] = [];
-    await analysisStore.iterate((value) => {
-      const result = Analysis.decode(value);
-      if (isLeft(result)) {
-        throw new Error(PathReporter.report(result).join('\n'));
-      }
-      const { descriptor, ...analysisSummary } = result.right;
-      records.push(analysisSummary);
-    });
-    return records;
-  },
-  async createAnalysis(newAnalysis: NewAnalysis) {
-    const usedIds = await analysisStore.keys();
-    const analysisId = String((max(usedIds.map((x) => Number(x))) ?? 0) + 1);
-    const now = new Date().toISOString();
-    await analysisStore.setItem<Analysis>(analysisId, {
-      ...newAnalysis,
-      ...computeSummaryCounts(newAnalysis.descriptor),
-      analysisId,
-      creationTime: now,
-      modificationTime: now,
-    });
-    return { analysisId };
-  },
-  async getAnalysis(id: string) {
-    const analysis = await analysisStore.getItem(id);
-    if (analysis) {
-      const result = Analysis.decode(analysis);
-      if (isRight(result)) return result.right;
-      throw new Error(PathReporter.report(result).join('\n'));
-    }
-    throw new Error(`Could not find analysis with id "${id}".`);
-  },
-  async updateAnalysis(
-    analysisId: string,
-    analysisPatch: SingleAnalysisPatchRequest
-  ) {
-    const analysis = await analysisStore.getItem(analysisId);
-    if (analysis == null) {
-      throw new Error(
-        `Tried to update a nonexistent analysis with id "${analysisId}".`
-      );
-    }
-
-    const result = Analysis.decode(analysis);
-    if (isLeft(result)) {
-      throw new Error(PathReporter.report(result).join('\n'));
-    }
-
-    const decodedAnalysis = result.right;
-    const now = new Date().toISOString();
-    await analysisStore.setItem<Analysis>(analysisId, {
-      ...decodedAnalysis,
-      ...analysisPatch,
-      modificationTime: now,
-    });
-  },
-  async deleteAnalysis(id: string) {
-    await analysisStore.removeItem(id);
-  },
-  async deleteAnalyses(ids: Iterable<string>) {
-    const deletionPromises = Array.from(ids).map((id) =>
-      analysisStore.removeItem(id)
-    );
-
-    await Promise.allSettled(deletionPromises);
-  },
-} as AnalysisClient;
-
-function computeSummaryCounts(
-  descriptor: AnalysisDescriptor
-): Pick<
-  AnalysisSummary,
-  'numComputations' | 'numFilters' | 'numVisualizations'
-> {
-  return {
-    numFilters: descriptor.subset.descriptor.length,
-    numComputations: descriptor.computations.length,
-    numVisualizations: descriptor.computations
-      .map(({ visualizations }) => visualizations.length)
-      .reduce((memo, visualizationCount) => memo + visualizationCount, 0),
-  };
-}
+export const mockAnalysisStore = makeMockAnalysisStore(
+  analysisStore,
+  preferenceStore
+);

--- a/src/lib/workspace/AnalysisList.tsx
+++ b/src/lib/workspace/AnalysisList.tsx
@@ -5,11 +5,11 @@ import * as Path from 'path';
 import * as React from 'react';
 import { useHistory } from 'react-router';
 import {
-  NewAnalysis,
-  Analysis,
-  useStudyRecord,
   AnalysisClient,
+  AnalysisSummary,
+  NewAnalysis,
   useAnalysisList,
+  useStudyRecord,
 } from '../core';
 
 export interface Props {
@@ -69,31 +69,32 @@ export function AnalysisList(props: Props) {
   const tableState = React.useMemo(
     () => ({
       options: {
-        isRowSelected: (analysis: Analysis) => selected.has(analysis.id),
+        isRowSelected: (analysis: AnalysisSummary) =>
+          selected.has(analysis.analysisId),
       },
       eventHandlers: {
-        onRowSelect: (analysis: Analysis) =>
+        onRowSelect: (analysis: AnalysisSummary) =>
           setSelected((set) => {
             const newSet = new Set(set);
-            newSet.add(analysis.id);
+            newSet.add(analysis.analysisId);
             return newSet;
           }),
-        onRowDeselect: (analysis: Analysis) =>
+        onRowDeselect: (analysis: AnalysisSummary) =>
           setSelected((set) => {
             const newSet = new Set(set);
-            newSet.delete(analysis.id);
+            newSet.delete(analysis.analysisId);
             return newSet;
           }),
-        onMultipleRowSelect: (analyses: Analysis[]) =>
+        onMultipleRowSelect: (analyses: AnalysisSummary[]) =>
           setSelected((set) => {
             const newSet = new Set(set);
-            for (const analysis of analyses) newSet.add(analysis.id);
+            for (const analysis of analyses) newSet.add(analysis.analysisId);
             return newSet;
           }),
-        onMultipleRowDeselect: (analyses: Analysis[]) =>
+        onMultipleRowDeselect: (analyses: AnalysisSummary[]) =>
           setSelected((set) => {
             const newSet = new Set(set);
-            for (const analysis of analyses) newSet.delete(analysis.id);
+            for (const analysis of analyses) newSet.delete(analysis.analysisId);
             return newSet;
           }),
       },
@@ -134,23 +135,25 @@ export function AnalysisList(props: Props) {
         {
           key: 'name',
           name: 'Name',
-          renderCell: (data: { row: Analysis }) => (
-            <Link to={Path.join(history.location.pathname, data.row.id)}>
-              {data.row.name}
+          renderCell: (data: { row: AnalysisSummary }) => (
+            <Link
+              to={Path.join(history.location.pathname, data.row.analysisId)}
+            >
+              {data.row.displayName}
             </Link>
           ),
         },
-        { key: 'created', name: 'Created' },
-        { key: 'modified', name: 'Modified' },
+        { key: 'creationTime', name: 'Created' },
+        { key: 'modificationTime', name: 'Modified' },
         {
           key: 'download',
           name: 'Download JSON',
-          renderCell: (data: { row: Analysis }) => (
+          renderCell: (data: { row: AnalysisSummary }) => (
             <a
               href={`data:text/plain;charset=utf-8,${encodeURIComponent(
                 JSON.stringify(data.row, null, 2)
               )}`}
-              download={`${data.row.name}.json`}
+              download={`${data.row.displayName}.json`}
             >
               Download JSON
             </a>

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -47,10 +47,11 @@ export function AnalysisPanel(props: Props) {
   } = analysisState;
   const { url: routeBase } = useRouteMatch();
   const totalCounts = useEntityCounts();
-  const filteredCounts = useEntityCounts(analysis?.filters);
+  const filters = analysis?.descriptor.subset.descriptor;
+  const filteredCounts = useEntityCounts(filters);
   const studyMetadata = useStudyMetadata();
   const entities = useStudyEntities(studyMetadata.rootEntity);
-  const filteredEntities = uniq(analysis?.filters.map((f) => f.entityId));
+  const filteredEntities = uniq(filters?.map((f) => f.entityId));
   const location = useLocation();
   const [lastVarPath, setLastVarPath] = useState('');
   const [lastVizPath, setLastVizPath] = useState('');
@@ -91,10 +92,12 @@ export function AnalysisPanel(props: Props) {
           open={globalFiltersDialogOpen}
           setOpen={setGlobalFiltersDialogOpen}
           entities={entities}
-          filters={analysis.filters}
+          filters={analysis.descriptor.subset.descriptor}
           setFilters={setFilters}
           removeFilter={(filter) =>
-            setFilters(analysis.filters.filter((f) => f !== filter))
+            setFilters(
+              analysis.descriptor.subset.descriptor.filter((f) => f !== filter)
+            )
           }
         />
         <Route

--- a/src/lib/workspace/AnalysisSummary.tsx
+++ b/src/lib/workspace/AnalysisSummary.tsx
@@ -10,7 +10,7 @@ import { cx } from './Utils';
 interface Props {
   analysis: Analysis | NewAnalysis;
   setAnalysisName: (name: string) => void;
-  copyAnalysis?: () => Promise<{ id: string }>;
+  copyAnalysis?: () => Promise<{ analysisId: string }>;
   saveAnalysis: () => Promise<void>;
   deleteAnalysis?: () => Promise<void>;
   onFilterIconClick: () => void;
@@ -32,7 +32,7 @@ export function AnalysisSummary(props: Props) {
     copyAnalysis &&
     (async () => {
       const res = await copyAnalysis();
-      history.replace(Path.resolve(url, `../${res.id}`));
+      history.replace(Path.resolve(url, `../${res.analysisId}`));
     });
   const handleDelete =
     deleteAnalysis &&
@@ -45,10 +45,10 @@ export function AnalysisSummary(props: Props) {
       <div className={cx('-AnalysisSummaryLeft')}>
         <SaveableTextEditor
           className={cx('-AnalysisNameEditBox')}
-          value={analysis.name}
+          value={analysis.displayName}
           onSave={setAnalysisName}
         />
-        {analysis.filters.length > 0 && (
+        {analysis.descriptor.subset.descriptor.length > 0 && (
           <Button
             className={cx('-SeeAllFiltersButton')}
             onClick={onFilterIconClick}

--- a/src/lib/workspace/EDAAnalysisList.tsx
+++ b/src/lib/workspace/EDAAnalysisList.tsx
@@ -1,7 +1,5 @@
 import React, { useMemo } from 'react';
 
-import { Loading } from '@veupathdb/wdk-client/lib/Components';
-
 import { RestrictedPage } from '@veupathdb/web-common/lib/App/DataRestriction/RestrictedPage';
 import { useApprovalStatus } from '@veupathdb/web-common/lib/hooks/dataRestriction';
 
@@ -31,28 +29,24 @@ export function EDAAnalysisList(props: Props) {
     [props.dataServiceUrl]
   );
 
-  const analysisClient:
-    | AnalysisClient
-    | undefined = useConfiguredAnalysisClient(props.userServiceUrl);
+  const analysisClient: AnalysisClient = useConfiguredAnalysisClient(
+    props.userServiceUrl
+  );
 
   const approvalStatus = useApprovalStatus(props.studyId, 'analysis');
 
   return (
     <RestrictedPage approvalStatus={approvalStatus}>
-      {analysisClient == null ? (
-        <Loading />
-      ) : (
-        <EDAAnalysisListContainer
-          studyId={props.studyId}
-          subsettingClient={subsettingClient}
-          dataClient={dataClient}
-          className={cx()}
-          analysisClient={analysisClient}
-        >
-          <EDAWorkspaceHeading />
-          <AnalysisList analysisStore={analysisClient} />
-        </EDAAnalysisListContainer>
-      )}
+      <EDAAnalysisListContainer
+        studyId={props.studyId}
+        subsettingClient={subsettingClient}
+        dataClient={dataClient}
+        className={cx()}
+        analysisClient={analysisClient}
+      >
+        <EDAWorkspaceHeading />
+        <AnalysisList analysisStore={analysisClient} />
+      </EDAAnalysisListContainer>
     </RestrictedPage>
   );
 }

--- a/src/lib/workspace/EDAAnalysisList.tsx
+++ b/src/lib/workspace/EDAAnalysisList.tsx
@@ -1,10 +1,14 @@
+import React, { useMemo } from 'react';
+
+import { Loading } from '@veupathdb/wdk-client/lib/Components';
+
 import { RestrictedPage } from '@veupathdb/web-common/lib/App/DataRestriction/RestrictedPage';
 import { useApprovalStatus } from '@veupathdb/web-common/lib/hooks/dataRestriction';
-import React, { useMemo } from 'react';
-import { EDAAnalysisListContainer } from '../core';
+
+import { AnalysisClient, EDAAnalysisListContainer } from '../core';
 import { SubsettingClient } from '../core/api/subsetting-api';
 import { DataClient } from '../core/api/data-api';
-import { mockAnalysisStore } from './Mocks';
+import { useConfiguredAnalysisClient } from '../core/hooks/analysisClient';
 import { EDAWorkspaceHeading } from './EDAWorkspaceHeading';
 import { AnalysisList } from './AnalysisList';
 import { cx } from './Utils';
@@ -13,6 +17,7 @@ export interface Props {
   studyId: string;
   subsettingServiceUrl: string;
   dataServiceUrl: string;
+  userServiceUrl: string;
 }
 
 export function EDAAnalysisList(props: Props) {
@@ -26,20 +31,28 @@ export function EDAAnalysisList(props: Props) {
     [props.dataServiceUrl]
   );
 
+  const analysisClient:
+    | AnalysisClient
+    | undefined = useConfiguredAnalysisClient(props.userServiceUrl);
+
   const approvalStatus = useApprovalStatus(props.studyId, 'analysis');
 
   return (
     <RestrictedPage approvalStatus={approvalStatus}>
-      <EDAAnalysisListContainer
-        studyId={props.studyId}
-        subsettingClient={subsettingClient}
-        dataClient={dataClient}
-        className={cx()}
-        analysisClient={mockAnalysisStore}
-      >
-        <EDAWorkspaceHeading />
-        <AnalysisList analysisStore={mockAnalysisStore} />
-      </EDAAnalysisListContainer>
+      {analysisClient == null ? (
+        <Loading />
+      ) : (
+        <EDAAnalysisListContainer
+          studyId={props.studyId}
+          subsettingClient={subsettingClient}
+          dataClient={dataClient}
+          className={cx()}
+          analysisClient={analysisClient}
+        >
+          <EDAWorkspaceHeading />
+          <AnalysisList analysisStore={analysisClient} />
+        </EDAAnalysisListContainer>
+      )}
     </RestrictedPage>
   );
 }

--- a/src/lib/workspace/LatestAnalysis.tsx
+++ b/src/lib/workspace/LatestAnalysis.tsx
@@ -26,12 +26,12 @@ export function LatestAnalysis(props: Props) {
         (analyses) =>
           orderBy(
             analyses.filter((analysis) => analysis.studyId === studyId),
-            (analysis) => analysis.modified,
+            (analysis) => analysis.modificationTime,
             ['desc']
           )[0]
       )
       .run((analysis) => {
-        const id = analysis?.id ?? 'new';
+        const id = analysis?.analysisId ?? 'new';
         const newLocation = {
           ...history.location,
           pathname: history.location.pathname.replace(replaceRegexp, id),

--- a/src/lib/workspace/Mocks.ts
+++ b/src/lib/workspace/Mocks.ts
@@ -1,16 +1,6 @@
-import { isLeft, isRight } from 'fp-ts/lib/Either';
-import { PathReporter } from 'io-ts/lib/PathReporter';
 import localforage from 'localforage';
-import {
-  Analysis,
-  AnalysisClient,
-  AnalysisDescriptor,
-  AnalysisPreferences,
-  AnalysisSummary,
-  NewAnalysis,
-  SingleAnalysisPatchRequest,
-} from '../core';
-import { max } from 'lodash';
+
+import { makeMockAnalysisStore } from '../core/Mocks';
 
 const analysisStore = localforage.createInstance({
   name: 'mockAnalysisStore',
@@ -20,100 +10,7 @@ const preferenceStore = localforage.createInstance({
   name: 'mockPreferenceStore',
 });
 
-export const mockAnalysisStore: AnalysisClient = {
-  async getPreferences() {
-    const prefs = await preferenceStore.getItem('preferences');
-    const result = AnalysisPreferences.decode(prefs);
-    if (isRight(result)) return result.right;
-    throw new Error(PathReporter.report(result).join('\n'));
-  },
-  async setPreferences(preferences: AnalysisPreferences) {
-    await preferenceStore.setItem<AnalysisPreferences>(
-      'preferences',
-      preferences
-    );
-  },
-  async getAnalyses() {
-    const records: AnalysisSummary[] = [];
-    await analysisStore.iterate((value) => {
-      const result = Analysis.decode(value);
-      if (isLeft(result)) {
-        throw new Error(PathReporter.report(result).join('\n'));
-      }
-      const { descriptor, ...analysisSummary } = result.right;
-      records.push(analysisSummary);
-    });
-    return records;
-  },
-  async createAnalysis(newAnalysis: NewAnalysis) {
-    const usedIds = await analysisStore.keys();
-    const analysisId = String((max(usedIds.map((x) => Number(x))) ?? 0) + 1);
-    const now = new Date().toISOString();
-    await analysisStore.setItem<Analysis>(analysisId, {
-      ...newAnalysis,
-      ...computeSummaryCounts(newAnalysis.descriptor),
-      analysisId,
-      creationTime: now,
-      modificationTime: now,
-    });
-    return { analysisId };
-  },
-  async getAnalysis(id: string) {
-    const analysis = await analysisStore.getItem(id);
-    if (analysis) {
-      const result = Analysis.decode(analysis);
-      if (isRight(result)) return result.right;
-      throw new Error(PathReporter.report(result).join('\n'));
-    }
-    throw new Error(`Could not find analysis with id "${id}".`);
-  },
-  async updateAnalysis(
-    analysisId: string,
-    analysisPatch: SingleAnalysisPatchRequest
-  ) {
-    const analysis = await analysisStore.getItem(analysisId);
-    if (analysis == null) {
-      throw new Error(
-        `Tried to update a nonexistent analysis with id "${analysisId}".`
-      );
-    }
-
-    const result = Analysis.decode(analysis);
-    if (isLeft(result)) {
-      throw new Error(PathReporter.report(result).join('\n'));
-    }
-
-    const decodedAnalysis = result.right;
-    const now = new Date().toISOString();
-    await analysisStore.setItem<Analysis>(analysisId, {
-      ...decodedAnalysis,
-      ...analysisPatch,
-      modificationTime: now,
-    });
-  },
-  async deleteAnalysis(id: string) {
-    await analysisStore.removeItem(id);
-  },
-  async deleteAnalyses(ids: Iterable<string>) {
-    const deletionPromises = Array.from(ids).map((id) =>
-      analysisStore.removeItem(id)
-    );
-
-    await Promise.allSettled(deletionPromises);
-  },
-} as AnalysisClient;
-
-function computeSummaryCounts(
-  descriptor: AnalysisDescriptor
-): Pick<
-  AnalysisSummary,
-  'numComputations' | 'numFilters' | 'numVisualizations'
-> {
-  return {
-    numFilters: descriptor.subset.descriptor.length,
-    numComputations: descriptor.computations.length,
-    numVisualizations: descriptor.computations
-      .map(({ visualizations }) => visualizations.length)
-      .reduce((memo, visualizationCount) => memo + visualizationCount, 0),
-  };
-}
+export const mockAnalysisStore = makeMockAnalysisStore(
+  analysisStore,
+  preferenceStore
+);

--- a/src/lib/workspace/Mocks.ts
+++ b/src/lib/workspace/Mocks.ts
@@ -1,4 +1,4 @@
-import { isRight } from 'fp-ts/lib/Either';
+import { isLeft, isRight } from 'fp-ts/lib/Either';
 import { PathReporter } from 'io-ts/lib/PathReporter';
 import localforage from 'localforage';
 import {
@@ -6,6 +6,11 @@ import {
   NewAnalysis,
   AnalysisClient,
   AnalysisPreferences,
+  NewAnalysisClient,
+  AnalysisSummary,
+  AnalysisDetails,
+  NewAnalysisDetails,
+  AnalysisDescriptor,
 } from '../core';
 import { max } from 'lodash';
 
@@ -66,3 +71,101 @@ export const mockAnalysisStore: AnalysisClient = {
     for (const id of ids) await analysisStore.removeItem(id);
   },
 } as AnalysisClient;
+
+export const newMockAnalysisStore: NewAnalysisClient = {
+  async getPreferences() {
+    const prefs = await preferenceStore.getItem('preferences');
+    const result = AnalysisPreferences.decode(prefs);
+    if (isRight(result)) return result.right;
+    throw new Error(PathReporter.report(result).join('\n'));
+  },
+  async setPreferences(preferences: AnalysisPreferences) {
+    await preferenceStore.setItem<AnalysisPreferences>(
+      'preferences',
+      preferences
+    );
+  },
+  async getAnalyses() {
+    const records: AnalysisSummary[] = [];
+    await analysisStore.iterate((value) => {
+      const result = AnalysisDetails.decode(value);
+      if (isLeft(result)) {
+        throw new Error(PathReporter.report(result).join('\n'));
+      }
+      const { descriptor, ...analysisSummary } = result.right;
+      records.push(analysisSummary);
+    });
+    return records;
+  },
+  async createAnalysis(newAnalysis: NewAnalysisDetails) {
+    const usedIds = await analysisStore.keys();
+    const analysisId = String((max(usedIds.map((x) => Number(x))) ?? 0) + 1);
+    const now = new Date().toISOString();
+    await analysisStore.setItem<AnalysisDetails>(analysisId, {
+      ...newAnalysis,
+      ...computeSummaryCounts(newAnalysis.descriptor),
+      analysisId,
+      creationTime: now,
+      modificationTime: now,
+    });
+    return { analysisId };
+  },
+  async getAnalysis(id: string) {
+    const analysis = await analysisStore.getItem(id);
+    if (analysis) {
+      const result = AnalysisDetails.decode(analysis);
+      if (isRight(result)) return result.right;
+      throw new Error(PathReporter.report(result).join('\n'));
+    }
+    throw new Error(`Could not find analysis with id "${id}".`);
+  },
+  async updateAnalysis(
+    analysisId: string,
+    analysisPatch: Partial<NewAnalysisDetails>
+  ) {
+    const analysis = await analysisStore.getItem(analysisId);
+    if (analysis == null) {
+      throw new Error(
+        `Tried to update a nonexistent analysis with id "${analysisId}".`
+      );
+    }
+
+    const result = AnalysisDetails.decode(analysis);
+    if (isLeft(result)) {
+      throw new Error(PathReporter.report(result).join('\n'));
+    }
+
+    const decodedAnalysis = result.right;
+    const now = new Date().toISOString();
+    await analysisStore.setItem<AnalysisDetails>(analysisId, {
+      ...decodedAnalysis,
+      ...analysisPatch,
+      modificationTime: now,
+    });
+  },
+  async deleteAnalysis(id: string) {
+    await analysisStore.removeItem(id);
+  },
+  async deleteAnalyses(ids: Iterable<string>) {
+    const deletionPromises = Array.from(ids).map((id) =>
+      analysisStore.removeItem(id)
+    );
+
+    await Promise.allSettled(deletionPromises);
+  },
+} as NewAnalysisClient;
+
+function computeSummaryCounts(
+  descriptor: AnalysisDescriptor
+): Pick<
+  AnalysisSummary,
+  'numComputations' | 'numFilters' | 'numVisualizations'
+> {
+  return {
+    numFilters: descriptor.subset.descriptor.length,
+    numComputations: descriptor.computations.length,
+    numVisualizations: descriptor.computations
+      .map(({ visualizations }) => visualizations.length)
+      .reduce((memo, visualizationCount) => memo + visualizationCount, 0),
+  };
+}

--- a/src/lib/workspace/Mocks.ts
+++ b/src/lib/workspace/Mocks.ts
@@ -3,14 +3,12 @@ import { PathReporter } from 'io-ts/lib/PathReporter';
 import localforage from 'localforage';
 import {
   Analysis,
-  NewAnalysis,
   AnalysisClient,
-  AnalysisPreferences,
-  NewAnalysisClient,
-  AnalysisSummary,
-  AnalysisDetails,
-  NewAnalysisDetails,
   AnalysisDescriptor,
+  AnalysisPreferences,
+  AnalysisSummary,
+  NewAnalysis,
+  SingleAnalysisPatchRequest,
 } from '../core';
 import { max } from 'lodash';
 
@@ -30,56 +28,6 @@ export const mockAnalysisStore: AnalysisClient = {
     throw new Error(PathReporter.report(result).join('\n'));
   },
   async setPreferences(preferences: AnalysisPreferences) {
-    await preferenceStore.setItem('preferences', preferences);
-  },
-  async getAnalyses() {
-    const records: Analysis[] = [];
-    await analysisStore.iterate((value) => {
-      records.push(value as Analysis);
-    });
-    return records;
-  },
-  async createAnalysis(newAnalysis: NewAnalysis) {
-    const usedIds = await analysisStore.keys();
-    const id = String((max(usedIds.map((x) => Number(x))) ?? 0) + 1);
-    const now = new Date().toISOString();
-    await analysisStore.setItem<Analysis>(id, {
-      ...newAnalysis,
-      id,
-      created: now,
-      modified: now,
-    });
-    return { id };
-  },
-  async getAnalysis(id: string) {
-    const analysis = await analysisStore.getItem(id);
-    if (analysis) {
-      const result = Analysis.decode(analysis);
-      if (isRight(result)) return result.right;
-      throw new Error(PathReporter.report(result).join('\n'));
-    }
-    throw new Error(`Could not find analysis with id "${id}".`);
-  },
-  async updateAnalysis(analysis: Analysis) {
-    const now = new Date().toISOString();
-    await analysisStore.setItem(analysis.id, { ...analysis, modified: now });
-  },
-  async deleteAnalysis(id: string) {
-    await analysisStore.removeItem(id);
-  },
-  async deleteAnalyses(ids: string[]) {
-    for (const id of ids) await analysisStore.removeItem(id);
-  },
-} as AnalysisClient;
-
-export const newMockAnalysisStore: NewAnalysisClient = {
-  async getPreferences() {
-    const prefs = await preferenceStore.getItem('preferences');
-    const result = AnalysisPreferences.decode(prefs);
-    if (isRight(result)) return result.right;
-    throw new Error(PathReporter.report(result).join('\n'));
-  },
-  async setPreferences(preferences: AnalysisPreferences) {
     await preferenceStore.setItem<AnalysisPreferences>(
       'preferences',
       preferences
@@ -88,7 +36,7 @@ export const newMockAnalysisStore: NewAnalysisClient = {
   async getAnalyses() {
     const records: AnalysisSummary[] = [];
     await analysisStore.iterate((value) => {
-      const result = AnalysisDetails.decode(value);
+      const result = Analysis.decode(value);
       if (isLeft(result)) {
         throw new Error(PathReporter.report(result).join('\n'));
       }
@@ -97,11 +45,11 @@ export const newMockAnalysisStore: NewAnalysisClient = {
     });
     return records;
   },
-  async createAnalysis(newAnalysis: NewAnalysisDetails) {
+  async createAnalysis(newAnalysis: NewAnalysis) {
     const usedIds = await analysisStore.keys();
     const analysisId = String((max(usedIds.map((x) => Number(x))) ?? 0) + 1);
     const now = new Date().toISOString();
-    await analysisStore.setItem<AnalysisDetails>(analysisId, {
+    await analysisStore.setItem<Analysis>(analysisId, {
       ...newAnalysis,
       ...computeSummaryCounts(newAnalysis.descriptor),
       analysisId,
@@ -113,7 +61,7 @@ export const newMockAnalysisStore: NewAnalysisClient = {
   async getAnalysis(id: string) {
     const analysis = await analysisStore.getItem(id);
     if (analysis) {
-      const result = AnalysisDetails.decode(analysis);
+      const result = Analysis.decode(analysis);
       if (isRight(result)) return result.right;
       throw new Error(PathReporter.report(result).join('\n'));
     }
@@ -121,7 +69,7 @@ export const newMockAnalysisStore: NewAnalysisClient = {
   },
   async updateAnalysis(
     analysisId: string,
-    analysisPatch: Partial<NewAnalysisDetails>
+    analysisPatch: SingleAnalysisPatchRequest
   ) {
     const analysis = await analysisStore.getItem(analysisId);
     if (analysis == null) {
@@ -130,14 +78,14 @@ export const newMockAnalysisStore: NewAnalysisClient = {
       );
     }
 
-    const result = AnalysisDetails.decode(analysis);
+    const result = Analysis.decode(analysis);
     if (isLeft(result)) {
       throw new Error(PathReporter.report(result).join('\n'));
     }
 
     const decodedAnalysis = result.right;
     const now = new Date().toISOString();
-    await analysisStore.setItem<AnalysisDetails>(analysisId, {
+    await analysisStore.setItem<Analysis>(analysisId, {
       ...decodedAnalysis,
       ...analysisPatch,
       modificationTime: now,
@@ -153,7 +101,7 @@ export const newMockAnalysisStore: NewAnalysisClient = {
 
     await Promise.allSettled(deletionPromises);
   },
-} as NewAnalysisClient;
+} as AnalysisClient;
 
 function computeSummaryCounts(
   descriptor: AnalysisDescriptor

--- a/src/lib/workspace/NewAnalysis.tsx
+++ b/src/lib/workspace/NewAnalysis.tsx
@@ -1,3 +1,4 @@
+import { Lens } from 'monocle-ts';
 import Path from 'path';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useLocation, useRouteMatch, useHistory } from 'react-router-dom';
@@ -11,8 +12,8 @@ import {
   useStudyRecord,
   VariableUISetting,
 } from '../core';
+import { Computation } from '../core/types/visualization';
 import { AnalysisPanel } from './AnalysisPanel';
-import { Visualization } from '../core/types/visualization';
 
 export function NewAnalysisPage() {
   const studyRecord = useStudyRecord();
@@ -29,11 +30,11 @@ export function NewAnalysisPage() {
       newAnalysis: NewAnalysis,
       subPath: string = location.pathname.slice(url.length)
     ) => {
-      const { id } = await analysisClient.createAnalysis(newAnalysis);
-      await preloadAnalysis(id);
+      const { analysisId } = await analysisClient.createAnalysis(newAnalysis);
+      await preloadAnalysis(analysisId);
       const newLocation = {
         ...location,
-        pathname: Path.resolve(url, '..', id + subPath),
+        pathname: Path.resolve(url, '..', analysisId + subPath),
       };
       history.replace(newLocation);
     },
@@ -48,10 +49,10 @@ export function NewAnalysisPage() {
   const deleteAnalysis = useCallback(() => {
     throw new Error('Cannot delete an unsaved analysis.');
   }, []);
-  const setName = useSetter('name', analysis, createAnalysis);
-  const setFilters = useSetter('filters', analysis, createAnalysis);
+  const setName = useSetter(analysisToNameLens, analysis, createAnalysis);
+  const setFilters = useSetter(analysisToFiltersLens, analysis, createAnalysis);
   const setStarredVariables = useSetter(
-    'starredVariables',
+    analysisToStarredVariablesLens,
     analysis,
     createAnalysis
   );
@@ -66,23 +67,36 @@ export function NewAnalysisPage() {
     ) => {
       const variableUISettings =
         typeof nextVariableUISettings === 'function'
-          ? nextVariableUISettings(analysis.variableUISettings)
+          ? nextVariableUISettings(analysis.descriptor.subset.uiSettings)
           : nextVariableUISettings;
-      setAnalysis((analysis) => ({ ...analysis, variableUISettings }));
+
+      setAnalysis(analysisToVariableUISettingsLens.set(variableUISettings));
     },
-    [analysis.variableUISettings]
+    [analysis.descriptor.subset.uiSettings]
   );
-  const setVisualizations = useSetter(
-    'visualizations',
+  const setComputations = useSetter(
+    analysisToComputationsLens,
     analysis,
     createAnalysis,
     useCallback(
-      (visualizations: Visualization[]) =>
-        Path.join(
+      (computations: Computation[]) => {
+        const computationWithNewVisualization = computations.find(
+          ({ visualizations }) => visualizations.length > 0
+        );
+
+        const newVisualizationId =
+          computationWithNewVisualization?.visualizations[0].visualizationId;
+
+        if (newVisualizationId == null) {
+          return undefined;
+        }
+
+        return Path.join(
           location.pathname.slice(url.length),
           '..',
-          visualizations[0].id
-        ),
+          newVisualizationId
+        );
+      },
       [location.pathname, url.length]
     )
   );
@@ -94,7 +108,7 @@ export function NewAnalysisPage() {
       setName,
       setStarredVariables,
       setVariableUISettings,
-      setVisualizations,
+      setComputations,
       saveAnalysis,
       copyAnalysis,
       deleteAnalysis,
@@ -115,28 +129,49 @@ export function NewAnalysisPage() {
       setName,
       setStarredVariables,
       setVariableUISettings,
-      setVisualizations,
+      setComputations,
     ]
   );
   return <AnalysisPanel analysisState={analysisState} hideCopyAndSave />;
 }
 
-function useSetter<T extends keyof NewAnalysis>(
-  property: T,
+function useSetter<T>(
+  nestedValueLens: Lens<NewAnalysis, T>,
   analysis: NewAnalysis,
   createAnalysis: (analysis: NewAnalysis, subPath?: string) => void,
-  getSubPath?: (value: NewAnalysis[T]) => string
+  getSubPath?: (value: T) => string | undefined
 ) {
   return useCallback(
-    (value: NewAnalysis[T] | ((value: NewAnalysis[T]) => NewAnalysis[T])) => {
-      const nextValue =
-        typeof value === 'function' ? value(analysis[property]) : value;
-      const nextAnalysis = {
-        ...analysis,
-        [property]: nextValue,
-      };
-      createAnalysis(nextAnalysis, getSubPath && getSubPath(nextValue));
+    (nestedValue: T | ((nestedValue: T) => T)) => {
+      const nextNestedValue =
+        typeof nestedValue === 'function'
+          ? (nestedValue as (nestedValue: T) => T)(
+              nestedValueLens.get(analysis)
+            )
+          : nestedValue;
+      const nextAnalysis = nestedValueLens.set(nextNestedValue)(analysis);
+      createAnalysis(nextAnalysis, getSubPath && getSubPath(nextNestedValue));
     },
-    [analysis, createAnalysis, getSubPath, property]
+    [analysis, createAnalysis, getSubPath, nestedValueLens]
   );
 }
+
+const analysisToNameLens = Lens.fromProp<NewAnalysis>()('displayName');
+const analysisToFiltersLens = Lens.fromPath<NewAnalysis>()([
+  'descriptor',
+  'subset',
+  'descriptor',
+]);
+const analysisToComputationsLens = Lens.fromPath<NewAnalysis>()([
+  'descriptor',
+  'computations',
+]);
+const analysisToStarredVariablesLens = Lens.fromPath<NewAnalysis>()([
+  'descriptor',
+  'starredVariables',
+]);
+const analysisToVariableUISettingsLens = Lens.fromPath<NewAnalysis>()([
+  'descriptor',
+  'subset',
+  'uiSettings',
+]);

--- a/src/lib/workspace/NewAnalysis.tsx
+++ b/src/lib/workspace/NewAnalysis.tsx
@@ -149,7 +149,9 @@ function useSetter<T>(
     (nestedValue: T | ((nestedValue: T) => T)) => {
       const nextNestedValue =
         typeof nestedValue === 'function'
-          ? nestedValueLens.get(analysis)
+          ? (nestedValue as (nestedValue: T) => T)(
+              nestedValueLens.get(analysis)
+            )
           : nestedValue;
       const nextAnalysis = nestedValueLens.set(nextNestedValue)(analysis);
       createAnalysis(nextAnalysis, getSubPath && getSubPath(nextNestedValue));

--- a/src/lib/workspace/NewAnalysis.tsx
+++ b/src/lib/workspace/NewAnalysis.tsx
@@ -1,6 +1,6 @@
 import { Lens } from 'monocle-ts';
 import Path from 'path';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useLocation, useRouteMatch, useHistory } from 'react-router-dom';
 import {
   AnalysisState,
@@ -25,18 +25,22 @@ export function NewAnalysisPage() {
   const history = useHistory();
   const location = useLocation();
   const { url } = useRouteMatch();
+  const creatingAnalysis = useRef(false);
   const createAnalysis = useCallback(
     async (
       newAnalysis: NewAnalysis,
       subPath: string = location.pathname.slice(url.length)
     ) => {
-      const { analysisId } = await analysisClient.createAnalysis(newAnalysis);
-      await preloadAnalysis(analysisId);
-      const newLocation = {
-        ...location,
-        pathname: Path.resolve(url, '..', analysisId + subPath),
-      };
-      history.replace(newLocation);
+      if (!creatingAnalysis.current) {
+        creatingAnalysis.current = true;
+        const { analysisId } = await analysisClient.createAnalysis(newAnalysis);
+        await preloadAnalysis(analysisId);
+        const newLocation = {
+          ...location,
+          pathname: Path.resolve(url, '..', analysisId + subPath),
+        };
+        history.replace(newLocation);
+      }
     },
     [analysisClient, history, location, preloadAnalysis, url]
   );

--- a/src/lib/workspace/NewAnalysis.tsx
+++ b/src/lib/workspace/NewAnalysis.tsx
@@ -145,9 +145,7 @@ function useSetter<T>(
     (nestedValue: T | ((nestedValue: T) => T)) => {
       const nextNestedValue =
         typeof nestedValue === 'function'
-          ? (nestedValue as (nestedValue: T) => T)(
-              nestedValueLens.get(analysis)
-            )
+          ? nestedValueLens.get(analysis)
           : nestedValue;
       const nextAnalysis = nestedValueLens.set(nextNestedValue)(analysis);
       createAnalysis(nextAnalysis, getSubPath && getSubPath(nextNestedValue));

--- a/src/lib/workspace/Subsetting.tsx
+++ b/src/lib/workspace/Subsetting.tsx
@@ -32,7 +32,8 @@ export function Subsetting(props: Props) {
   const variable = entity?.variables.find((v) => v.id === variableId);
   const history = useHistory();
   const totalCounts = useEntityCounts();
-  const filteredCounts = useEntityCounts(analysisState.analysis?.filters);
+  const filters = analysisState.analysis?.descriptor.subset.descriptor;
+  const filteredCounts = useEntityCounts(filters);
   const makeVariableLink = useMakeVariableLink();
 
   const toggleStarredVariable = useToggleStarredVariable(analysisState);
@@ -54,7 +55,7 @@ export function Subsetting(props: Props) {
           includeMultiFilters
           rootEntity={entities[0]}
           entityId={entity.id}
-          starredVariables={analysisState.analysis?.starredVariables}
+          starredVariables={analysisState.analysis?.descriptor.starredVariables}
           toggleStarredVariable={toggleStarredVariable}
           variableId={variable.id}
           onChange={(variable) => {
@@ -69,13 +70,13 @@ export function Subsetting(props: Props) {
       </div>
       <div className="FilterChips">
         <FilterChipList
-          filters={analysisState.analysis?.filters.filter(
-            (f) => f.entityId === entity.id
-          )}
+          filters={filters?.filter((f) => f.entityId === entity.id)}
           removeFilter={(filter) =>
             analysisState.analysis &&
             analysisState.setFilters(
-              analysisState.analysis.filters.filter((f) => f !== filter)
+              analysisState.analysis.descriptor.subset.descriptor.filter(
+                (f) => f !== filter
+              )
             )
           }
           entities={entities}

--- a/src/lib/workspace/WorkspaceContainer.tsx
+++ b/src/lib/workspace/WorkspaceContainer.tsx
@@ -1,3 +1,4 @@
+import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { find } from '@veupathdb/wdk-client/lib/Utils/IterableUtils';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { RestrictedPage } from '@veupathdb/web-common/lib/App/DataRestriction/RestrictedPage';
@@ -10,9 +11,9 @@ import {
   StudyMetadata,
   SubsettingClient,
 } from '../core';
+import { useConfiguredAnalysisClient } from '../core/hooks/analysisClient';
 import { VariableDescriptor } from '../core/types/variable';
 import { EDAWorkspaceHeading } from './EDAWorkspaceHeading';
-import { mockAnalysisStore } from './Mocks';
 import { cx, findFirstVariable } from './Utils';
 import { SavedAnalysis } from './SavedAnalysis';
 import { NewAnalysisPage } from './NewAnalysis';
@@ -22,6 +23,7 @@ interface Props {
   analysisId?: string;
   subsettingServiceUrl: string;
   dataServiceUrl: string;
+  userServiceUrl: string;
 }
 export function WorkspaceContainer(props: Props) {
   const { url } = useRouteMatch();
@@ -33,6 +35,7 @@ export function WorkspaceContainer(props: Props) {
     () => new DataClient({ baseUrl: props.dataServiceUrl }),
     [props.dataServiceUrl]
   );
+  const analysisClient = useConfiguredAnalysisClient(props.userServiceUrl);
   const makeVariableLink = useCallback(
     (
       {
@@ -60,21 +63,25 @@ export function WorkspaceContainer(props: Props) {
 
   return (
     <RestrictedPage approvalStatus={approvalStatus}>
-      <EDAWorkspaceContainer
-        studyId={props.studyId}
-        className={cx()}
-        analysisClient={mockAnalysisStore}
-        dataClient={dataClient}
-        subsettingClient={subsettingClient}
-        makeVariableLink={makeVariableLink}
-      >
-        <EDAWorkspaceHeading />
-        {props.analysisId == null ? (
-          <NewAnalysisPage />
-        ) : (
-          <SavedAnalysis analysisId={props.analysisId} />
-        )}
-      </EDAWorkspaceContainer>
+      {analysisClient == null ? (
+        <Loading />
+      ) : (
+        <EDAWorkspaceContainer
+          studyId={props.studyId}
+          className={cx()}
+          analysisClient={analysisClient}
+          dataClient={dataClient}
+          subsettingClient={subsettingClient}
+          makeVariableLink={makeVariableLink}
+        >
+          <EDAWorkspaceHeading />
+          {props.analysisId == null ? (
+            <NewAnalysisPage />
+          ) : (
+            <SavedAnalysis analysisId={props.analysisId} />
+          )}
+        </EDAWorkspaceContainer>
+      )}
     </RestrictedPage>
   );
 }

--- a/src/lib/workspace/WorkspaceContainer.tsx
+++ b/src/lib/workspace/WorkspaceContainer.tsx
@@ -1,4 +1,3 @@
-import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { find } from '@veupathdb/wdk-client/lib/Utils/IterableUtils';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { RestrictedPage } from '@veupathdb/web-common/lib/App/DataRestriction/RestrictedPage';
@@ -63,25 +62,21 @@ export function WorkspaceContainer(props: Props) {
 
   return (
     <RestrictedPage approvalStatus={approvalStatus}>
-      {analysisClient == null ? (
-        <Loading />
-      ) : (
-        <EDAWorkspaceContainer
-          studyId={props.studyId}
-          className={cx()}
-          analysisClient={analysisClient}
-          dataClient={dataClient}
-          subsettingClient={subsettingClient}
-          makeVariableLink={makeVariableLink}
-        >
-          <EDAWorkspaceHeading />
-          {props.analysisId == null ? (
-            <NewAnalysisPage />
-          ) : (
-            <SavedAnalysis analysisId={props.analysisId} />
-          )}
-        </EDAWorkspaceContainer>
-      )}
+      <EDAWorkspaceContainer
+        studyId={props.studyId}
+        className={cx()}
+        analysisClient={analysisClient}
+        dataClient={dataClient}
+        subsettingClient={subsettingClient}
+        makeVariableLink={makeVariableLink}
+      >
+        <EDAWorkspaceHeading />
+        {props.analysisId == null ? (
+          <NewAnalysisPage />
+        ) : (
+          <SavedAnalysis analysisId={props.analysisId} />
+        )}
+      </EDAWorkspaceContainer>
     </RestrictedPage>
   );
 }

--- a/src/lib/workspace/WorkspaceRouter.tsx
+++ b/src/lib/workspace/WorkspaceRouter.tsx
@@ -5,37 +5,47 @@ import {
   useRouteMatch,
   Redirect,
 } from 'react-router';
-import { EDAAnalysisList } from './EDAAnalysisList';
-import { WorkspaceContainer } from './WorkspaceContainer';
-import { mockAnalysisStore } from './Mocks';
+
+import { Loading } from '@veupathdb/wdk-client/lib/Components';
+
 import { SubsettingClient } from '../core/api/subsetting-api';
+import { useConfiguredAnalysisClient } from '../core/hooks/analysisClient';
 import { AllAnalyses } from './AllAnalyses';
+import { EDAAnalysisList } from './EDAAnalysisList';
 import { LatestAnalysis } from './LatestAnalysis';
 import { StudyList } from './StudyList';
+import { WorkspaceContainer } from './WorkspaceContainer';
 
 type Props = {
   subsettingServiceUrl: string;
   dataServiceUrl: string;
+  userServiceUrl: string;
 };
 
 export function WorkspaceRouter({
   subsettingServiceUrl,
   dataServiceUrl,
+  userServiceUrl,
 }: Props) {
   const { path, url } = useRouteMatch();
   const subsettingClient = SubsettingClient.getClient(subsettingServiceUrl);
+  const analysisClient = useConfiguredAnalysisClient(userServiceUrl);
 
   return (
     <Switch>
       <Route
         path={path}
         exact
-        render={() => (
-          <AllAnalyses
-            analysisClient={mockAnalysisStore}
-            subsettingClient={subsettingClient}
-          />
-        )}
+        render={() =>
+          analysisClient == null ? (
+            <Loading />
+          ) : (
+            <AllAnalyses
+              analysisClient={analysisClient}
+              subsettingClient={subsettingClient}
+            />
+          )
+        }
       />
       {/* replacing/redirecting double slashes url with single slash one */}
       <Route
@@ -64,6 +74,7 @@ export function WorkspaceRouter({
             {...props.match.params}
             subsettingServiceUrl={subsettingServiceUrl}
             dataServiceUrl={dataServiceUrl}
+            userServiceUrl={userServiceUrl}
           />
         )}
       />
@@ -74,18 +85,23 @@ export function WorkspaceRouter({
             {...props.match.params}
             subsettingServiceUrl={subsettingServiceUrl}
             dataServiceUrl={dataServiceUrl}
+            userServiceUrl={userServiceUrl}
           />
         )}
       />
       <Route
         path={`${path}/:studyId/~latest`}
-        render={(props: RouteComponentProps<{ studyId: string }>) => (
-          <LatestAnalysis
-            {...props.match.params}
-            replaceRegexp={/~latest/}
-            analysisClient={mockAnalysisStore}
-          />
-        )}
+        render={(props: RouteComponentProps<{ studyId: string }>) =>
+          analysisClient == null ? (
+            <Loading />
+          ) : (
+            <LatestAnalysis
+              {...props.match.params}
+              replaceRegexp={/~latest/}
+              analysisClient={analysisClient}
+            />
+          )
+        }
       />
       <Route
         path={`${path}/:studyId/:analysisId`}
@@ -96,6 +112,7 @@ export function WorkspaceRouter({
             {...props.match.params}
             subsettingServiceUrl={subsettingServiceUrl}
             dataServiceUrl={dataServiceUrl}
+            userServiceUrl={userServiceUrl}
           />
         )}
       />

--- a/src/lib/workspace/WorkspaceRouter.tsx
+++ b/src/lib/workspace/WorkspaceRouter.tsx
@@ -6,8 +6,6 @@ import {
   Redirect,
 } from 'react-router';
 
-import { Loading } from '@veupathdb/wdk-client/lib/Components';
-
 import { SubsettingClient } from '../core/api/subsetting-api';
 import { useConfiguredAnalysisClient } from '../core/hooks/analysisClient';
 import { AllAnalyses } from './AllAnalyses';
@@ -36,16 +34,12 @@ export function WorkspaceRouter({
       <Route
         path={path}
         exact
-        render={() =>
-          analysisClient == null ? (
-            <Loading />
-          ) : (
-            <AllAnalyses
-              analysisClient={analysisClient}
-              subsettingClient={subsettingClient}
-            />
-          )
-        }
+        render={() => (
+          <AllAnalyses
+            analysisClient={analysisClient}
+            subsettingClient={subsettingClient}
+          />
+        )}
       />
       {/* replacing/redirecting double slashes url with single slash one */}
       <Route
@@ -91,17 +85,13 @@ export function WorkspaceRouter({
       />
       <Route
         path={`${path}/:studyId/~latest`}
-        render={(props: RouteComponentProps<{ studyId: string }>) =>
-          analysisClient == null ? (
-            <Loading />
-          ) : (
-            <LatestAnalysis
-              {...props.match.params}
-              replaceRegexp={/~latest/}
-              analysisClient={analysisClient}
-            />
-          )
-        }
+        render={(props: RouteComponentProps<{ studyId: string }>) => (
+          <LatestAnalysis
+            {...props.match.params}
+            replaceRegexp={/~latest/}
+            analysisClient={analysisClient}
+          />
+        )}
       />
       <Route
         path={`${path}/:studyId/:analysisId`}

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -39,6 +39,18 @@ module.exports = function (app) {
     })
   );
   app.use(
+    '/eda-user-service',
+    createProxyMiddleware({
+      target: process.env.EDA_USER_SERVICE_URL,
+      pathRewrite: { [`^/eda-user-service`]: '' },
+      secure: false,
+      changeOrigin: true,
+      followRedirects: true,
+      logLevel: 'debug',
+      onProxyReq: addAuthCookie,
+    })
+  );
+  app.use(
     '/dataset-access',
     createProxyMiddleware({
       target: process.env.DATASET_ACCESS_SERVICE_URL,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11238,6 +11238,11 @@ moment@^2.21.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
+monocle-ts@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/monocle-ts/-/monocle-ts-2.3.11.tgz#562cd960bc24eaa84d9b6118d46a5441f3c0aac0"
+  integrity sha512-YJQdpDeKU0NNAecDjFgDDnDoivmf2nXsJZTRQdKh5jsPKG2lT/15dFnSuUcQoKB/VZN1z7jQ0B0bffbRFUtLmg==
+
 monotone-convex-hull-2d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz#47f5daeadf3c4afd37764baa1aa8787a40eee08c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3126,10 +3126,10 @@
     md5 "^2.3.0"
     whatwg-fetch "^3.5.0"
 
-"@veupathdb/web-common@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.1.6.tgz#ac82e8ccf4376ff298dc8b594b3543f0004fc86d"
-  integrity sha512-herx52rSrkrsDZt4cStx2tRWFr/NRc675ExCpepGVnzlKndDOaui5/VmHcf02rtRZiIGYm/gn2V3w9GtIg8XlQ==
+"@veupathdb/web-common@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.1.7.tgz#cf3f63d1d51b96f873051d2df42b2735e08aa782"
+  integrity sha512-fIUiob8kKlFp+VfvKX54DBTyP0zwV96JGSbAFba8EuzoXUk7ICJeb9BlYcxQcIZ9j8H9MDqaY7aYovuM2vy2BQ==
   dependencies:
     "@veupathdb/eda" "^0.11.9"
     custom-event-polyfill "^1.0.7"


### PR DESCRIPTION
Resolves #441.

Broadly speaking, this PR updates the `AnalysisClient` interface to conform to the [EDA User Service API](https://veupathdb.github.io/EdaUserService/api.html), and introduces an `AnalysisClient` implementation which exercises that service.

**Notes**:
1. The "footprint" of this PR is deceptively large - most of changes here are due to changes in the structure of the "analysis" JSON. Most of the differences in structure are straightforward (e.g., `analysis.starredVariables` is now `analysis.descriptor.starredVariables`), but two nontrivial changes are worth noting here:
   - `StarredVariables` is now an array of `VariableDescriptor`s, as opposed to an array of (string) variable IDs.
   - Computations and visualizations are now stored in a nested JSON structure, as opposed to two "flat" arrays of computations and visualizations. Now, each analysis has an array of `Computation`s, and each `Computation` has an array of `Visualization`s.
2. I have updated the mock analysis client in case we want to use it in the future. (In particular, since we don't yet have WDK login for the local dev environment, it might be worth adding some sort of `USE_MOCK_ANALYSIS_STORE` environment variable.)

**Future work**:
1. I uncovered a preexisting bug with copying analyses - after the copy is complete, the client redirects to the copy's URL, but the page's analysis state is not changed. I'm guessing we just need to make a small update to the [analysis hook](https://github.com/VEuPathDB/web-eda/blob/main/src/lib/core/hooks/analysis.ts).
2. It appears that EDA services on our servers (`ash`, `fir`, etc.) are sending responses with a `set-cookie` header that resets the `JSESSIONID` used by the WDK service. Maybe we need to add some sort of (backend) filter to prevent this from happening?
3. Fix the client unit tests. (Some of them are [and were previously] broken due to what looks like a transpilation error.)