### PR TITLE
addressing feedback on thumbnail gray out box

### DIFF
--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -45,18 +45,19 @@
 
     // gray out box for thumbnail view
     &GrayOut {
-      background: rgba(217, 217, 217, 0.3);
+      background: rgba(217, 217, 217, 0.5);
       position: absolute;
       top: 0;
       width: 100%;
       height: 100%;
-      border-radius: 0.5em;
       display: flex;
       justify-content: center;
       align-items: center;
       font-size: 1.7em;
       text-align: center;
-      color: #555;
+      color: #333;
+      // outer glow effect
+      text-shadow: 0em 0em 0.25em #fff;
     }
 
     // adjusting icons for thumbnail


### PR DESCRIPTION
Danica suggested some changes on thumbnail gray out box (see from [this comment](https://github.com/VEuPathDB/web-eda/issues/465#issuecomment-931518602) to the last) and she is now satisfied with my changes. Thus I am making this PR.
Also I realized there was a minor bug not to fill gray color to each corner, which is due to the unnecessary border-radius css: fixed by removing it. 

Since this is already confirmed by Danica, and not that difficult to review, I will just ask @jtlong3rd to review this so that this PR can be merged quickly.