### PR TITLE
temporarily remove bulk download button

### DIFF
--- a/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -49,7 +49,7 @@ export function EDAWorkspaceHeading({
       <div className={cx('-Heading')}>
         <h1>{safeHtml(studyRecord.displayName)}</h1>
         <div className={cx('-Linkouts')}>
-          {studyRecord.attributes.bulk_download_url && (
+          {/* {studyRecord.attributes.bulk_download_url && (
             <div>
               <Tooltip title="Download study files">
                 <Button
@@ -73,7 +73,7 @@ export function EDAWorkspaceHeading({
                 </Button>
               </Tooltip>
             </div>
-          )}
+          )} */}
           <div>
             <Tooltip title="Create a new analysis">
               <Button


### PR DESCRIPTION
As discussed on slack, temporarily removes the study download button.

<img width="1776" alt="Screen Shot 2021-10-13 at 2 17 45 PM" src="https://user-images.githubusercontent.com/11710234/137192171-7baca37d-bbc1-4357-8451-9dd3701bc8f6.png">


