### PR TITLE
fix a legend bug for scatter faceted plot

### DIFF
--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -438,26 +438,17 @@ function ScatterplotViz(props: VisualizationProps) {
       ? allData?.series
       : uniqBy(
           allData.facets
-            .map((facet) =>
-              facet?.data?.series.map((series) => {
-                return {
-                  name: series.name,
-                  mode: series.mode,
-                  fill: series.fill,
-                };
-              })
-            )
+            .map((facet) => facet?.data?.series)
             .flat()
-            .filter((element) => element != null),
+            .filter((element): element is XYPlotDataSeries => element != null),
           'name'
         );
 
     // logic for setting markerColor correctly
     // find raw legend label (excluding No data as well)
-    // due to a union type of legendData, set any[] is a trick to avoid 'not callable' error
     const legendLabel =
       legendData != null
-        ? (legendData as any[])
+        ? legendData
             .filter(
               (data) =>
                 !data?.name?.includes(SMOOTHEDMEANSUFFIX) &&
@@ -499,20 +490,20 @@ function ScatterplotViz(props: VisualizationProps) {
                 vizConfig.valueSpecConfig === 'Best fit line with raw'
               ) {
                 // Best fit
-                return (legendData as any[])?.filter((element) => {
+                return legendData.filter((element) => {
                   // checking No data case
                   if (vizConfig.showMissingness) {
                     if (index < legendData.length - 1) {
-                      return element.name.includes(
+                      return element.name?.includes(
                         legendLabel[index - numberLegendRawItems] +
                           BESTFITSUFFIX
                       );
                     } else {
                       // No data case
-                      return element.name.includes('No data' + BESTFITSUFFIX);
+                      return element.name?.includes('No data' + BESTFITSUFFIX);
                     }
                   } else {
-                    return element.name.includes(
+                    return element.name?.includes(
                       legendLabel[index - numberLegendRawItems] + BESTFITSUFFIX
                     );
                   }
@@ -535,8 +526,8 @@ function ScatterplotViz(props: VisualizationProps) {
                   } else if (dataItem?.name?.includes(CI95SUFFIX)) {
                     // increase count here
                     ++count;
-                    return (legendData as any[])?.filter((element) => {
-                      return element.name.includes(
+                    return legendData.filter((element) => {
+                      return element.name?.includes(
                         legendLabel[index - (numberLegendRawItems + count)] +
                           CI95SUFFIX
                       );
@@ -546,16 +537,16 @@ function ScatterplotViz(props: VisualizationProps) {
                 } else {
                   if (dataItem?.name?.includes(SMOOTHEDMEANSUFFIX)) {
                     if (index < legendData.length - 2) {
-                      return (legendData as any[])?.filter((element) => {
-                        return element.name.includes(
+                      return legendData.filter((element) => {
+                        return element.name?.includes(
                           legendLabel[index - (numberLegendRawItems + count)] +
                             SMOOTHEDMEANSUFFIX
                         );
                       });
                     } else {
                       // No data case
-                      return (legendData as any[])?.filter((element) => {
-                        return element.name.includes(
+                      return legendData.filter((element) => {
+                        return element.name?.includes(
                           'No data' + SMOOTHEDMEANSUFFIX
                         );
                       });
@@ -564,15 +555,15 @@ function ScatterplotViz(props: VisualizationProps) {
                     // increase count here
                     ++count;
                     if (index < legendData.length - 2) {
-                      return (legendData as any[])?.filter((element) => {
-                        return element.name.includes(
+                      return legendData.filter((element) => {
+                        return element.name?.includes(
                           legendLabel[index - (numberLegendRawItems + count)] +
                             CI95SUFFIX
                         );
                       });
                     } else {
-                      return (legendData as any[])?.filter((element) => {
-                        return element.name.includes('No data' + CI95SUFFIX);
+                      return legendData.filter((element) => {
+                        return element.name?.includes('No data' + CI95SUFFIX);
                       });
                     }
                   }

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -438,8 +438,7 @@ function ScatterplotViz(props: VisualizationProps) {
       ? allData?.series
       : uniqBy(
           allData.facets
-            .map((facet) => facet?.data?.series)
-            .flat()
+            .flatMap((facet) => facet?.data?.series)
             .filter((element): element is XYPlotDataSeries => element != null),
           'name'
         );
@@ -482,7 +481,7 @@ function ScatterplotViz(props: VisualizationProps) {
     const sortedLegendData =
       isFaceted(allData) && vizConfig.valueSpecConfig !== 'Raw'
         ? legendData
-            ?.map((dataItem, index) => {
+            ?.flatMap((dataItem, index) => {
               if (index < numberLegendRawItems) {
                 // Raw data is ordered correctly
                 return dataItem;
@@ -572,7 +571,6 @@ function ScatterplotViz(props: VisualizationProps) {
               return [];
               // observed No data is often undefined during data loading by toggling showMissingness for large scatter data/graphics
             })
-            .flat()
             .filter((element) => element != null)
         : legendData;
 


### PR DESCRIPTION
While thinking and checking of a potential scatter plot R-square table with a couple of example cases, I found that there was a bug for some specific data for the case of faceted plots. 

Just made a new ticket so this PR will address #741 

For an example like below with the plot options of Best fit with raw (or Smoothed mean with raw) using GEMS1 Study control, the custom legend showed 5 Raw and 3 Best fit. It is because the condition to find the legend list is based on the first non-undefined data. However, when I checked whole faceted data, it is found that actually all 5 Best fits exist throughout countries, thus it is necessary to find whole 5 Best fits by going through whole data, like below screenshot. While fixing the issue, it was inevitable to use complex conditions to properly order the legend items. Perhaps that part may be revisited for better logic/scheme in the future, especially considering the B55 release date, but at least this PR would work.

# before fix
![scatter-facet-bug](https://user-images.githubusercontent.com/12802305/142669356-e1f9f3ab-cd7b-4c8d-ba64-00b36277e86d.png)

# after fix
![scatter-bug-fix](https://user-images.githubusercontent.com/12802305/142669658-a510b764-cbc2-452d-b1e4-9199c97c1814.png)
