### PR TITLE
add unit for table filter's header

### DIFF
--- a/src/lib/core/components/filter/TableFilter.tsx
+++ b/src/lib/core/components/filter/TableFilter.tsx
@@ -15,6 +15,8 @@ import { TableVariable } from './types';
 import { getDistribution } from './util';
 import { DistributionResponse } from '../../api/SubsettingClient';
 import { gray, red } from './colors';
+// import axis label unit util
+import { axisLabelWithUnit } from '../../utils/axis-label-unit';
 
 type Props = {
   studyMetadata: StudyMetadata;
@@ -130,7 +132,8 @@ export function TableFilter({
   );
   const activeField = useMemo(
     () => ({
-      display: variable.displayName,
+      // add units
+      display: axisLabelWithUnit(variable),
       isRange: false,
       parent: variable.parentId,
       precision: 1,


### PR DESCRIPTION
This will address #426 : thinking of a bit harder solution while Dave did let me know much simpler solution to directly change variable from parent 😄 Used pre-existing util to have units. Here is an example at GEMS1 Study control

![table-filter-header-units](https://user-images.githubusercontent.com/12802305/141848794-8c82fbc2-9cfc-433a-8e3a-ce9c3ac890fe.png)

