### PR TITLE
Update table icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@types/debounce-promise": "^3.1.3",
     "@veupathdb/components": "^0.7.18",
     "@veupathdb/wdk-client": "^0.4.4",
-    "@veupathdb/web-common": "^0.1.7",
+    "@veupathdb/web-common": "^0.1.9",
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",
     "io-ts": "^2.2.13",

--- a/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -4,15 +4,23 @@ import Path from 'path';
 import { cx } from './Utils';
 import { useStudyRecord } from '../core';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
-import { Button, Tooltip, Icon } from '@material-ui/core';
+import { Button, Tooltip, Icon, makeStyles } from '@material-ui/core';
 import { LinkAttributeValue } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import { useAttemptActionCallback } from '@veupathdb/web-common/lib/hooks/dataRestriction';
 import { Action } from '@veupathdb/web-common/lib/App/DataRestriction/DataRestrictionUtils';
+
+// Add custom styling for ebrc icons for better alignment in buttons
+const useStyles = makeStyles((theme) => ({
+  ebrcStartIcon: {
+    marginTop: -5,
+  },
+}));
 
 export function EDAWorkspaceHeading() {
   const studyRecord = useStudyRecord();
   const { url } = useRouteMatch();
   const attemptAction = useAttemptActionCallback();
+  const iconClasses = useStyles();
   return (
     <div className={cx('-Heading')}>
       <h1>{safeHtml(studyRecord.displayName)}</h1>
@@ -62,6 +70,7 @@ export function EDAWorkspaceHeading() {
             <Button
               variant="text"
               color="primary"
+              classes={{ startIcon: iconClasses.ebrcStartIcon }}
               startIcon={<Icon className="ebrc-icon-table" />}
               component={Link}
               to={'/eda?s=' + encodeURIComponent(studyRecord.displayName)}

--- a/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -62,7 +62,7 @@ export function EDAWorkspaceHeading() {
             <Button
               variant="text"
               color="primary"
-              startIcon={<Icon className="fa fa-table fa-fw" />}
+              startIcon={<Icon className="ebrc-icon-table" />}
               component={Link}
               to={'/eda?s=' + encodeURIComponent(studyRecord.displayName)}
             >

--- a/src/lib/workspace/Subsetting.tsx
+++ b/src/lib/workspace/Subsetting.tsx
@@ -95,7 +95,7 @@ export function Subsetting(props: Props) {
             className="link"
             onClick={() => alert('Coming soon')}
           >
-            <i className="fa fa-table" />
+            <i className="ebrc-icon-table-download" />
           </button>
         </Tooltip>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3126,10 +3126,10 @@
     md5 "^2.3.0"
     whatwg-fetch "^3.5.0"
 
-"@veupathdb/web-common@^0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.1.7.tgz#cf3f63d1d51b96f873051d2df42b2735e08aa782"
-  integrity sha512-fIUiob8kKlFp+VfvKX54DBTyP0zwV96JGSbAFba8EuzoXUk7ICJeb9BlYcxQcIZ9j8H9MDqaY7aYovuM2vy2BQ==
+"@veupathdb/web-common@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.1.9.tgz#8c8c9b531199b98cbddb03e4f7906dfb5704e1d3"
+  integrity sha512-Ot10rsWiDQmiDS+yk07w1scOsOF/d25ZT9tfrZTRk8Ukalh9Zb1fj/nCwAbgtOxUeSRL7ZGh1CnPTuIg09Q4Ng==
   dependencies:
     "@veupathdb/eda" "^0.11.9"
     custom-event-polyfill "^1.0.7"


### PR DESCRIPTION
In part addresses web-eda issue #487
Related to but does not depend on EbrcWebsiteCommon PR [#70](https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/70)

This PR makes the following changes:
1. Replaces My Analyses table icon with custom ebrc icon
2. Replaces download current subset icon with custom ebrc icon.

See below.
<img width="1771" alt="Screen Shot 2021-09-29 at 2 14 20 PM" src="https://user-images.githubusercontent.com/11710234/135326886-40a649b5-599d-4ffd-b544-fa95cece467d.png">

One problem I ran into was using these icons in the mui button. The table icon for My Analyses isn't centered vertically. This is more obvious when looking at where the icon should lie:
<img width="504" alt="Screen Shot 2021-09-29 at 1 35 25 PM" src="https://user-images.githubusercontent.com/11710234/135327017-2ac05567-0bfe-4253-bb97-6654f2bfbcfc.png">

I investigated the bug for a bit but could not find any solution that worked. Another clue then surfaced - none of the icons are actually centered vertically within the mui button. I think the table one just is the most obvious.
<img width="1033" alt="Screen Shot 2021-09-29 at 1 46 14 PM" src="https://user-images.githubusercontent.com/11710234/135327292-6a5a526c-56ec-4a22-b563-52823e436f02.png">

Any ideas on this? All the solutions I found either didn't work or seemed far too complicated for what I imagine would be a simple fix?