### PR TITLE
Make HistogramVisualization aspect ratio the same as others so that the facet thumbnails all look consistent

### DIFF
--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -89,7 +89,7 @@ type HistogramDataWithCoverageStatistics = (
 
 const plotContainerStyles = {
   width: 750,
-  height: 400,
+  height: 450,
   marginLeft: '0.75rem',
   border: '1px solid #dedede',
   boxShadow: '1px 1px 4px #00000066',


### PR DESCRIPTION
No issue to link to.

Before

![image](https://user-images.githubusercontent.com/308639/142708227-e8d431ce-8989-4cd9-b3ae-7d77254946df.png)

After

![image](https://user-images.githubusercontent.com/308639/142708305-4559d458-d1d7-48d9-905e-1fed55918da8.png)

Ignore the slightly clipped edges of the screenshots.  It's that big white gap at the bottom that we get rid of. :-) 