### PR TITLE
Scatter visualisation - implement limit on number of data points

### DIFF
--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -207,6 +207,7 @@ export interface ScatterplotRequestParams {
     yAxisVariable: VariableDescriptor;
     overlayVariable?: VariableDescriptor;
     showMissingness?: 'TRUE' | 'FALSE';
+    maxAllowedDataPoints?: number;
   };
 }
 

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -316,7 +316,7 @@ function BarplotViz(props: VisualizationProps) {
             filters={filters}
             outputEntity={entity}
             stratificationIsActive={overlayVariable != null}
-            enableSpinner={vizConfig.xAxisVariable != null}
+            enableSpinner={vizConfig.xAxisVariable != null && !data.error}
           />
           <VariableCoverageTable
             completeCases={data.pending ? undefined : data.value?.completeCases}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -335,7 +335,9 @@ function BoxplotViz(props: VisualizationProps) {
             filters={filters}
             outputEntity={outputEntity}
             stratificationIsActive={overlayVariable != null}
-            enableSpinner={xAxisVariable != null && yAxisVariable != null}
+            enableSpinner={
+              xAxisVariable != null && yAxisVariable != null && !data.error
+            }
           />
           <VariableCoverageTable
             completeCases={data.pending ? undefined : data.value?.completeCases}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -317,6 +317,7 @@ function HistogramViz(props: VisualizationProps) {
       )}
       <HistogramPlotWithControls
         data={data.value && !data.pending ? data.value : undefined}
+        error={data.error}
         onBinWidthChange={onBinWidthChange}
         dependentAxisLogScale={vizConfig.dependentAxisLogScale}
         onDependentAxisLogScaleChange={onDependentAxisLogScaleChange}
@@ -372,10 +373,12 @@ type HistogramPlotWithControlsProps = HistogramProps & {
   onValueSpecChange: (newValueSpec: ValueSpec) => void;
   showMissingness: boolean;
   updateThumbnail: (src: string) => void;
+  error: unknown;
 } & Partial<CoverageStatistics>;
 
 function HistogramPlotWithControls({
   data,
+  error,
   onBinWidthChange,
   onDependentAxisLogScaleChange,
   filters,
@@ -440,7 +443,7 @@ function HistogramPlotWithControls({
             filters={filters}
             outputEntity={outputEntity}
             stratificationIsActive={overlayVariable != null}
-            enableSpinner={independentAxisVariable != null}
+            enableSpinner={independentAxisVariable != null && !error}
           />
           <VariableCoverageTable
             completeCases={completeCases}

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -359,7 +359,9 @@ function MosaicViz(props: Props) {
           filters={filters}
           outputEntity={outputEntity}
           stratificationIsActive={false}
-          enableSpinner={xAxisVariable != null && yAxisVariable != null}
+          enableSpinner={
+            xAxisVariable != null && yAxisVariable != null && !data.error
+          }
         />
         <VariableCoverageTable
           completeCases={data.pending ? undefined : data.value?.completeCases}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -63,6 +63,10 @@ import { axisRangeMargin } from '../../../utils/axis-range-margin';
 import { VariablesByInputName } from '../../../utils/data-element-constraints';
 // util to find dependent axis range
 import { defaultDependentAxisRange } from '../../../utils/default-dependent-axis-range';
+import { useRouteMatch } from 'react-router';
+import { Link } from '@veupathdb/wdk-client/lib/Components';
+
+const MAXALLOWEDDATAPOINTS = 5000;
 
 const plotDimensions = {
   width: 750,
@@ -314,6 +318,8 @@ function ScatterplotViz(props: VisualizationProps) {
     return axisRangeMargin(defaultDependentRange, yAxisVariable?.type);
   }, [data, data.value, yAxisVariable]);
 
+  const { url } = useRouteMatch();
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
@@ -371,11 +377,24 @@ function ScatterplotViz(props: VisualizationProps) {
           }}
         >
           <i className="fa fa-warning" style={{ marginRight: '1ex' }}></i>{' '}
-          {data.error instanceof Error
-            ? data.error.message.match(/400.+too large/is)
-              ? 'Your plot currently has too many points to display in a reasonable time. Please either add filters in the Browse and subset tab to reduce the number, or consider using a summary plot such as histogram or boxplot.'
-              : data.error.message
-            : String(data.error)}
+          {data.error instanceof Error ? (
+            data.error.message.match(/400.+too large/is) ? (
+              <span>
+                Your plot currently has too many points (&gt;
+                {MAXALLOWEDDATAPOINTS.toLocaleString()}) to display in a
+                reasonable time. Please either add filters in the{' '}
+                <Link replace to={url.replace(/visualizations.+/, 'variables')}>
+                  Browse and subset
+                </Link>{' '}
+                tab to reduce the number, or consider using a summary plot such
+                as histogram or boxplot.
+              </span>
+            ) : (
+              data.error.message
+            )
+          ) : (
+            String(data.error)
+          )}
         </div>
       )}
       <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
@@ -659,7 +678,7 @@ function getRequestParams(
         yAxisVariable: yAxisVariable,
         overlayVariable: overlayVariable,
         showMissingness: showMissingness ? 'TRUE' : 'FALSE',
-        maxAllowedDataPoints: 5000,
+        maxAllowedDataPoints: MAXALLOWEDDATAPOINTS,
       },
     } as ScatterplotRequestParams;
   }

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -66,7 +66,7 @@ import { defaultDependentAxisRange } from '../../../utils/default-dependent-axis
 import { useRouteMatch } from 'react-router';
 import { Link } from '@veupathdb/wdk-client/lib/Components';
 
-const MAXALLOWEDDATAPOINTS = 5000;
+const MAXALLOWEDDATAPOINTS = 100000;
 
 const plotDimensions = {
   width: 750,

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -372,7 +372,9 @@ function ScatterplotViz(props: VisualizationProps) {
         >
           <i className="fa fa-warning" style={{ marginRight: '1ex' }}></i>{' '}
           {data.error instanceof Error
-            ? data.error.message
+            ? data.error.message.match(/400.+too large/is)
+              ? 'Your plot currently has too many points to display in a reasonable time. Please either add filters in the Browse and subset tab to reduce the number, or consider using a summary plot such as histogram or boxplot.'
+              : data.error.message
             : String(data.error)}
         </div>
       )}
@@ -447,7 +449,9 @@ function ScatterplotViz(props: VisualizationProps) {
             filters={filters}
             outputEntity={outputEntity}
             stratificationIsActive={overlayVariable != null}
-            enableSpinner={xAxisVariable != null && yAxisVariable != null}
+            enableSpinner={
+              xAxisVariable != null && yAxisVariable != null && !data.error
+            }
           />
           <VariableCoverageTable
             completeCases={
@@ -655,6 +659,7 @@ function getRequestParams(
         yAxisVariable: yAxisVariable,
         overlayVariable: overlayVariable,
         showMissingness: showMissingness ? 'TRUE' : 'FALSE',
+        maxAllowedDataPoints: 5000,
       },
     } as ScatterplotRequestParams;
   }


### PR DESCRIPTION
Resolves #324 

I have set the limit very low (5,000) for now - just so it's easier to test.  Should we increase this before or after testing from the QA crew? I think they may also have suggestions about the wording. 

(I wasn't sure how to make links to open a new histogram or boxplot.)

![image](https://user-images.githubusercontent.com/308639/135534435-261bd90a-c774-4654-b23f-e44a93e19ae3.png)
