### PR TITLE
Use tree order for multiFilter sub-variables

### DIFF
--- a/src/lib/core/components/filter/MultiFilter.tsx
+++ b/src/lib/core/components/filter/MultiFilter.tsx
@@ -270,7 +270,7 @@ export function MultiFilter(props: Props) {
               case 'count':
                 return summary.internalsCount;
               default:
-                return summary.display;
+                return leafSummariesPromise.value?.indexOf(summary);
             }
           },
         ],


### PR DESCRIPTION
Fixes #425 