### PR TITLE
Facet wiring for scatterplot

### DIFF
--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -384,7 +384,8 @@ function HistogramViz(props: VisualizationProps) {
   const legendItems: LegendItemsProps[] = useMemo(() => {
     const legendData = !isFaceted(data.value)
       ? data.value?.series
-      : data.value?.facets[0].data.series;
+      : data.value?.facets.find(({ data }) => data.series.length > 0)?.data
+          .series;
 
     return legendData != null
       ? legendData
@@ -408,9 +409,7 @@ function HistogramViz(props: VisualizationProps) {
                         el.data.series[index].bins != null &&
                         el.data.series[index].bins.length > 0
                     )
-                    .includes(true)
-                ? true
-                : false,
+                    .includes(true),
               group: 1,
               rank: 1,
             };
@@ -599,8 +598,10 @@ function HistogramPlotWithControls({
 
   const widgetHeight = '4em';
 
-  // controls need the bin info from just one facet
-  const data0 = isFaceted(data) ? data.facets[0].data : data;
+  // controls need the bin info from just one facet (not an empty one)
+  const data0 = isFaceted(data)
+    ? data.facets.find(({ data }) => data.series.length > 0)?.data
+    : data;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1202,10 +1202,8 @@ function processInputData<T extends number | string>(
           ? fixLabelForNumberVariables(
               el.overlayVariableDetails.value,
               overlayVariable
-            ) +
-            ', R² = ' +
-            el.r2
-          : 'Best fit, R² = ' + el.r2,
+            ) + ', Best fit' // TO DO: put R^2 values in a table, esp for faceting
+          : 'Best fit', // ditto - see issue 694
         mode: 'lines', // no data point is displayed: only line
         line: {
           // use darker color for best fit line


### PR DESCRIPTION
Resolves #659 
Resolves #690 

This was quite tricky but I refactored `processInputData` to only use the `response.scatterplot.data` data, so that I could use this function to process the data after the groupBy facetVariableDetails.value.  It needed some global response info, so this is now provided as the `hasMissingData` prop.

The rest is fairly straightforward.  I made some new tickets (in Next cycle) for some things I found along the way.