### PR TITLE
R-square table for Scatter plot with Best fit option

### DIFF
--- a/src/lib/core/components/ScatterplotRsquareTable.tsx
+++ b/src/lib/core/components/ScatterplotRsquareTable.tsx
@@ -1,0 +1,134 @@
+import {
+  XYPlotDataSeries,
+  XYPlotData,
+} from '@veupathdb/components/lib/types/plots';
+import { VariableTreeNode } from '../types/study';
+
+interface facetDataProps {
+  label: string;
+  data?: XYPlotData | undefined;
+}
+
+export interface Props {
+  data: XYPlotDataSeries[] | facetDataProps[] | undefined;
+  isFaceted: boolean;
+  overlayVariable?: VariableTreeNode;
+  facetVariable?: VariableTreeNode;
+}
+
+export function ScatterplotRsquareTable({
+  data,
+  isFaceted,
+  overlayVariable,
+  facetVariable,
+}: Props) {
+  // non-facet or facet data
+  const filteredData = !isFaceted
+    ? overlayVariable != null
+      ? (data as XYPlotDataSeries[])?.filter((data) =>
+          data?.name?.includes(', Best fit')
+        )
+      : (data as XYPlotDataSeries[])?.filter((data) =>
+          data?.name?.includes('Best fit')
+        )
+    : (data as facetDataProps[]).filter((element) => element.data != null);
+
+  if (!isFaceted) {
+    return (
+      <div className={'ScatterRsquareTable'}>
+        <table>
+          <tbody>
+            <tr>
+              <th>
+                {overlayVariable != null ? overlayVariable.displayName : 'Name'}
+              </th>
+              <th className="numeric">
+                R<sup>2</sup> (Best fit)
+              </th>
+            </tr>
+            {filteredData != null
+              ? (filteredData as XYPlotDataSeries[]).map((data) => (
+                  <tr>
+                    <td>{data?.name?.split(', Best fit')[0]}</td>
+                    <td>{data.r2 ?? 'N/A'}</td>
+                  </tr>
+                ))
+              : ''}
+          </tbody>
+        </table>
+      </div>
+    );
+  } else {
+    return (
+      <div
+        className={'ScatterRsquareTable'}
+        style={{ maxHeight: 250, overflowX: 'hidden', overflowY: 'auto' }}
+      >
+        <table>
+          <tbody>
+            <tr>
+              <th>{facetVariable?.displayName}</th>
+              {overlayVariable != null && (
+                <th>{overlayVariable.displayName}</th>
+              )}
+              <th className="numeric">
+                R<sup>2</sup> (Best fit)
+              </th>
+            </tr>
+            {filteredData != null
+              ? (filteredData as facetDataProps[]).map((data) => (
+                  <>
+                    {data?.data?.series != null
+                      ? data.data.series
+                          .filter((series) =>
+                            overlayVariable != null
+                              ? series?.name?.includes(', Best fit')
+                              : series?.name?.includes('Best fit')
+                          )
+                          .map((series, index, array) => {
+                            if (index === 0) {
+                              return (
+                                <tr>
+                                  {/* each vocabulary/name have different number of available data ,so need to check rowSpan per data */}
+                                  <td
+                                    rowSpan={
+                                      overlayVariable != null
+                                        ? array.filter((arr) =>
+                                            arr?.name?.includes(', Best fit')
+                                          ).length
+                                        : 1
+                                    }
+                                  >
+                                    {data.label}
+                                  </td>
+                                  {overlayVariable != null && (
+                                    <td>
+                                      {series?.name?.split(', Best fit')[0]}
+                                    </td>
+                                  )}
+                                  <td>{series.r2 ?? 'N/A'}</td>
+                                </tr>
+                              );
+                            } else {
+                              return (
+                                <tr>
+                                  {overlayVariable != null && (
+                                    <td>
+                                      {series?.name?.split(', Best fit')[0]}
+                                    </td>
+                                  )}
+                                  <td>{series.r2 ?? 'N/A'}</td>
+                                </tr>
+                              );
+                            }
+                          })
+                      : ''}
+                  </>
+                ))
+              : ''}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}

--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -274,3 +274,20 @@ $data-table-inner-border: 1px solid #888;
     visibility: hidden;
   }
 }
+
+// R-square table for Scatter plot's Best fit option
+.ScatterRsquareTable {
+  @include data-table;
+  width: 400px;
+
+  .percentage {
+    color: #333;
+    font-size: 0.85em;
+  }
+  th {
+    vertical-align: baseline;
+  }
+  th:first-of-type {
+    border-bottom: $data-table-inner-border;
+  }
+}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -96,6 +96,8 @@ import { isFaceted } from '@veupathdb/components/lib/types/guards';
 import FacetedPlot from '@veupathdb/components/lib/plots/FacetedPlot';
 // for converting rgb() to rgba()
 import * as ColorMath from 'color-math';
+// R-square table component
+import { ScatterplotRsquareTable } from '../../ScatterplotRsquareTable';
 
 const MAXALLOWEDDATAPOINTS = 100000;
 const SMOOTHEDMEANTEXT = 'Smoothed mean';
@@ -757,8 +759,28 @@ function ScatterplotViz(props: VisualizationProps) {
           },
         ]}
       />
+      {/* R-square table component */}
+      {vizConfig.valueSpecConfig === 'Best fit line with raw' &&
+        data.value != null &&
+        !data.pending && (
+          <ScatterplotRsquareTable
+            data={
+              data.value && !data.pending
+                ? !isFaceted(data.value?.dataSetProcess)
+                  ? data.value?.dataSetProcess.series
+                  : data.value?.dataSetProcess.facets
+                : undefined
+            }
+            isFaceted={isFaceted(data.value?.dataSetProcess)}
+            overlayVariable={overlayVariable}
+            facetVariable={facetVariable}
+          />
+        )}
     </>
   );
+
+  //DKDK
+  console.log('data.value =', data.value);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -1420,12 +1442,14 @@ function processInputData<T extends number | string>(
         y: el.bestFitLineY,
         // display R-square value at legend text(s)
         // name: 'Best fit<br>R<sup>2</sup> = ' + el.r2,
+        // include R-square value at dataSetProcess
+        r2: el.r2,
         name: el.overlayVariableDetails
           ? fixLabelForNumberVariables(
               el.overlayVariableDetails.value,
               overlayVariable
-            ) + BESTFITSUFFIX // TO DO: put R^2 values in a table, esp for faceting
-          : BESTFITTEXT, // ditto - see issue 694
+            ) + BESTFITSUFFIX
+          : BESTFITTEXT,
         mode: 'lines', // no data point is displayed: only line
         line: {
           // use darker color for best fit line


### PR DESCRIPTION
This will possibly address #694. Also, this depends on the [PR #274 at web-components](https://github.com/VEuPathDB/web-components/pull/274) to avoid a type error. Certainly this needs to be refined with layout etc. so this will be a draft PR for the time being. 

This PR adds a R-square table for Scatter plot with the plot options of 'Best fit line with raw'. For now, the new table is added as a last item of `tableGroupNode` as shown in the screenshot. Since faceted plot with overlay can possibly be very lengthy, maximum height is set and scroll bar is used.

@jtlong3rd I will leave this to you for layout etc. as I am not quite sure how we will show this table 😄 

- No overlay and no facet
![scatter-r2-noOverlay-noFacet](https://user-images.githubusercontent.com/12802305/143135502-c0731f66-5422-434f-8b2b-91ebb244690a.png)

- With overlay but no facet
![scatter-r2-overlay-noFacet](https://user-images.githubusercontent.com/12802305/143135535-4d939010-e884-45ba-a6b2-61223d6c67e1.png)

- No overlay but with facet
![scatter-r2-noOverlay-facet](https://user-images.githubusercontent.com/12802305/143135594-95966a0c-49f5-4b83-a6f9-68b2b198114b.png)

- Both overlay and facet
![scatter-r2-overlay-facet](https://user-images.githubusercontent.com/12802305/143135636-c9366768-e3b6-4b0d-8dbb-9674588c4ccd.png)

