### PR TITLE
Rudimentary handling of empty facets for HistogramVisualization only

### DIFF
--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -802,21 +802,32 @@ function reorderData(
   facetVocabulary: string[] = []
 ): HistogramDataWithCoverageStatistics | HistogramData {
   if (isFaceted(data)) {
+    // for each value in the facet vocabulary's correct order
+    // find the index in the series where series.name equals that value
+    const facetValues = data.facets.map((facet) => facet.label);
+    const facetIndices = facetVocabulary.map((name) =>
+      facetValues.indexOf(name)
+    );
+
     return {
       ...data,
-      facets: sortBy(data.facets, ({ label }) =>
-        facetVocabulary.indexOf(label)
-      ).map(({ label, data }) => ({
-        label,
-        data: reorderData(
-          data,
-          overlayVocabulary,
-          facetVocabulary
-        ) as HistogramData,
+      facets: facetIndices.map((i, j) => ({
+        label:
+          facetVocabulary[j] +
+          (data.facets[i] ? '' : ' (no plottable data for this facet)'),
+        data: data.facets[i]
+          ? (reorderData(
+              data.facets[i].data,
+              overlayVocabulary,
+              facetVocabulary
+            ) as HistogramData)
+          : // dummy data for empty facet
+            { series: [] },
       })),
     };
   }
 
+  // otherwise handle non-faceted data
   if (overlayVocabulary.length > 0) {
     // for each value in the overlay vocabulary's correct order
     // find the index in the series where series.name equals that value


### PR DESCRIPTION
This is one way to do it, but it's not ideal.
GEMS1 filter country=India

![image](https://user-images.githubusercontent.com/308639/140946838-ca0633da-9472-4c32-b27a-d09aded3eba9.png)

An improvement would be for FacetedPlot to render the facet title outside of Plotly (this would give us more control over styling and things like overflow/ellipsis handling).  FacetedPlot could also render a large "No data for this facet" for individual facets where `facet.data == null`.  Thoughts?

Note that the back end doesn't return empty data for empty facets, but it's easy for the client to put in an `undefined` where needed (I'll add an annotation to the PR).