### PR TITLE
Multiple mui instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
-    "@mui/styles": "^5.0.1",
     "@types/debounce-promise": "^3.1.3",
     "@veupathdb/components": "^0.11.1",
     "@veupathdb/core-components": "^0.2.45",

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -68,46 +68,41 @@ export interface Props {
   outputEntity?: StudyEntity;
 }
 
-const useStyles = makeStyles(
-  {
-    inputs: {
-      display: 'flex',
-      flexWrap: 'nowrap', // if it didn't wrap so aggressively, it would be good to allow wrapping
-      // perhaps after the Material UI capitalization is removed.
-      marginLeft: '0.5em', // this indent is only needed because the wdk-SaveableTextEditor above it is indented
-      alignItems: 'flex-start',
-    },
-    inputGroup: {
-      display: 'flex',
-      flexWrap: 'wrap',
-    },
-    input: {
-      display: 'flex',
-      alignItems: 'center',
-      marginBottom: '0.5em', // in case they end up stacked vertically on a narrow screen
-      marginRight: '2em',
-    },
-    label: {
-      marginRight: '1ex',
-      fontWeight: 500,
-    },
-    dataLabel: {
-      textAlign: 'right',
-      marginTop: '2em',
-      fontSize: '1.35em',
-      fontWeight: 500,
-    },
-    fullRow: {
-      flexBasis: '100%',
-    },
-    primary: {},
-    stratification: {},
-    showMissingness: {},
+const useStyles = makeStyles({
+  inputs: {
+    display: 'flex',
+    flexWrap: 'nowrap', // if it didn't wrap so aggressively, it would be good to allow wrapping
+    // perhaps after the Material UI capitalization is removed.
+    marginLeft: '0.5em', // this indent is only needed because the wdk-SaveableTextEditor above it is indented
+    alignItems: 'flex-start',
   },
-  {
-    name: 'InputVariables',
-  }
-);
+  inputGroup: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  input: {
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: '0.5em', // in case they end up stacked vertically on a narrow screen
+    marginRight: '2em',
+  },
+  label: {
+    marginRight: '1ex',
+    fontWeight: 500,
+  },
+  dataLabel: {
+    textAlign: 'right',
+    marginTop: '2em',
+    fontSize: '1.35em',
+    fontWeight: 500,
+  },
+  fullRow: {
+    flexBasis: '100%',
+  },
+  primary: {},
+  stratification: {},
+  showMissingness: {},
+});
 
 export function InputVariables(props: Props) {
   const {

--- a/src/lib/workspace/WorkspaceContainer.tsx
+++ b/src/lib/workspace/WorkspaceContainer.tsx
@@ -15,7 +15,7 @@ import { VariableDescriptor } from '../core/types/variable';
 import { EDAWorkspace } from './EDAWorkspace';
 import { cx, findFirstVariable } from './Utils';
 
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles({
   workspace: {


### PR DESCRIPTION
fixes #745

This PR removes an import of a different version of `makeStyles`, which was causing classname collisions.

I will merge this before end of day (us/eastern) so that the qa site can be have the fix tomorrow.