### PR TITLE
Added leading edge behaviour to entity count debouncing

### DIFF
--- a/src/lib/core/hooks/entityCounts.ts
+++ b/src/lib/core/hooks/entityCounts.ts
@@ -14,7 +14,10 @@ export function useEntityCounts(filters?: Filter[]) {
 
   // debounce the dependencies of the useCallback below
   const [counter, setCounter] = useState(0);
-  const debouncedSetCounter = useMemo(() => debounce(setCounter, 2000), []);
+  const debouncedSetCounter = useMemo(
+    () => debounce(setCounter, 2000, { leading: true, trailing: true }),
+    []
+  );
   useEffect(() => debouncedSetCounter.cancel, []);
   useEffect(() => {
     debouncedSetCounter((count) => count + 1);


### PR DESCRIPTION
As discussed in [Slack](https://epvb.slack.com/archives/C012ZK4Q5CZ/p1633385788097900) initiated by @steve-fischer-200 

Now there will be back end requests for the first and last click of a burst of clicks.

But not only clicks.  The first time a study is rendered, the entity counts ought to be displayed ASAP, not after 2 seconds, so this fixes that.