### PR TITLE
Show filter chips for all entities, and add header to tooltip content.

### DIFF
--- a/src/lib/core/components/FilterChipList.tsx
+++ b/src/lib/core/components/FilterChipList.tsx
@@ -48,13 +48,13 @@ export default function FilterChipList(props: Props) {
             // Set filterValueDisplay based on the filter's type
             switch (filter.type) {
               case 'stringSet':
-                filterValueDisplay = filter.stringSet.join(', ');
+                filterValueDisplay = filter.stringSet.join(' | ');
                 break;
               case 'numberSet':
-                filterValueDisplay = filter.numberSet.join(', ');
+                filterValueDisplay = filter.numberSet.join(' | ');
                 break;
               case 'dateSet':
-                filterValueDisplay = filter.dateSet.join(', ');
+                filterValueDisplay = filter.dateSet.join(' | ');
                 break;
               case 'numberRange':
               case 'dateRange':
@@ -70,7 +70,7 @@ export default function FilterChipList(props: Props) {
                     if (entAndVar == null) return '';
                     return `${
                       entAndVar.variable.displayName
-                    } = ${subFilter.stringSet.join(', ')}`;
+                    } = ${subFilter.stringSet.join(' | ')}`;
                   })
                   .flatMap((text, index) => (
                     <>

--- a/src/lib/core/components/FilterChipList.tsx
+++ b/src/lib/core/components/FilterChipList.tsx
@@ -83,9 +83,24 @@ export default function FilterChipList(props: Props) {
                 filterValueDisplay = '';
             }
 
+            const tooltipText = (
+              <>
+                <div
+                  style={{
+                    fontSize: '1.05em',
+                    fontWeight: 700,
+                    marginBottom: '.75em',
+                  }}
+                >
+                  {entity.displayName}: {variable.displayName}
+                </div>
+                <div>{filterValueDisplay}</div>
+              </>
+            );
+
             return (
               <FilterChip
-                tooltipText={filterValueDisplay}
+                tooltipText={tooltipText}
                 isActive={
                   entity.id === selectedEntityId &&
                   variable.id === selectedVariableId

--- a/src/lib/workspace/Subsetting.tsx
+++ b/src/lib/workspace/Subsetting.tsx
@@ -70,7 +70,7 @@ export function Subsetting(props: Props) {
       </div>
       <div className="FilterChips">
         <FilterChipList
-          filters={filters?.filter((f) => f.entityId === entity.id)}
+          filters={filters}
           removeFilter={(filter) =>
             analysisState.analysis &&
             analysisState.setFilters(


### PR DESCRIPTION
We got very quick buy-in for showing filter chips for all entities in the subsetting panel. This PR primarily serves as a paper trail, as I am going to merge w/out approval.