### PR TITLE
set dependent axis range for Boxplot Viz with facet

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -328,7 +328,7 @@ function BoxplotViz(props: VisualizationProps) {
                   data.value.facets.flatMap((facet) =>
                     facet.data.series
                       .flatMap((o) => o.outliers as number[][])
-                      .flatMap((o) => o)
+                      .flat()
                   )
                 ),
                 min(
@@ -343,7 +343,7 @@ function BoxplotViz(props: VisualizationProps) {
                   data.value.facets.flatMap((facet) =>
                     facet.data.series
                       .flatMap((o) => o.outliers as number[][])
-                      .flatMap((o) => o)
+                      .flat()
                   )
                 ),
                 max(
@@ -364,7 +364,7 @@ function BoxplotViz(props: VisualizationProps) {
                 min(
                   data.value.series
                     .flatMap((o) => o.outliers as number[][])
-                    .flatMap((o) => o)
+                    .flat()
                 ),
                 min(data.value.series.flatMap((o) => o.lowerfence as number[])),
               ]) as number) * 1.05,
@@ -373,7 +373,7 @@ function BoxplotViz(props: VisualizationProps) {
                 max(
                   data.value.series
                     .flatMap((o) => o.outliers as number[][])
-                    .flatMap((o) => o)
+                    .flat()
                 ),
                 max(data.value.series.flatMap((o) => o.upperfence as number[])),
               ]) as number) * 1.05,


### PR DESCRIPTION
This will address the ticket, [Faceting: calculate dependentAxisRange from plugin response for Boxplot and maybe others #650](https://github.com/VEuPathDB/web-eda/issues/650)

A part of an example screenshot is attached (GEMS1 Case Control; X: Floor material; Y: Sleeping rooms in dwelling count; Overlay: Drinking water container; Facet: Country). They showed the same dependent axis range

![boxplot-dependent-axis-range](https://user-images.githubusercontent.com/12802305/141349627-9243bd85-a66f-499e-a1f5-f8992f320fbb.png)

