### PR TITLE
Revert "omit credentials (cookies) for eda services"

### DIFF
--- a/src/lib/core/api/analysis-api.ts
+++ b/src/lib/core/api/analysis-api.ts
@@ -36,13 +36,7 @@ export class AnalysisClient extends FetchClient {
   );
 
   constructor(options: FetchApiOptions, private wdkService: WdkService) {
-    super({
-      ...options,
-      init: {
-        ...options.init,
-        credentials: 'omit',
-      },
-    });
+    super(options);
   }
 
   protected async fetch<T>(apiRequest: ApiRequest<T>): Promise<T> {

--- a/src/lib/core/api/data-api.ts
+++ b/src/lib/core/api/data-api.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 import {
   createJsonRequest,
-  FetchApiOptions,
   FetchClient,
 } from '@veupathdb/web-common/lib/util/api';
 import {
@@ -466,16 +465,6 @@ export const BoxplotResponse = type({
 });
 
 export class DataClient extends FetchClient {
-  constructor(options: FetchApiOptions) {
-    super({
-      ...options,
-      init: {
-        ...options.init,
-        credentials: 'omit',
-      },
-    });
-  }
-
   getApps(): Promise<TypeOf<typeof AppsResponse>> {
     return this.fetch(
       createJsonRequest({

--- a/src/lib/core/api/subsetting-api.ts
+++ b/src/lib/core/api/subsetting-api.ts
@@ -2,7 +2,6 @@
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import {
   createJsonRequest,
-  FetchApiOptions,
   FetchClient,
 } from '@veupathdb/web-common/lib/util/api';
 import {
@@ -68,16 +67,6 @@ export class SubsettingClient extends FetchClient {
   static getClient = memoize(
     (baseUrl: string): SubsettingClient => new SubsettingClient({ baseUrl })
   );
-
-  constructor(options: FetchApiOptions) {
-    super({
-      ...options,
-      init: {
-        ...options.init,
-        credentials: 'omit',
-      },
-    });
-  }
 
   getStudies(): Promise<StudyOverview[]> {
     return this.fetch(


### PR DESCRIPTION
Reverts VEuPathDB/web-eda#524

This approach breaks in certain situations. For instance, if services are protected by a gateway that uses cookies to validate requests, omitting credentials will cause these requests to break. An alternative approach will be needed.