### PR TITLE
Centralize loading of entity counts

### DIFF
--- a/src/lib/core/components/BirdsEyeView.tsx
+++ b/src/lib/core/components/BirdsEyeView.tsx
@@ -1,4 +1,3 @@
-import { Filter } from '../types/filter';
 import { EntityCounts } from '../hooks/entityCounts';
 import { CoverageStatistics } from '../types/visualization';
 import BirdsEyePlot from '@veupathdb/components/lib/plots/BirdsEyePlot';
@@ -7,8 +6,6 @@ import { StudyEntity } from '../types/study';
 import { HelpIcon } from '@veupathdb/wdk-client/lib/Components';
 
 interface Props extends Partial<CoverageStatistics> {
-  /** Current active filters */
-  filters?: Filter[];
   /** The output entity */
   outputEntity?: StudyEntity;
   /** Are any stratification variables active? */
@@ -21,7 +18,6 @@ interface Props extends Partial<CoverageStatistics> {
 
 export function BirdsEyeView(props: Props) {
   const {
-    filters = [],
     outputEntity,
     completeCasesAllVars,
     completeCasesAxesVars,

--- a/src/lib/core/components/BirdsEyeView.tsx
+++ b/src/lib/core/components/BirdsEyeView.tsx
@@ -1,5 +1,5 @@
 import { Filter } from '../types/filter';
-import { useEntityCounts } from '../hooks/entityCounts';
+import { EntityCounts } from '../hooks/entityCounts';
 import { CoverageStatistics } from '../types/visualization';
 import BirdsEyePlot from '@veupathdb/components/lib/plots/BirdsEyePlot';
 import { red, gray } from './filter/colors';
@@ -15,6 +15,8 @@ interface Props extends Partial<CoverageStatistics> {
   stratificationIsActive: boolean;
   /** Should the spinner be enabled? This doesn't mean that it is shown. Just that it might be. */
   enableSpinner?: boolean;
+  totalCounts: EntityCounts | undefined;
+  filteredCounts: EntityCounts | undefined;
 }
 
 export function BirdsEyeView(props: Props) {
@@ -25,19 +27,17 @@ export function BirdsEyeView(props: Props) {
     completeCasesAxesVars,
     stratificationIsActive,
     enableSpinner = false,
+    totalCounts,
+    filteredCounts,
   } = props;
 
-  const unfilteredEntityCounts = useEntityCounts();
-  const filteredEntityCounts = useEntityCounts(filters);
   const outputEntityId = outputEntity?.id;
 
   const totalSize =
-    unfilteredEntityCounts.value && outputEntityId
-      ? unfilteredEntityCounts.value[outputEntityId]
-      : undefined;
+    totalCounts && outputEntityId ? totalCounts[outputEntityId] : undefined;
   const subsetSize =
-    filteredEntityCounts.value && outputEntityId
-      ? filteredEntityCounts.value[outputEntityId]
+    filteredCounts && outputEntityId
+      ? filteredCounts[outputEntityId]
       : undefined;
 
   const birdsEyeData =

--- a/src/lib/core/components/computations/PassThroughComputation.tsx
+++ b/src/lib/core/components/computations/PassThroughComputation.tsx
@@ -17,10 +17,13 @@ import { VisualizationType } from '../visualizations/VisualizationTypes';
 import { scatterplotVisualization } from '../visualizations/implementations/ScatterplotVisualization';
 import { barplotVisualization } from '../visualizations/implementations/BarplotVisualization';
 import { boxplotVisualization } from '../visualizations/implementations/BoxplotVisualization';
+import { EntityCounts } from '../../hooks/entityCounts';
 
 interface Props {
   analysisState: AnalysisState;
   computationAppOverview: ComputationAppOverview;
+  totalCounts: EntityCounts | undefined;
+  filteredCounts: EntityCounts | undefined;
 }
 
 /**
@@ -40,7 +43,12 @@ const visualizationTypes: Record<string, VisualizationType> = {
 };
 
 export function PassThroughComputation(props: Props) {
-  const { analysisState, computationAppOverview } = props;
+  const {
+    analysisState,
+    computationAppOverview,
+    totalCounts,
+    filteredCounts,
+  } = props;
   const { analysis, setComputations } = analysisState;
   const filters = useMemo(() => analysis?.descriptor.subset.descriptor ?? [], [
     analysis?.descriptor.subset.descriptor,
@@ -105,6 +113,8 @@ export function PassThroughComputation(props: Props) {
       filters={filters}
       starredVariables={analysis.descriptor.starredVariables}
       toggleStarredVariable={toggleStarredVariable}
+      totalCounts={totalCounts}
+      filteredCounts={filteredCounts}
     />
   );
 }

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -1,3 +1,4 @@
+import { EntityCounts } from '../../hooks/entityCounts';
 import { Filter } from '../../types/filter';
 import { VariableDescriptor } from '../../types/variable';
 import {
@@ -20,6 +21,8 @@ export interface VisualizationProps {
   filters?: Filter[];
   starredVariables: VariableDescriptor[];
   toggleStarredVariable: (targetVariableId: VariableDescriptor) => void;
+  totalCounts: EntityCounts | undefined;
+  filteredCounts: EntityCounts | undefined;
 }
 
 export type SelectorProps = VisualizationOverview;

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -26,6 +26,7 @@ import { ContentError } from '@veupathdb/wdk-client/lib/Components/PageStatus/Co
 import PlaceholderIcon from './PlaceholderIcon';
 import { Tooltip } from '@material-ui/core';
 import { isEqual } from 'lodash';
+import { EntityCounts } from '../../hooks/entityCounts';
 
 const cx = makeClassNameHelper('VisualizationsContainer');
 
@@ -41,6 +42,8 @@ interface Props {
   filters: Filter[];
   starredVariables: VariableDescriptor[];
   toggleStarredVariable: (targetVariable: VariableDescriptor) => void;
+  totalCounts: EntityCounts | undefined;
+  filteredCounts: EntityCounts | undefined;
 }
 
 /**
@@ -252,6 +255,8 @@ function FullScreenVisualization(props: Props & { id: string }) {
     filters,
     starredVariables,
     toggleStarredVariable,
+    totalCounts,
+    filteredCounts,
   } = props;
   const history = useHistory();
   const viz = computation.visualizations.find((v) => v.visualizationId === id);
@@ -401,6 +406,8 @@ function FullScreenVisualization(props: Props & { id: string }) {
             toggleStarredVariable={toggleStarredVariable}
             updateConfiguration={updateConfiguration}
             updateThumbnail={updateThumbnail}
+            totalCounts={totalCounts}
+            filteredCounts={filteredCounts}
           />
         </div>
       )}

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -152,6 +152,8 @@ function BarplotViz(props: VisualizationProps) {
     dataElementDependencyOrder,
     starredVariables,
     toggleStarredVariable,
+    totalCounts,
+    filteredCounts,
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
@@ -481,6 +483,8 @@ function BarplotViz(props: VisualizationProps) {
         outputEntity={entity}
         stratificationIsActive={overlayVariable != null}
         enableSpinner={vizConfig.xAxisVariable != null && !data.error}
+        totalCounts={totalCounts}
+        filteredCounts={filteredCounts}
       />
       <VariableCoverageTable
         completeCases={data.pending ? undefined : data.value?.completeCases}

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -479,7 +479,6 @@ function BarplotViz(props: VisualizationProps) {
         completeCasesAxesVars={
           data.pending ? undefined : data.value?.completeCasesAxesVars
         }
-        filters={filters}
         outputEntity={entity}
         stratificationIsActive={overlayVariable != null}
         enableSpinner={vizConfig.xAxisVariable != null && !data.error}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -141,6 +141,8 @@ function BoxplotViz(props: VisualizationProps) {
     dataElementDependencyOrder,
     starredVariables,
     toggleStarredVariable,
+    totalCounts,
+    filteredCounts,
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
@@ -503,6 +505,8 @@ function BoxplotViz(props: VisualizationProps) {
         enableSpinner={
           xAxisVariable != null && yAxisVariable != null && !data.error
         }
+        totalCounts={totalCounts}
+        filteredCounts={filteredCounts}
       />
       <VariableCoverageTable
         completeCases={data.pending ? undefined : data.value?.completeCases}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -497,7 +497,6 @@ function BoxplotViz(props: VisualizationProps) {
         completeCasesAxesVars={
           data.pending ? undefined : data.value?.completeCasesAxesVars
         }
-        filters={filters}
         outputEntity={outputEntity}
         stratificationIsActive={
           overlayVariable != null || facetVariable != null

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -79,6 +79,7 @@ import PlotLegend, {
   LegendItemsProps,
 } from '@veupathdb/components/lib/components/plotControls/PlotLegend';
 import { ColorPaletteDefault } from '@veupathdb/components/lib/types/plots/addOns';
+import { EntityCounts } from '../../../hooks/entityCounts';
 
 type HistogramDataWithCoverageStatistics = (
   | HistogramData
@@ -168,6 +169,8 @@ function HistogramViz(props: VisualizationProps) {
     dataElementDependencyOrder,
     starredVariables,
     toggleStarredVariable,
+    totalCounts,
+    filteredCounts,
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
@@ -541,6 +544,8 @@ function HistogramViz(props: VisualizationProps) {
         legendItems={legendItems}
         checkedLegendItems={vizConfig.checkedLegendItems}
         onCheckedLegendItemsChange={onCheckedLegendItemsChange}
+        totalCounts={totalCounts}
+        filteredCounts={filteredCounts}
       />
     </div>
   );
@@ -566,6 +571,8 @@ type HistogramPlotWithControlsProps = Omit<HistogramProps, 'data'> & {
   legendItems: LegendItemsProps[];
   checkedLegendItems: string[] | undefined;
   onCheckedLegendItemsChange: (checkedLegendItems: string[]) => void;
+  totalCounts: EntityCounts | undefined;
+  filteredCounts: EntityCounts | undefined;
 } & Partial<CoverageStatistics>;
 
 function HistogramPlotWithControls({
@@ -591,6 +598,8 @@ function HistogramPlotWithControls({
   legendItems,
   checkedLegendItems,
   onCheckedLegendItemsChange,
+  totalCounts,
+  filteredCounts,
   ...histogramProps
 }: HistogramPlotWithControlsProps) {
   const barLayout = 'stack';
@@ -710,6 +719,8 @@ function HistogramPlotWithControls({
           overlayVariable != null || facetVariable != null
         }
         enableSpinner={independentAxisVariable != null && !error}
+        totalCounts={totalCounts}
+        filteredCounts={filteredCounts}
       />
       <VariableCoverageTable
         completeCases={completeCases}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -713,7 +713,6 @@ function HistogramPlotWithControls({
       <BirdsEyeView
         completeCasesAllVars={completeCasesAllVars}
         completeCasesAxesVars={completeCasesAxesVars}
-        filters={filters}
         outputEntity={outputEntity}
         stratificationIsActive={
           overlayVariable != null || facetVariable != null

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -161,6 +161,8 @@ function MosaicViz(props: Props) {
     dataElementDependencyOrder,
     starredVariables,
     toggleStarredVariable,
+    totalCounts,
+    filteredCounts,
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
@@ -433,6 +435,8 @@ function MosaicViz(props: Props) {
           enableSpinner={
             xAxisVariable != null && yAxisVariable != null && !data.error
           }
+          totalCounts={totalCounts}
+          filteredCounts={filteredCounts}
         />
         <VariableCoverageTable
           completeCases={data.pending ? undefined : data.value?.completeCases}

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -429,7 +429,6 @@ function MosaicViz(props: Props) {
           completeCasesAxesVars={
             data.pending ? undefined : data.value?.completeCasesAxesVars
           }
-          filters={filters}
           outputEntity={outputEntity}
           stratificationIsActive={facetVariable != null}
           enableSpinner={

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -185,6 +185,8 @@ function ScatterplotViz(props: VisualizationProps) {
     dataElementDependencyOrder,
     starredVariables,
     toggleStarredVariable,
+    totalCounts,
+    filteredCounts,
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
@@ -591,6 +593,8 @@ function ScatterplotViz(props: VisualizationProps) {
         enableSpinner={
           xAxisVariable != null && yAxisVariable != null && !data.error
         }
+        totalCounts={totalCounts}
+        filteredCounts={filteredCounts}
       />
       <VariableCoverageTable
         completeCases={

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -587,7 +587,6 @@ function ScatterplotViz(props: VisualizationProps) {
         completeCasesAxesVars={
           data.pending ? undefined : data.value?.completeCasesAxesVars
         }
-        filters={filters}
         outputEntity={outputEntity}
         stratificationIsActive={overlayVariable != null}
         enableSpinner={

--- a/src/lib/core/hooks/entityCounts.ts
+++ b/src/lib/core/hooks/entityCounts.ts
@@ -5,6 +5,8 @@ import { usePromise } from './promise';
 import { useStudyMetadata, useSubsettingClient } from './workspace';
 import { debounce } from 'lodash';
 
+export type EntityCounts = Record<string, number>;
+
 export function useEntityCounts(filters?: Filter[]) {
   const { id, rootEntity } = useStudyMetadata();
   const subsettingClient = useSubsettingClient();

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -228,12 +228,23 @@ export function AnalysisPanel({
           render={(
             props: RouteComponentProps<{ entityId: string; variableId: string }>
           ) => (
-            <Subsetting {...props.match.params} analysisState={analysisState} />
+            <Subsetting
+              {...props.match.params}
+              analysisState={analysisState}
+              totalCounts={totalCounts.value}
+              filteredCounts={filteredCounts.value}
+            />
           )}
         />
         <Route
           path={`${routeBase}/visualizations`}
-          render={() => <ComputationRoute analysisState={analysisState} />}
+          render={() => (
+            <ComputationRoute
+              analysisState={analysisState}
+              totalCounts={totalCounts.value}
+              filteredCounts={filteredCounts.value}
+            />
+          )}
         />
         <Route
           path={`${routeBase}/notes`}

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -4,14 +4,17 @@ import { useRouteMatch } from 'react-router-dom';
 import { AnalysisState, useDataClient } from '../core';
 import { PassThroughComputation } from '../core/components/computations/PassThroughComputation';
 import { PromiseResult } from '../core/components/Promise';
+import { EntityCounts } from '../core/hooks/entityCounts';
 import { usePromise } from '../core/hooks/promise';
 
 export interface Props {
   analysisState: AnalysisState;
+  totalCounts: EntityCounts | undefined;
+  filteredCounts: EntityCounts | undefined;
 }
 
 export function ComputationRoute(props: Props) {
-  const { analysisState } = props;
+  const { analysisState, totalCounts, filteredCounts } = props;
   const { url } = useRouteMatch();
   const dataClient = useDataClient();
   const promiseState = usePromise(
@@ -37,6 +40,8 @@ export function ComputationRoute(props: Props) {
             <PassThroughComputation
               analysisState={analysisState}
               computationAppOverview={computationAppOverview}
+              totalCounts={totalCounts}
+              filteredCounts={filteredCounts}
             />
           </Route>
         </Switch>

--- a/src/lib/workspace/Subsetting/index.tsx
+++ b/src/lib/workspace/Subsetting/index.tsx
@@ -18,7 +18,7 @@ import SubsettingDataGridModal from './SubsettingDataGridModal';
 import { TableDownload } from '@veupathdb/core-components/dist/components/icons';
 
 // Hooks
-import { useEntityCounts } from '../../core/hooks/entityCounts';
+import { EntityCounts } from '../../core/hooks/entityCounts';
 import { useToggleStarredVariable } from '../../core/hooks/starredVariables';
 import { useStudyEntities } from '../../core/hooks/study';
 
@@ -39,6 +39,8 @@ interface SubsettingProps {
    * a variable is a child of an entity.
    */
   variableId: string;
+  totalCounts: EntityCounts | undefined;
+  filteredCounts: EntityCounts | undefined;
 }
 
 /** Allow user to filter study data based on the value(s) of any available variable. */
@@ -46,6 +48,8 @@ export default function Subsetting({
   entityId,
   variableId,
   analysisState,
+  totalCounts,
+  filteredCounts,
 }: SubsettingProps) {
   const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
 
@@ -64,9 +68,7 @@ export default function Subsetting({
   const variable = entity?.variables.find((v) => v.id === variableId);
 
   const history = useHistory();
-  const totalCounts = useEntityCounts();
   const filters = analysisState.analysis?.descriptor.subset.descriptor;
-  const filteredCounts = useEntityCounts(filters);
   const makeVariableLink = useMakeVariableLink();
 
   const toggleStarredVariable = useToggleStarredVariable(analysisState);
@@ -77,11 +79,10 @@ export default function Subsetting({
   )
     return <div>Could not find specified variable.</div>;
 
-  const totalEntityCount = totalCounts.value && totalCounts.value[entity.id];
+  const totalEntityCount = totalCounts && totalCounts[entity.id];
 
   // This will give you the count of rows for the current entity.
-  const filteredEntityCount =
-    filteredCounts.value && filteredCounts.value[entity.id];
+  const filteredEntityCount = filteredCounts && filteredCounts[entity.id];
 
   return (
     <div className={cx('-Subsetting')}>


### PR DESCRIPTION
Uses the tried and test approach of "props passing" (and lots of it). I considered using `React.Context` to avoid passing props all over the place, but this approach is simple and works.

closes #713 