### PR TITLE
Fix broken Birds Eye Plot tooltip with a unified new one

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@mui/styles": "^5.0.1",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.10.2",
+    "@veupathdb/components": "^0.10.5",
     "@veupathdb/core-components": "^0.2.45",
     "@veupathdb/http-utils": "^1.0.1",
     "@veupathdb/study-data-access": "^0.0.3",

--- a/src/lib/core/components/BirdsEyeView.tsx
+++ b/src/lib/core/components/BirdsEyeView.tsx
@@ -3,7 +3,9 @@ import { CoverageStatistics } from '../types/visualization';
 import BirdsEyePlot from '@veupathdb/components/lib/plots/BirdsEyePlot';
 import { red, gray } from './filter/colors';
 import { StudyEntity } from '../types/study';
-import { HelpIcon } from '@veupathdb/wdk-client/lib/Components';
+import Tooltip, {
+  TooltipPosition,
+} from '@veupathdb/wdk-client/lib/Components/Overlays/Tooltip';
 
 interface Props extends Partial<CoverageStatistics> {
   /** The output entity */
@@ -75,43 +77,56 @@ export function BirdsEyeView(props: Props) {
   const entityPluralString =
     outputEntity?.displayNamePlural ?? outputEntity?.displayName;
 
+  const tooltipContent = (
+    <div>
+      {stratificationIsActive && completeCasesAllVars != null && (
+        <>
+          <b>Data for axes & strata:</b> {completeCasesAllVars.toLocaleString()}{' '}
+          <i>{entityPluralString}</i> in the subset that have data for all axis
+          and stratification variables.
+          <br />
+        </>
+      )}
+      {completeCasesAxesVars != null && (
+        <>
+          <b>Data for axes:</b> {completeCasesAxesVars.toLocaleString()}{' '}
+          <i>{entityPluralString}</i> in the subset that have data for all axis
+          variables.
+          <br />
+        </>
+      )}
+      {subsetSize != null && (
+        <>
+          <b>Subset:</b> {subsetSize.toLocaleString()}{' '}
+          <i>{entityPluralString}</i> that match the filters applied in this
+          analysis.
+          <br />
+        </>
+      )}
+      {totalSize != null && (
+        <>
+          <b>All:</b> {totalSize.toLocaleString()}, the total number of{' '}
+          <i>{entityPluralString}</i> in the dataset.
+        </>
+      )}
+    </div>
+  );
+
   return (
-    // wrap 500px birds eye plot in an overflowing 400px div so that the mouseover-popup isn't clipped,
-    // but at the same time don't cause wrapping of the side plots/tables on 1280px screens.
-    <div style={{ width: '400px', overflow: 'visible' }}>
-      <div
-        style={{
-          marginLeft: '100px',
-          visibility: birdsEyeData ? 'visible' : 'hidden',
-        }}
-      >
-        <HelpIcon
-          tooltipPosition={{
-            my: 'bottom left',
-            at: 'top right',
-          }}
-        >
-          <div>
-            <b>Data for axes & strata:</b> The number of{' '}
-            <i>{entityPluralString}</i> in the subset that have data for all
-            axis and stratification variables.
-            <br />
-            <b>Data for axes:</b> The number of <i>{entityPluralString}</i> in
-            the subset that have data for all axis variables.
-            <br />
-            <b>Subset:</b> The number of <i>{entityPluralString}</i> that match
-            the filters applied in this analysis.
-            <br />
-            <b>All:</b> The total number of <i>{entityPluralString}</i> in the
-            dataset.
-          </div>
-        </HelpIcon>
-      </div>
+    <Tooltip
+      content={tooltipContent}
+      position={{
+        my: 'middle middle',
+        at: 'middle middle',
+      }}
+      showDelay={50}
+      showTip={false}
+    >
       <BirdsEyePlot
         data={birdsEyeData}
         containerClass="birds-eye-plot"
         containerStyles={{
-          width: '500px',
+          width: '400px',
           height: '110px',
           marginBottom: '1.5em',
         }}
@@ -119,12 +134,12 @@ export function BirdsEyeView(props: Props) {
           marginTop: 5,
           marginBottom: 5,
           marginLeft: 5,
-          marginRight: 100,
+          marginRight: 5,
         }}
         interactive={true}
         dependentAxisLabel={entityPluralString}
         showSpinner={enableSpinner && !birdsEyeData}
       />
-    </div>
+    </Tooltip>
   );
 }

--- a/src/lib/core/components/BirdsEyeView.tsx
+++ b/src/lib/core/components/BirdsEyeView.tsx
@@ -82,15 +82,15 @@ export function BirdsEyeView(props: Props) {
       {stratificationIsActive && completeCasesAllVars != null && (
         <>
           <b>Data for axes & strata:</b> {completeCasesAllVars.toLocaleString()}{' '}
-          <i>{entityPluralString}</i> in the subset that have data for all axis
-          and stratification variables.
+          <i>{entityPluralString}</i> in the subset have data for all axis and
+          stratification variables.
           <br />
         </>
       )}
       {completeCasesAxesVars != null && (
         <>
           <b>Data for axes:</b> {completeCasesAxesVars.toLocaleString()}{' '}
-          <i>{entityPluralString}</i> in the subset that have data for all axis
+          <i>{entityPluralString}</i> in the subset have data for all axis
           variables.
           <br />
         </>
@@ -98,7 +98,7 @@ export function BirdsEyeView(props: Props) {
       {subsetSize != null && (
         <>
           <b>Subset:</b> {subsetSize.toLocaleString()}{' '}
-          <i>{entityPluralString}</i> that match the filters applied in this
+          <i>{entityPluralString}</i> match the filters applied in this
           analysis.
           <br />
         </>

--- a/src/lib/core/components/layouts/SinglePlotLayout.tsx
+++ b/src/lib/core/components/layouts/SinglePlotLayout.tsx
@@ -24,7 +24,6 @@ const defaultTableGroupStyles: CSSProperties = {
   gridAutoFlow: 'row',
   gap: '0.75em',
   marginLeft: '3em',
-  marginTop: '1.5em',
 };
 
 export function SinglePlotLayout({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,10 +3342,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.10.2.tgz#2cb9c24c1063d32ae449fde69428449f71bb7c04"
-  integrity sha512-TykRPUKJVapudugWuE8IfIVrV8Axd72BtFCvU+D/05sGNtPsa/mPzX6yxHyG5//KZRBIoJIEg0Yx29fcr64B4g==
+"@veupathdb/components@^0.10.5":
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.10.5.tgz#4df221e83a0f93e5908c68d532ef65bc79663b90"
+  integrity sha512-ggsT/d/VsXhlDqJ2PLXyVgYXMjw2LlDjqk/sWhnd4l1M4/vqpD/4MNCaTTCJXl1lGWa8QhH8Dr0A+TVmA89cfw==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"


### PR DESCRIPTION
Requires https://github.com/VEuPathDB/web-components/pull/267
Issue is in web-components: https://github.com/VEuPathDB/web-components/issues/263

> Reviewer(s) - please self-assign and approve trivial components PR when you review. Thanks! 

It was impossible to fix the built-in mouseover of the Plotly-based Birds Eye Plot, so I implemented it on the EDA side, but putting the numbers into the WDK tooltip, and making the whole birds eye plot trigger it (quicker than the default time too).

I hope Outreach like the solution!
![image](https://user-images.githubusercontent.com/308639/142296580-45415a46-f0c5-4977-963a-1e067c23317a.png)

I also fixed the top-alignment that irked Steve.

Note that the new layout requires a minimum of around 1430 horizontal pixels to keep everything in one row.

When the legend was inside the main plot, we managed to fit in into 1280px (target minimum width)