### PR TITLE
Temporary fix to single facet detection

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -585,7 +585,7 @@ export function barplotResponseToData(
           data.facetVariableDetails[0].value,
           facetVariable
         )
-      : undefined
+      : '__NO_FACET__'
   );
 
   // process data and overlay value within each facet grouping
@@ -613,7 +613,8 @@ export function barplotResponseToData(
 
   return {
     // data
-    ...(size(processedData) === 1 && head(keys(processedData)) === 'undefined'
+    ...(size(processedData) === 1 &&
+    head(keys(processedData)) === '__NO_FACET__'
       ? // unfaceted
         head(values(processedData))
       : // faceted

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -613,7 +613,7 @@ export function barplotResponseToData(
 
   return {
     // data
-    ...(size(processedData) === 1 && head(keys(processedData)) == null
+    ...(size(processedData) === 1 && head(keys(processedData)) === 'undefined'
       ? // unfaceted
         head(values(processedData))
       : // faceted

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -719,9 +719,15 @@ export function boxplotResponseToData(
     };
   });
 
+  console.log('head keys and size');
+  console.log(head(keys(processedData)));
+  console.log(size(processedData));
+
+  const foo = head(keys(processedData));
+
   return {
     // data
-    ...(size(processedData) === 1 && head(keys(processedData)) == null
+    ...(size(processedData) === 1 && head(keys(processedData)) === 'undefined'
       ? // unfaceted
         head(values(processedData))
       : // faceted

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -679,7 +679,7 @@ export function boxplotResponseToData(
           data.facetVariableDetails[0].value,
           facetVariable
         )
-      : undefined
+      : '__NO_FACET__'
   );
 
   // process data and overlay value within each facet grouping
@@ -719,15 +719,10 @@ export function boxplotResponseToData(
     };
   });
 
-  console.log('head keys and size');
-  console.log(head(keys(processedData)));
-  console.log(size(processedData));
-
-  const foo = head(keys(processedData));
-
   return {
     // data
-    ...(size(processedData) === 1 && head(keys(processedData)) === 'undefined'
+    ...(size(processedData) === 1 &&
+    head(keys(processedData)) === '__NO_FACET__'
       ? // unfaceted
         head(values(processedData))
       : // faceted

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -834,7 +834,7 @@ export function histogramResponseToData(
 
   return {
     // data
-    ...(size(processedData) === 1 && head(keys(processedData)) == null
+    ...(size(processedData) === 1 && head(keys(processedData)) === 'undefined'
       ? // unfaceted
         head(values(processedData))
       : // faceted

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -775,7 +775,7 @@ export function histogramResponseToData(
           data.facetVariableDetails[0].value,
           facetVariable
         )
-      : undefined
+      : '__NO_FACET__'
   );
 
   const binWidth =
@@ -834,7 +834,8 @@ export function histogramResponseToData(
 
   return {
     // data
-    ...(size(processedData) === 1 && head(keys(processedData)) === 'undefined'
+    ...(size(processedData) === 1 &&
+    head(keys(processedData)) === '__NO_FACET__'
       ? // unfaceted
         head(values(processedData))
       : // faceted

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -705,7 +705,8 @@ export function contTableResponseToData(
 
   return {
     // data
-    ...(_.size(processedData) === 1 && _.head(_.keys(processedData)) == null
+    ...(_.size(processedData) === 1 &&
+    _.head(_.keys(processedData)) === 'undefined'
       ? // unfaceted
         _.head(_.values(processedData))
       : // faceted

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -662,7 +662,7 @@ export function contTableResponseToData(
           data.facetVariableDetails[0].value,
           facetVariable
         )
-      : undefined
+      : '__NO_FACET__'
   );
   const facetGroupedResponseStats = _.groupBy(response.statsTable, (stats) =>
     stats.facetVariableDetails && stats.facetVariableDetails.length === 1
@@ -670,7 +670,7 @@ export function contTableResponseToData(
           stats.facetVariableDetails[0].value,
           facetVariable
         )
-      : undefined
+      : '__NO_FACET__'
   );
 
   const processedData = _.mapValues(
@@ -706,7 +706,7 @@ export function contTableResponseToData(
   return {
     // data
     ...(_.size(processedData) === 1 &&
-    _.head(_.keys(processedData)) === 'undefined'
+    _.head(_.keys(processedData)) === '__NO_FACET__'
       ? // unfaceted
         _.head(_.values(processedData))
       : // faceted

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -858,7 +858,7 @@ export function scatterplotResponseToData(
   const yMax = max(map(processedData, ({ yMax }) => yMax));
 
   const dataSetProcess =
-    size(processedData) === 1 && head(keys(processedData)) == null
+    size(processedData) === 1 && head(keys(processedData)) === 'undefined'
       ? // unfaceted
         head(values(processedData))?.dataSetProcess
       : // faceted

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -827,7 +827,7 @@ export function scatterplotResponseToData(
           data.facetVariableDetails[0].value,
           facetVariable
         )
-      : undefined
+      : '__NO_FACET__'
   );
 
   const processedData = mapValues(facetGroupedResponseData, (group) => {
@@ -858,7 +858,7 @@ export function scatterplotResponseToData(
   const yMax = max(map(processedData, ({ yMax }) => yMax));
 
   const dataSetProcess =
-    size(processedData) === 1 && head(keys(processedData)) === 'undefined'
+    size(processedData) === 1 && head(keys(processedData)) === '__NO_FACET__'
       ? // unfaceted
         head(values(processedData))?.dataSetProcess
       : // faceted


### PR DESCRIPTION
DK spotted that the `processedData` Dictionary was using `'undefined'` the string as the key, not undefined the value.

We should probably think of a better solution than this.

We could get real life data with 'undefined' values. 