### PR TITLE
Fix categorical number filter

### DIFF
--- a/src/lib/core/utils/wdk-filter-param-adapter.ts
+++ b/src/lib/core/utils/wdk-filter-param-adapter.ts
@@ -111,7 +111,8 @@ export function fromEdaFilter(filter: EdaFilter): WdkFilter {
             ),
             operation: filter.operation,
           }
-        : filter[filter.type],
+        : // numberSet
+          filter[filter.type],
     __entityId: filter.entityId,
   } as WdkFilter;
 }


### PR DESCRIPTION
The values used for filter objects of categorical number variables are being set a strings. This is causing causing data integrity issues. The fix is to ensure the proper data type is passed to the `MembershipField` component.

fixes #531 