### PR TITLE
omit credentials (cookies) for eda services

### DIFF
--- a/src/lib/core/api/analysis-api.ts
+++ b/src/lib/core/api/analysis-api.ts
@@ -36,7 +36,13 @@ export class AnalysisClient extends FetchClient {
   );
 
   constructor(options: FetchApiOptions, private wdkService: WdkService) {
-    super(options);
+    super({
+      ...options,
+      init: {
+        ...options.init,
+        credentials: 'omit',
+      },
+    });
   }
 
   protected async fetch<T>(apiRequest: ApiRequest<T>): Promise<T> {

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 import {
   createJsonRequest,
+  FetchApiOptions,
   FetchClient,
 } from '@veupathdb/web-common/lib/util/api';
 import {
@@ -465,6 +466,16 @@ export const BoxplotResponse = type({
 });
 
 export class DataClient extends FetchClient {
+  constructor(options: FetchApiOptions) {
+    super({
+      ...options,
+      init: {
+        ...options.init,
+        credentials: 'omit',
+      },
+    });
+  }
+
   getApps(): Promise<TypeOf<typeof AppsResponse>> {
     return this.fetch(
       createJsonRequest({

--- a/src/lib/core/api/subsetting-api.ts
+++ b/src/lib/core/api/subsetting-api.ts
@@ -2,6 +2,7 @@
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import {
   createJsonRequest,
+  FetchApiOptions,
   FetchClient,
 } from '@veupathdb/web-common/lib/util/api';
 import {
@@ -67,6 +68,16 @@ export class SubsettingClient extends FetchClient {
   static getClient = memoize(
     (baseUrl: string): SubsettingClient => new SubsettingClient({ baseUrl })
   );
+
+  constructor(options: FetchApiOptions) {
+    super({
+      ...options,
+      init: {
+        ...options.init,
+        credentials: 'omit',
+      },
+    });
+  }
 
   getStudies(): Promise<StudyOverview[]> {
     return this.fetch(


### PR DESCRIPTION
This can be tested by watching the value of the JSESSIONID cookie in the browser's dev tools. In Firefox, the value lights up when it changes - you can see this happen several times before applying this branch, and then not at all after applying this branch.

fixes #523 