### PR TITLE
faceting legend fix for representative facet

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -340,7 +340,8 @@ function BarplotViz(props: VisualizationProps) {
   const legendItems: LegendItemsProps[] = useMemo(() => {
     const legendData = !isFaceted(data.value)
       ? data.value?.series
-      : data.value?.facets[0].data.series;
+      : data.value?.facets.find(({ data }) => data.series.length > 0)?.data
+          .series;
 
     return legendData != null
       ? legendData.map((dataItem: BarplotDataSeries, index: number) => {

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -402,7 +402,8 @@ function BoxplotViz(props: VisualizationProps) {
   const legendItems: LegendItemsProps[] = useMemo(() => {
     const legendData = !isFaceted(data.value)
       ? data.value?.series
-      : data.value?.facets[0].data.series;
+      : data.value?.facets.find(({ data }) => data.series.length > 0)?.data
+          .series;
 
     return legendData != null
       ? legendData.map((dataItem: BoxplotDataObject, index: number) => {


### PR DESCRIPTION
This addresses [Faceting legends - make sure representative facet is chosen correctly #691](https://github.com/VEuPathDB/web-eda/issues/691). Since Bob already did for histogram and scatter plot vizs, this is quite straightforward for barplot and boxplot viz.