### PR TITLE
disable Plotly's default legend

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -402,10 +402,7 @@ function BarplotViz(props: VisualizationProps) {
       : plotSpacingOptions,
     orientation: 'vertical',
     barLayout: 'group',
-    displayLegend:
-      data.value &&
-      !isFaceted(data.value) &&
-      (data.value.series.length > 1 || vizConfig.overlayVariable != null),
+    displayLegend: false,
     independentAxisLabel: axisLabelWithUnit(variable) ?? 'Main',
     dependentAxisLabel:
       vizConfig.valueSpec === 'count' ? 'Count' : 'Proportion',

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -447,9 +447,6 @@ function BoxplotViz(props: VisualizationProps) {
     }
   }, [data, legendItems]);
 
-  console.log('data at boxplot viz =', data);
-  console.log('legendItems = ', legendItems);
-
   const plotNode = (
     <BoxplotWithControls
       // data.value
@@ -462,7 +459,6 @@ function BoxplotViz(props: VisualizationProps) {
         isFaceted(data.value) ? facetedPlotSpacingOptions : plotSpacingOptions
       }
       orientation={'vertical'}
-      // add condition to show legend when overlayVariable is used
       displayLegend={false}
       independentAxisLabel={axisLabelWithUnit(xAxisVariable) ?? 'X-axis'}
       dependentAxisLabel={axisLabelWithUnit(yAxisVariable) ?? 'Y-axis'}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -463,11 +463,7 @@ function BoxplotViz(props: VisualizationProps) {
       }
       orientation={'vertical'}
       // add condition to show legend when overlayVariable is used
-      displayLegend={
-        data.value &&
-        !isFaceted(data.value) &&
-        (data.value.series.length > 1 || vizConfig.overlayVariable != null)
-      }
+      displayLegend={false}
       independentAxisLabel={axisLabelWithUnit(xAxisVariable) ?? 'X-axis'}
       dependentAxisLabel={axisLabelWithUnit(yAxisVariable) ?? 'Y-axis'}
       // show/hide independent/dependent axis tick label

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -510,11 +510,7 @@ function HistogramViz(props: VisualizationProps) {
         }
         orientation={'vertical'}
         barLayout={'stack'}
-        displayLegend={
-          data.value &&
-          !isFaceted(data.value) &&
-          (data.value.series.length > 1 || vizConfig.overlayVariable != null)
-        }
+        displayLegend={false}
         outputEntity={outputEntity}
         independentAxisVariable={vizConfig.xAxisVariable}
         independentAxisLabel={axisLabelWithUnit(xAxisVariable) ?? 'Main'}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -529,12 +529,7 @@ function ScatterplotViz(props: VisualizationProps) {
           : plotSpacingOptions
       }
       // title={'Scatter plot'}
-      displayLegend={
-        data.value &&
-        !isFaceted(data.value.dataSetProcess) &&
-        (data.value.dataSetProcess.series.length > 1 ||
-          vizConfig.overlayVariable != null)
-      }
+      displayLegend={false}
       independentAxisLabel={axisLabelWithUnit(xAxisVariable) ?? 'X-axis'}
       dependentAxisLabel={axisLabelWithUnit(yAxisVariable) ?? 'Y-axis'}
       // variable's metadata-based independent axis range with margin


### PR DESCRIPTION
With the new custom legend, we do not need to have the Plotly's default legend anymore. Thus it is now disabled except Mosaic plot Viz where it still relies on the Plotly's legend.