### PR TITLE
Faceted Layout for Mosaic Visualizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@mui/styles": "^5.0.1",
     "@types/debounce-promise": "^3.1.3",
-    "@veupathdb/components": "^0.10.6",
+    "@veupathdb/components": "^0.10.7",
     "@veupathdb/core-components": "^0.2.45",
     "@veupathdb/http-utils": "^1.0.1",
     "@veupathdb/study-data-access": "^0.0.3",

--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -195,15 +195,6 @@ $data-table-inner-border: 1px solid #888;
   }
 }
 
-.viz-plot-info {
-  display: grid;
-  grid-auto-flow: row;
-  gap: 0.75em;
-  margin-left: 3em;
-  margin-top: 1.5em;
-  margin-left: 3em;
-}
-
 .VariableCoverageTable {
   @include data-table;
   width: 400px;

--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -217,6 +217,11 @@ $data-table-inner-border: 1px solid #888;
   @include data-table;
   overflow: auto;
 
+  th {
+    max-width: 150px;
+    white-space: normal;
+  }
+
   .contingency-table_column-label {
     border-bottom: $data-table-inner-border !important;
   }

--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -152,9 +152,6 @@
       font-style: italic;
       margin-bottom: 1em;
     }
-    .MosaicVisualization-Plot .web-components-plot {
-      margin-left: 0;
-    }
   }
   &-FullScreenActions {
     display: flex;
@@ -220,71 +217,54 @@ $data-table-inner-border: 1px solid #888;
   }
 }
 
-.MosaicVisualization {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  min-height: 500px;
-  width: 90vw;
+.MosaicVisualization-StatsTable {
+  @include data-table;
+  width: 400px;
+}
 
-  &-Plot {
-    min-width: 500px;
-    max-width: 1000px;
+.contingency-table {
+  @include data-table;
+  overflow: auto;
+
+  .contingency-table_column-label {
+    border-bottom: $data-table-inner-border !important;
   }
 
-  &-StatsTable {
-    @include data-table;
-    width: 400px;
+  .contingency-table_column-label:first-of-type {
+    border-left: $data-table-inner-border;
   }
 
-  .VariableCoverageTable {
-    margin: 0;
+  .contingency-table_row-label {
+    border-bottom: 0;
+    border-right: $data-table-inner-border;
   }
 
-  .contingency-table {
-    @include data-table;
-    overflow: auto;
+  .contingency-table_row-header {
+    border-bottom: $data-table-inner-border !important;
+    border-right: $data-table-inner-border;
+  }
 
-    .contingency-table_column-label {
-      border-bottom: $data-table-inner-border !important;
-    }
+  .contingency-table_totals-row-header {
+    text-align: end;
+    border-top: $data-table-inner-border;
+    border-right: $data-table-inner-border;
+  }
 
-    .contingency-table_column-label:first-of-type {
-      border-left: $data-table-inner-border;
-    }
+  .contingency-table_totals-column-header {
+    border-left: $data-table-inner-border;
+  }
 
-    .contingency-table_row-label {
-      border-bottom: 0;
-      border-right: $data-table-inner-border;
-    }
+  .contingency-table_totals-row-value {
+    border-top: $data-table-inner-border;
+  }
 
-    .contingency-table_row-header {
-      border-bottom: $data-table-inner-border !important;
-      border-right: $data-table-inner-border;
-    }
+  .contingency-table_totals-column-value {
+    border-left: $data-table-inner-border;
+  }
 
-    .contingency-table_totals-row-header {
-      text-align: end;
-      border-top: $data-table-inner-border;
-      border-right: $data-table-inner-border;
-    }
-
-    .contingency-table_totals-column-header {
-      border-left: $data-table-inner-border;
-    }
-
-    .contingency-table_totals-row-value {
-      border-top: $data-table-inner-border;
-    }
-
-    .contingency-table_totals-column-value {
-      border-left: $data-table-inner-border;
-    }
-
-    .contingency-table_grand-total {
-      border-top: $data-table-inner-border;
-      border-left: $data-table-inner-border;
-    }
+  .contingency-table_grand-total {
+    border-top: $data-table-inner-border;
+    border-left: $data-table-inner-border;
   }
 }
 

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -70,6 +70,23 @@ const facetedPlotSpacingOptions = {
   marginTop: 50,
 };
 
+const statsTableStyles = {
+  width: plotContainerStyles.width,
+};
+
+const facetedStatsTableStyles = {
+  width: 'auto',
+};
+
+const facetedStatsTableContainerStyles = {
+  display: 'grid',
+  gridAutoFlow: 'column',
+  alignItems: 'flex-start',
+  width: '100%',
+  overflow: 'auto',
+  gap: '0.5em',
+};
+
 type ContTableData = MosaicData &
   Partial<{
     pValue: number | string;

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -77,7 +77,8 @@ const statsTableStyles = {
 
 const facetedStatsTableStyles = {
   width: 'auto',
-};
+  whiteSpace: 'nowrap',
+} as const;
 
 const facetedStatsTableContainerStyles = {
   display: 'grid',

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -75,14 +75,12 @@ const statsTableStyles = {
   width: plotContainerStyles.width,
 };
 
-const facetedStatsTableStyles = {
-  width: 'auto',
-  whiteSpace: 'nowrap',
-} as const;
+const facetedStatsTableStyles = {};
 
 const facetedStatsTableContainerStyles = {
   display: 'grid',
   gridAutoFlow: 'column',
+  gridAutoColumns: 'max-content',
   alignItems: 'flex-start',
   width: '100%',
   overflow: 'auto',
@@ -431,7 +429,6 @@ function MosaicViz(props: Props) {
                   : statsTableStyles
               }
               facetedContainerStyles={facetedStatsTableContainerStyles}
-              singleFacetContainerStyles={facetedStatsTableStyles}
               independentVariable={xAxisLabel ?? 'X-axis'}
               dependentVariable={yAxisLabel ?? 'Y-axis'}
               facetVariable={
@@ -449,7 +446,7 @@ function MosaicViz(props: Props) {
               : facetVariable != null && (
                   <div style={facetedStatsTableContainerStyles}>
                     {data.value.facets.map(({ label, data }, index) => (
-                      <table key={index} style={facetedStatsTableStyles}>
+                      <table key={index}>
                         <tbody>
                           <tr>
                             <th

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -423,7 +423,7 @@ function MosaicViz(props: Props) {
           content: (
             <ContingencyTable
               data={data.pending ? undefined : data.value}
-              containerStyles={
+              tableContainerStyles={
                 isFaceted(data.value)
                   ? facetedStatsTableStyles
                   : statsTableStyles

--- a/yarn.lock
+++ b/yarn.lock
@@ -2962,10 +2962,15 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.104", "@types/lodash@^4.14.146", "@types/lodash@^4.14.160", "@types/lodash@^4.14.168":
+"@types/lodash@^4.14.104", "@types/lodash@^4.14.168":
   version "4.14.176"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.176.tgz#641150fc1cda36fbfa329de603bbb175d7ee20c0"
   integrity sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==
+
+"@types/lodash@^4.14.146", "@types/lodash@^4.14.160":
+  version "4.14.177"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.177.tgz#f70c0d19c30fab101cad46b52be60363c43c4578"
+  integrity sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==
 
 "@types/minimatch@*":
   version "3.0.5"
@@ -3116,7 +3121,16 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.14.8", "@types/react@>=16.9.0", "@types/react@>=16.9.11":
+"@types/react@*", "@types/react@>=16.14.8", "@types/react@>=16.9.11":
+  version "17.0.35"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.35.tgz#217164cf830267d56cd1aec09dcf25a541eedd4c"
+  integrity sha512-r3C8/TJuri/SLZiiwwxQoLAoavaczARfT9up9b4Jr65+ErAUX3MIkU0oMOQnrpfgHme8zIqZLX7O5nnjm5Wayw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
   version "17.0.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.34.tgz#797b66d359b692e3f19991b6b07e4b0c706c0102"
   integrity sha512-46FEGrMjc2+8XhHXILr+3+/sTe3OfzSPU9YGKILLrUYbQ1CLQC9Daqo1KzENGXAWwrFwiY0l4ZbF20gRvgpWTg==
@@ -3342,10 +3356,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.10.6":
-  version "0.10.6"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.10.6.tgz#ca7a244704ab2fd6376b6c6cb4d86bd5c2f30231"
-  integrity sha512-beuEZsUDtP0mSfBIXx4lRjiq/6Ytvu4HKev8dkzSJwwEcS2FCsBjUr4wyHlBE6BDgL4LJRljHP+OxHmALWvrEQ==
+"@veupathdb/components@^0.10.7":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.10.7.tgz#4e3ec0eeb14944bb2280e14a7443e37bc71948bc"
+  integrity sha512-+ut8w6caGpXn98nEZv/ir+mdNnRr/Q0Ia+IKUBUCvT3qcdBhHe3Vt/YBvZnR5uzHxidZqji9E5a+XUXY0bX4Pw==
   dependencies:
     "@material-ui/core" "^4.11.2"
     "@material-ui/icons" "^4.11.2"
@@ -6527,12 +6541,22 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.5.2, csstype@^2.5.7:
+csstype@^2.5.2:
+  version "2.6.19"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.19.tgz#feeb5aae89020bb389e1f63669a5ed490e391caa"
+  integrity sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==
+
+csstype@^2.5.7:
   version "2.6.18"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.18.tgz#980a8b53085f34af313410af064f2bd241784218"
   integrity sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ==
 
-csstype@^3.0.2, csstype@^3.0.9:
+csstype@^3.0.2:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
+
+csstype@^3.0.9:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
   integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
@@ -13365,9 +13389,9 @@ plotly.js@^1.54.1:
     world-calendars "^1.0.3"
 
 plotly.js@^2.6.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/plotly.js/-/plotly.js-2.6.2.tgz#79827a4233d445475072e800938d094f226bacfc"
-  integrity sha512-KzOwyNNdRnJVvZPnBvA2VwgcO9202FexFpiivuWaAFvmQiX+oC3yKrQHyXaPeNqZn4lAq3GVgYYPQdx3o5uEuw==
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/plotly.js/-/plotly.js-2.6.3.tgz#a86b797e4b1299d2c6935d29e562aa2b838d5ec9"
+  integrity sha512-MSdevryj5VvSZvr+slTnJcZgOmvMPZEUe8rFY+3ygxbVUFqmcOvT0TurUx4g07tfAVZ+UhXIaskHnAZNmUcNTg==
   dependencies:
     "@plotly/d3" "3.8.0"
     "@plotly/d3-sankey" "0.7.2"


### PR DESCRIPTION
(Probably don't need everybody to review the code, but testing / UX feedback would be welcome!)

Depends on https://github.com/VEuPathDB/web-components/pull/268

Resolves #725 

This PR uses the new `PlotLayout` component to handle the unfaceted and faceted layout for the Mosaic visualization. For the faceted layout, the tabs take up the full width of the visualization container, and in the `Table` and `Statistics` tables, the table are laid out horizontally, just as the corresponding mosaic plots are.

**Future work:**

In this visualization, our "data" tables are being styled by a mix of CSS and inline styling. We should probably unify these two batches of styles.