### PR TITLE
Treat multiFilter fields as categories when checking for compatible variables

### DIFF
--- a/src/lib/core/components/variableTrees/VariableList.tsx
+++ b/src/lib/core/components/variableTrees/VariableList.tsx
@@ -401,7 +401,8 @@ export default function VariableList({
     tree = showOnlyCompatibleVariables
       ? pruneDescendantNodes((node) => {
           if (disabledFields.size === 0) return true;
-          if (node.field.type == null) return node.children.length > 0;
+          if (node.field.type == null || node.field.type === 'multiFilter')
+            return node.children.length > 0;
           return !disabledFields.has(node.field.term);
         }, tree)
       : tree;


### PR DESCRIPTION
This PR will make it so that multifilter variables are not visible in the variable tree dropdown if all descendants are incompatible.

fixes #707 