### PR TITLE
Data shape fixes for non-continuous vars in histogram viz

### DIFF
--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -26,12 +26,15 @@ import {
 import { usePromise } from '../../../hooks/promise';
 import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
 import { Filter } from '../../../types/filter';
-import { StudyEntity } from '../../../types/study';
+import {
+  DateVariable,
+  NumberVariable,
+  StudyEntity,
+} from '../../../types/study';
 import { VariableDescriptor } from '../../../types/variable';
 import { CoverageStatistics } from '../../../types/visualization';
 import { VariableCoverageTable } from '../../VariableCoverageTable';
 import { BirdsEyeView } from '../../BirdsEyeView';
-import { isHistogramVariable } from '../../filter/guards';
 import { HistogramVariable } from '../../filter/types';
 import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
@@ -212,7 +215,11 @@ function HistogramViz(props: VisualizationProps) {
       if (vizConfig.xAxisVariable == null || xAxisVariable == null)
         return undefined;
 
-      if (xAxisVariable && !isHistogramVariable(xAxisVariable))
+      if (
+        xAxisVariable &&
+        !NumberVariable.is(xAxisVariable) &&
+        !DateVariable.is(xAxisVariable)
+      )
         return undefined;
 
       const params = getRequestParams(

--- a/src/lib/core/types/study.ts
+++ b/src/lib/core/types/study.ts
@@ -97,21 +97,16 @@ export const NumberVariable = t.intersection([
       units: t.string,
     }),
   ]),
-  t.union([
-    t.type({
-      dataShape: CategoryVariableDataShape,
-    }),
-    t.type({
-      dataShape: ContinuousVariableDataShape,
-      rangeMin: t.number,
-      rangeMax: t.number,
-      binWidth: t.number,
-    }),
-  ]),
+  t.type({
+    dataShape: VariableDataShape,
+    rangeMin: t.number,
+    rangeMax: t.number,
+  }),
   t.partial({
     // TODO This is supposed to be required, but the backend isn't populating it.
     displayRangeMin: t.number,
     displayRangeMax: t.number,
+    binWidth: t.number,
     binWidthOverride: t.number,
   }),
 ]);
@@ -122,21 +117,16 @@ export const DateVariable = t.intersection([
   t.type({
     type: t.literal('date'),
   }),
-  t.union([
-    t.type({
-      dataShape: CategoryVariableDataShape,
-    }),
-    t.type({
-      dataShape: ContinuousVariableDataShape,
-      rangeMin: t.string,
-      rangeMax: t.string,
-      binWidth: t.number,
-      binUnits: TimeUnit,
-    }),
-  ]),
+  t.type({
+    dataShape: VariableDataShape,
+    rangeMin: t.string,
+    rangeMax: t.string,
+  }),
   t.partial({
     displayRangeMin: t.string,
     displayRangeMax: t.string,
+    binWidth: t.number,
+    binUnits: TimeUnit,
     binWidthOverride: t.number,
   }),
 ]);

--- a/src/lib/core/utils/default-independent-axis-range.ts
+++ b/src/lib/core/utils/default-independent-axis-range.ts
@@ -6,7 +6,7 @@ export function defaultIndependentAxisRange(
   plotName: string
 ): NumberOrDateRange | undefined {
   // make universal range variable
-  if (variable != null && variable.dataShape === 'continuous') {
+  if (variable != null) {
     if (NumberVariable.is(variable)) {
       return variable.displayRangeMin != null &&
         variable.displayRangeMax != null


### PR DESCRIPTION
Resolves #491

study: India ICEMR Severe P. vivax and falciparum Cohort
back end: dfalke-b

Calcium variable was never showing a histogram in the viz tab.  No request was made.  A type guard was being over-zealous.

Now 'number' variables like Calcium, Bicarbonate, Alkaline phosphatase all fail with 500 at the histogram endpoint.  The requests look well formed. 
Interestingly an 'integer' variable like "fasting blood sugar" with only 2 distinct values works fine.  

Another issue was that NumberVariable and DateVariable should have rangeMin/Max and regardless of data shape.

binWidth needs to be optional because some numeric/date variables have just one distinct value and have no binWidth - this didn't have any TypeScript issues but may have runtime consequences.  An example is "EUPATH_0021230" "Vitamin B12" 

