### PR TITLE
Testing out serial MultiFilter distribution requests

### DIFF
--- a/src/lib/core/components/filter/MultiFilter.tsx
+++ b/src/lib/core/components/filter/MultiFilter.tsx
@@ -378,3 +378,27 @@ function findThisFilter(
       filter.type === 'multiFilter'
   );
 }
+
+/**
+ * Takes and array of data, and a function that operates on items from
+ * that array and returns a Promise, and overall returns a promise of an array of results.
+ *
+ * @param array
+ * @param fn
+ */
+function seriallyProcessArray<D, R>(
+  array: Array<D>,
+  fn: (item: D) => Promise<R>
+): Promise<R[] | void> {
+  const results: Array<R> = [];
+  return array.reduce(
+    (p, item) =>
+      p.then(() =>
+        fn(item).then((output) => {
+          results.push(output);
+          return results;
+        })
+      ),
+    Promise.resolve() as Promise<R[] | void>
+  );
+}


### PR DESCRIPTION
With this draft PR, I demonstrate the speed of serialising the back end calls to update the pink/grey bars in the MultiFilter table.  See the issue here: https://github.com/VEuPathDB/web-eda/issues/358 

It takes 10 seconds to complete the process for GEMS1A Cooking fuel 
 
![distribution-calls-in-serial](https://user-images.githubusercontent.com/308639/134520375-e954d6de-7fba-488d-8acd-f01729925c27.png)

Note: most of the diff is due to indentation changes - I really just swapped out the `Promise.all ... leaves.map()` for `serialArrayPromise(leaves, ...)` - it's not a big change at all.