### PR TITLE
Fixed birds eye layout to stop clipping of popup

### DIFF
--- a/src/lib/core/components/BirdsEyeView.tsx
+++ b/src/lib/core/components/BirdsEyeView.tsx
@@ -80,7 +80,9 @@ export function BirdsEyeView(props: Props) {
     outputEntity?.displayNamePlural ?? outputEntity?.displayName;
 
   return (
-    <div>
+    // wrap 450px birds eye plot in an overflowing 400px div so that the mouseover-popup isn't clipped,
+    // but at the same time don't cause wrapping of the side plots/tables on 1280px screens.
+    <div style={{ width: '400px', overflow: 'visible' }}>
       <div
         style={{
           marginLeft: '100px',
@@ -113,7 +115,7 @@ export function BirdsEyeView(props: Props) {
         data={birdsEyeData}
         containerClass="birds-eye-plot"
         containerStyles={{
-          width: '400px',
+          width: '450px',
           height: '110px',
           marginBottom: '1.5em',
         }}
@@ -121,7 +123,7 @@ export function BirdsEyeView(props: Props) {
           marginTop: 5,
           marginBottom: 5,
           marginLeft: 5,
-          marginRight: 5,
+          marginRight: 50,
         }}
         interactive={true}
         dependentAxisLabel={entityPluralString}


### PR DESCRIPTION
Resolves #419 

Doesn't need all three reviews!

Tweaked container div styles to allow the popup to be shown but doesn't wrap the whole thing on smaller screens.

To reproduce:

WASH Benefits Kenya Cluster Randomized Trial
Subset on: cluster study arm = active control
Viz: pretty much any histogram, overlay variable = **Wasted**

![image](https://user-images.githubusercontent.com/308639/137130399-859d85d9-2087-4cc9-a1ce-2e3bb2641f2b.png)
