### PR TITLE
Fix star toggle hover

### DIFF
--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -605,8 +605,8 @@ function makeStarredVariablesFilterTooltipContent(
   return starredVariablesToggleDisabled ? (
     <>To use this filter, star at least one variable below</>
   ) : showOnlyStarredVariables ? (
-    <>Click to show all variables.</>
+    <>Click to show all variables</>
   ) : (
-    <>Click to show only starred variables.</>
+    <>Click to show only starred variables</>
   );
 }

--- a/src/lib/core/components/VariableList.tsx
+++ b/src/lib/core/components/VariableList.tsx
@@ -603,7 +603,7 @@ function makeStarredVariablesFilterTooltipContent(
   starredVariablesToggleDisabled: boolean
 ) {
   return starredVariablesToggleDisabled ? (
-    <>To use this filter, star at least one variable below.</>
+    <>To use this filter, star at least one variable below</>
   ) : showOnlyStarredVariables ? (
     <>Click to show all variables.</>
   ) : (

--- a/src/lib/core/components/VariableTree.scss
+++ b/src/lib/core/components/VariableTree.scss
@@ -117,6 +117,7 @@
 
     &:disabled {
       opacity: 0.5;
+      pointer-events: none;
     }
 
     i {


### PR DESCRIPTION
Resolves issue #424 


The overly-persistent tooltip was an issue only when the button is disabled. Found a discussion of this issue [here](https://github.com/bsidelinger912/react-tooltip-lite/issues/46).

Other solutions included modifying the div structure, but this was the most straightforward solution.

Additionally updated the toggle text as suggested in the issue's description. Removed all periods from this text for consistency.