### PR TITLE
General button styling updates

### DIFF
--- a/src/lib/workspace/EDAWorkspace.scss
+++ b/src/lib/workspace/EDAWorkspace.scss
@@ -88,9 +88,11 @@
     gap: 1em;
     margin-right: auto;
     margin-left: 2em;
-    a {
-      font-size: 0.75em;
-    }
+    align-items: center;
+  }
+
+  .Linkouts-buttons {
+    font-size: 0.75em;
   }
 
   &-Analysis {

--- a/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -48,6 +48,7 @@ export function EDAWorkspaceHeading({
                 <Button
                   variant="text"
                   color="primary"
+                  className="Linkouts-buttons"
                   startIcon={<Icon className="fa fa-download fa-fw" />}
                   type="button"
                   onClick={() => {
@@ -70,6 +71,7 @@ export function EDAWorkspaceHeading({
               <Button
                 variant="text"
                 color="primary"
+                className="Linkouts-buttons"
                 startIcon={<Icon className="fa fa-plus fa-fw" />}
                 onClick={
                   /** If (1) there is no analysis, (2) we're in an unsaved new
@@ -90,8 +92,9 @@ export function EDAWorkspaceHeading({
               <Button
                 variant="text"
                 color="primary"
+                className="Linkouts-buttons"
                 classes={{ startIcon: iconClasses.ebrcStartIcon }}
-                startIcon={<Icon className="fa fa-table fa-fw" />}
+                startIcon={<Icon className="ebrc-icon-table" />}
                 component={Link}
                 to={'/eda?s=' + encodeURIComponent(studyRecord.displayName)}
               >

--- a/src/lib/workspace/Subsetting.tsx
+++ b/src/lib/workspace/Subsetting.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router';
+import { Link } from 'react-router-dom';
 import {
   MultiFilterVariable,
   useMakeVariableLink,
@@ -14,7 +15,7 @@ import { useEntityCounts } from '../core/hooks/entityCounts';
 import { useToggleStarredVariable } from '../core/hooks/starredVariables';
 import { VariableTree } from '../core/components/VariableTree';
 import FilterChipList from '../core/components/FilterChipList';
-import { Tooltip } from '@material-ui/core';
+import { Tooltip, Button, Icon } from '@material-ui/core';
 
 interface Props {
   analysisState: AnalysisState;
@@ -90,13 +91,15 @@ export function Subsetting(props: Props) {
             entity.displayNamePlural ?? entity.displayName
           }`}
         >
-          <button
-            type="button"
-            className="link"
+          <Button
+            variant="text"
+            color="primary"
+            size="large"
+            startIcon={<Icon className="ebrc-icon-table-download" />}
             onClick={() => alert('Coming soon')}
           >
-            <i className="ebrc-icon-table-download" />
-          </button>
+            View and download
+          </Button>
         </Tooltip>
       </div>
       <div className="Filter">

--- a/src/lib/workspace/Subsetting.tsx
+++ b/src/lib/workspace/Subsetting.tsx
@@ -87,7 +87,7 @@ export function Subsetting(props: Props) {
       </div>
       <div className="TabularDownload">
         <Tooltip
-          title={`Download current subset of ${
+          title={`View and download current subset of ${
             entity.displayNamePlural ?? entity.displayName
           }`}
         >


### PR DESCRIPTION
Resolves #450 and one half of #449. 

This PR addresses the styling of the EDA header and subsetting buttons. Specifically, those buttons in the header are styled with their own class. An alternative route could be to use [styled](https://mui.com/customization/how-to-customize/#2-reusable-style-overrides) in the future if we find we are doing this more frequently. The main reason the styling of these three buttons differs is because some, but not all, are using a Link component.

Finally, the View and Download current subset button was updated with new language as described in #449.

Note, as mentioned in #450 there will be a separate issue for modifying the download icon, because it will be a more involved process and should be it's own decision, as it affects more sites than just clinepi.


<img width="1169" alt="Screen Shot 2021-10-08 at 11 05 54 AM" src="https://user-images.githubusercontent.com/11710234/136580778-3f1574d2-08d9-46d0-9422-f82cf0a15b2f.png">


