### PR TITLE
Fix for API change to user service data table columns

### DIFF
--- a/src/lib/core/types/analysis.ts
+++ b/src/lib/core/types/analysis.ts
@@ -60,7 +60,15 @@ export const AnalysisDescriptor = t.type({
   }),
   computations: t.array(Computation),
   starredVariables: t.array(VariableDescriptor),
-  dataTableColumns: t.array(VariableDescriptor),
+  dataTableConfig: t.type({
+    variables: t.array(VariableDescriptor),
+    sorting: t.array(
+      t.type({
+        key: t.string,
+        direction: t.keyof({ asc: null, desc: null }),
+      })
+    ),
+  }),
   derivedVariables: t.array(DerivedVariable),
 });
 
@@ -98,7 +106,10 @@ export function makeNewAnalysis(studyId: string): NewAnalysis {
         uiSettings: {},
       },
       starredVariables: [],
-      dataTableColumns: [],
+      dataTableConfig: {
+        variables: [],
+        sorting: [],
+      },
       derivedVariables: [],
       computations: [
         {


### PR DESCRIPTION
This is a basic fix. I was unable to make a backwards-compatible fix, so all old analyses will fail to load.

Do we want a backwards-compatible fix?