### PR TITLE
fix dependent axis range reset for scatter plot

### DIFF
--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -541,9 +541,7 @@ function ScatterplotViz(props: VisualizationProps) {
       // variable's metadata-based independent axis range with margin
       independentAxisRange={defaultIndependentRangeMargin}
       // new dependent axis range
-      dependentAxisRange={
-        data.value && !data.pending ? defaultDependentRangeMargin : undefined
-      }
+      dependentAxisRange={data.value ? defaultDependentRangeMargin : undefined}
       // set valueSpec as Raw when yAxisVariable = date
       valueSpec={
         yAxisVariable?.type === 'date' ? 'Raw' : vizConfig.valueSpecConfig


### PR DESCRIPTION
This will address [Scatterplot visualization - dependent axis range resets temporarily between overlay variable changes #671](#671 ).

I thought the source of the problem might be complicated and was investigating this too deep. However, the actual reason turned out to be pretty simple: the dependentAxisRange had a condition to check data.pending 😐 Anyway, now it seems to work as expected without changing the range. 