### PR TITLE
allow entity diagram scrolling on overflow

### DIFF
--- a/src/lib/workspace/EDAWorkspace.scss
+++ b/src/lib/workspace/EDAWorkspace.scss
@@ -157,7 +157,11 @@
 
   .Entities {
     display: flex;
-    justify-content: center;
+    overflow-x: auto;
+  }
+
+  .expanded-diagram {
+    margin: auto;
   }
 
   &-Variables {


### PR DESCRIPTION
With web-components [PR #218](https://github.com/VEuPathDB/web-components/pull/218), resolves #428 

Goal: Add scroll bar to entity diagram when it is wider than the window.

A first attempt at simply adding `overflow-x: auto` failed, in that the left portion was unreachable with the scroll bar. Thanks to the good people at SO, I learned about and implemented [this approach](https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container). Required giving a class name to the expanded diagram, hence the need for the `web-components` PR.


<img width="902" alt="Screen Shot 2021-10-04 at 1 50 07 PM" src="https://user-images.githubusercontent.com/11710234/135899602-b57217e6-0ce6-4eef-a4d9-4ef056dad9ca.png">

