### PR TITLE
Thumbnail improvements for B55

### DIFF
--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -30,6 +30,7 @@
 
     img {
       width: 100%;
+      height: 100%;
       text-align: center;
     }
 

--- a/src/lib/core/hooks/thumbnails.ts
+++ b/src/lib/core/hooks/thumbnails.ts
@@ -1,4 +1,10 @@
-import { DependencyList, useCallback, useEffect, useRef } from 'react';
+import {
+  DependencyList,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from 'react';
 
 import { FacetedPlotRef, PlotRef } from '@veupathdb/components/lib/types/plots';
 import { Task } from '@veupathdb/wdk-client/lib/Utils/Task';
@@ -27,7 +33,7 @@ export function useUpdateThumbnailEffect(
 
   // Whenever one of the "deps" change, capture a thumbnail image
   // and save it to the analysis config
-  useEffect(() => {
+  useLayoutEffect(() => {
     const plotInstance = plotRef.current;
 
     if (plotInstance == null) {
@@ -36,9 +42,18 @@ export function useUpdateThumbnailEffect(
 
     const { updateThumbnail, thumbnailDimensions } = thumbnailArgsRef.current;
 
-    return Task.fromPromise(() =>
-      makePlotThumbnailUrl(plotInstance, thumbnailDimensions)
-    ).run(updateThumbnail);
+    return Task.fromPromise(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(resolve, 0);
+        })
+    )
+      .chain(() =>
+        Task.fromPromise(() =>
+          makePlotThumbnailUrl(plotInstance, thumbnailDimensions)
+        )
+      )
+      .run(updateThumbnail);
 
     // Disabling react-hooks/exhaustive-deps because it objects to the use
     // of "deps" which are not array literals

--- a/src/lib/core/utils/thumbnails.tsx
+++ b/src/lib/core/utils/thumbnails.tsx
@@ -102,7 +102,7 @@ async function makeFacetedPlotThumbnailUrl(
         fontSize={thumbnailDimensions.height * 0.075}
         textAnchor="middle"
       >
-        {facetedPlotRef.length} facets
+        Faceted
       </text>
     </svg>
   );

--- a/src/lib/core/utils/thumbnails.tsx
+++ b/src/lib/core/utils/thumbnails.tsx
@@ -85,22 +85,24 @@ async function makeFacetedPlotThumbnailUrl(
     >
       {plotImageNodes}
       <rect
-        x={thumbnailDimensions.width * 0.75}
-        y={thumbnailDimensions.height * 0.875}
-        width={thumbnailDimensions.width * 0.225}
-        height={thumbnailDimensions.height * 0.1}
-        fill="#F5F5F5"
+        x={0}
+        y={thumbnailDimensions.height * 0.9}
+        width={thumbnailDimensions.width}
+        height={thumbnailDimensions.height * 0.11}
+        fill="#555"
         stroke="#777"
         opacity={0.75}
       />
       <text
         style={{
           fontFamily: 'sans-serif',
+          fontStyle: 'italic',
         }}
-        x={thumbnailDimensions.width * 0.8625}
-        y={thumbnailDimensions.height * 0.95}
+        x={thumbnailDimensions.width * 0.5}
+        y={thumbnailDimensions.height * 0.975}
         fontSize={thumbnailDimensions.height * 0.075}
         textAnchor="middle"
+        fill="white"
       >
         Faceted
       </text>

--- a/src/lib/core/utils/thumbnails.tsx
+++ b/src/lib/core/utils/thumbnails.tsx
@@ -84,16 +84,25 @@ async function makeFacetedPlotThumbnailUrl(
       viewBox={`0 0 ${thumbnailDimensions.width} ${thumbnailDimensions.height}`}
     >
       {plotImageNodes}
+      <rect
+        x={thumbnailDimensions.width * 0.75}
+        y={thumbnailDimensions.height * 0.875}
+        width={thumbnailDimensions.width * 0.225}
+        height={thumbnailDimensions.height * 0.1}
+        fill="#F5F5F5"
+        stroke="#777"
+        opacity={0.75}
+      />
       <text
         style={{
           fontFamily: 'sans-serif',
         }}
-        x={thumbnailDimensions.width * 0.5}
-        y={thumbnailDimensions.height * 0.55}
-        fontSize={thumbnailDimensions.height * 0.15}
+        x={thumbnailDimensions.width * 0.8625}
+        y={thumbnailDimensions.height * 0.95}
+        fontSize={thumbnailDimensions.height * 0.075}
         textAnchor="middle"
       >
-        {facetedPlotRef.length}
+        {facetedPlotRef.length} facets
       </text>
     </svg>
   );


### PR DESCRIPTION
Resolves #716 and resolves #718.

More specifically, this PR improves the thumbnails for faceted plots in the following ways:

* The facet count has been styled as per the spec in #716.
* Introduces a short-term fix for thumbnails going blank under certain sporadic circumstances.

Some followup work for B56+:

* The content / verbiage of faceted thumbnails will be revisited in a future UX meeting. (One proposal is to only display a single plot.)
* #718 is a symptom of a bigger issue with how we're generating thumbnails: there is a race condition between the effect which triggers the thumbnail capture (managed by React) and the drawing of the plot (managed by Plotly "outside" of the React lifecycle). In this PR, I have mitigated this race condition by "rigging the race" in favor of Plotly (by making the thumbnail capture a [layout effect](https://reactjs.org/docs/hooks-reference.html#uselayouteffect) and introducing a `setTimeout`). In the long term, we'll want to eliminate the race condition by moving the thumbnail capturing from a React-managed effect to a Plotly-managed `onUpdate` callback. (I opened a tech debt issue [here](https://github.com/VEuPathDB/web-eda/issues/739).)