### PR TITLE
Add user documentation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,14 @@
+body {
+  font-size: 13px;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Roboto', 'Helvetica Neue', Helvetica, 'Segoe UI', Arial,
+    freesans, sans-serif;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,8 @@ import { WorkspaceRouter } from './lib/workspace/WorkspaceRouter';
 import { useAttemptActionClickHandler } from '@veupathdb/study-data-access/lib/data-restriction/dataRestrictionHooks';
 import { useCoreUIFonts } from '@veupathdb/core-components/dist/hooks';
 
+import './index.css';
+
 const subsettingServiceUrl = '/eda-subsetting-service';
 const dataServiceUrl = '/eda-data-service';
 const userServiceUrl = '/eda-user-service';

--- a/src/lib/core/components/EDAAnalysisListContainer.tsx
+++ b/src/lib/core/components/EDAAnalysisListContainer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core';
 
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
 
@@ -8,9 +7,7 @@ import { AnalysisClient } from '../api/analysis-api';
 import SubsettingClient from '../api/SubsettingClient';
 import DataClient from '../api/DataClient';
 import { WorkspaceContext } from '../context/WorkspaceContext';
-import { workspaceTheme } from './workspaceTheme';
 
-const theme = createMuiTheme(workspaceTheme);
 interface Props {
   studyId: string;
   children: React.ReactChild | React.ReactChild[];
@@ -43,7 +40,7 @@ export function EDAAnalysisListContainer(props: Props) {
           dataClient,
         }}
       >
-        <ThemeProvider theme={theme}>{children}</ThemeProvider>
+        {children}
       </WorkspaceContext.Provider>
     </div>
   );

--- a/src/lib/core/components/EDAWorkspaceContainer.tsx
+++ b/src/lib/core/components/EDAWorkspaceContainer.tsx
@@ -8,12 +8,8 @@ import {
   WorkspaceContext,
 } from '../context/WorkspaceContext';
 import { useStudyMetadata, useWdkStudyRecord } from '../hooks/study';
-import { ThemeProvider } from '@material-ui/core/styles';
-import { createMuiTheme } from '@material-ui/core';
-import { workspaceTheme } from './workspaceTheme';
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
 
-const theme = createMuiTheme(workspaceTheme);
 export interface Props {
   studyId: string;
   children: React.ReactChild | React.ReactChild[];
@@ -48,9 +44,7 @@ export function EDAWorkspaceContainer({
         makeVariableLink,
       }}
     >
-      <ThemeProvider theme={theme}>
-        <div className={className}>{children}</div>
-      </ThemeProvider>
+      <div className={className}>{children}</div>
     </WorkspaceContext.Provider>
   );
 }

--- a/src/lib/core/components/docs/Documentation.tsx
+++ b/src/lib/core/components/docs/Documentation.tsx
@@ -1,0 +1,22 @@
+import { ErrorBoundary } from '@veupathdb/wdk-client/lib/Controllers';
+import React, { Suspense } from 'react';
+
+interface Props {
+  documentName: string;
+}
+
+export function Documentation(props: Props) {
+  const Component = React.lazy(() =>
+    import('./' + props.documentName).catch((error) => {
+      console.error(error);
+      return import('@veupathdb/wdk-client/lib/Components/PageStatus/Error');
+    })
+  );
+  return (
+    <ErrorBoundary>
+      <Suspense fallback="Loading...">
+        <Component />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/src/lib/core/components/docs/DocumentationContainer.tsx
+++ b/src/lib/core/components/docs/DocumentationContainer.tsx
@@ -1,0 +1,77 @@
+import { FullScreenModal } from '@veupathdb/core-components';
+import { Close } from '@veupathdb/core-components/dist/components/icons';
+import { Launch } from '@material-ui/icons';
+import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
+import React, { useState, PropsWithChildren, useMemo } from 'react';
+import { useRouteMatch } from 'react-router';
+import { Link } from 'react-router-dom';
+import { Documentation } from './Documentation';
+
+interface DocumentContextValue {
+  setActiveDocument(name?: string): void;
+}
+const DocumentationContext = React.createContext<DocumentContextValue | null>(
+  null
+);
+
+export function useActiveDocument() {
+  return useNonNullableContext(DocumentationContext);
+}
+
+export function DocumentationContainer(props: PropsWithChildren<{}>) {
+  const [activeDocument, setActiveDocument] = useState<string>();
+  const value = useMemo(() => ({ setActiveDocument }), [setActiveDocument]);
+  const { url } = useRouteMatch();
+  const modal = activeDocument ? (
+    <FullScreenModal
+      zIndex={10000}
+      visible={activeDocument != null}
+      onClose={() => setActiveDocument(undefined)}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'nowrap',
+          alignItems: 'flex-start',
+        }}
+      >
+        <div style={{ marginRight: 'auto' }}>
+          <Documentation documentName={activeDocument} />
+        </div>
+        <button
+          style={{
+            fontSize: '2em',
+            border: 'none',
+            background: 'none',
+            padding: 0,
+          }}
+          type="button"
+          onClick={() => setActiveDocument(undefined)}
+          title="Close"
+        >
+          <Close />
+        </button>
+      </div>
+      <div
+        style={{
+          position: 'sticky',
+          bottom: 0,
+          padding: '.5em 0',
+          background: 'white',
+        }}
+      >
+        <Link to={`${url}/documentation/${activeDocument}`} target="_blank">
+          <Launch fontSize="inherit" /> Open in new window
+        </Link>
+      </div>
+    </FullScreenModal>
+  ) : (
+    <></>
+  );
+  return (
+    <DocumentationContext.Provider value={value}>
+      {modal}
+      {props.children}
+    </DocumentationContext.Provider>
+  );
+}

--- a/src/lib/core/components/docs/variable-constraints.tsx
+++ b/src/lib/core/components/docs/variable-constraints.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { useSetDocumentTitle } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+
+export function Tooltip() {
+  return (
+    <>
+      If your variable of interest cannot be selected for use in a particular
+      visualization, it is likely due to a constraint that restricts the
+      variables to only those compatible with the visualization. Not all
+      visualizations can display all types or combinations of variables. As an
+      example, it is not possible to display categorical data on the X-axis in a
+      Histogram.
+    </>
+  );
+}
+
+export function Document() {
+  useSetDocumentTitle('Variable Constraints on ClinEpiDB Visualizations');
+
+  return (
+    <div style={{ maxWidth: '1000px', fontSize: '1.1em' }}>
+      <h1>Variable Constraints on ClinEpiDB Visualizations</h1>
+
+      <div>
+        <h2 style={{ fontSize: '1.4em' }}>TLDR (Too Long Didn’t Read)</h2>
+        <strong>
+          <Tooltip />
+        </strong>
+      </div>
+
+      <br />
+
+      <p>
+        Variable constraints are a way to define which variables are compatible
+        with different visual elements (axes, color, etc) of any given
+        visualization. For example, our qualitative color palette only has 8
+        colors, and variable constraints allow us to prevent a variable with 9
+        or more unique values from being used to color the plot. Constraints are
+        defined for each visual element available to a visualization and applied
+        across all variables based on the entire dataset rather than the current
+        subset. Each visualization has constraints on variables that are
+        specific to the particular visual elements of that visualization. Find
+        the sub-heading below pertaining to a visualization of interest to learn
+        more about the visual elements available to them and their constraints.
+      </p>
+
+      <h2>Histogram</h2>
+
+      <ul>
+        <li>
+          X-axis/ Main: Variables must be either a number or date in order to
+          algorithmically determine meaningful bins.
+        </li>
+
+        <li>
+          Overlay: Variables must have 8 or fewer unique values to associate
+          each value with a color-blind friendly color.
+        </li>
+      </ul>
+
+      <h2>Bar Plot</h2>
+
+      <ul>
+        <li>
+          X-axis/ Main: Variables must have 10 or fewer unique values to ensure
+          legibility of the X-axis ticks.
+        </li>
+
+        <li>
+          Overlay: Variables must have 8 or fewer unique values to associate
+          each value with a color-blind friendly color.
+        </li>
+      </ul>
+
+      <h2>Scatter Plot</h2>
+
+      <ul>
+        <li>
+          X-axis: Variables must be numeric or date as this axis is represented
+          over a range of values and does not support discrete tick marks.
+        </li>
+
+        <li>
+          Y-axis: Variables must be numeric or date as this axis is represented
+          over a range of values and does not support discrete tick marks.
+        </li>
+
+        <li>
+          Overlay: Variables must have 8 or fewer unique values to associate
+          each value with a color-blind friendly color.
+        </li>
+      </ul>
+
+      <h2>Box Plot</h2>
+
+      <ul>
+        <li>
+          X-axis: Variables must have 10 or fewer unique values to ensure
+          legibility of the X-axis ticks.
+        </li>
+
+        <li>
+          Y-axis: Variables must be numeric to calculate meaningful summary
+          statistics for them.
+        </li>
+
+        <li>
+          Overlay: Variables must have 8 or fewer unique values to associate
+          each value with a color-blind friendly color.
+        </li>
+      </ul>
+
+      <h2>Mosaic Plot: 2x2 Table</h2>
+
+      <ul>
+        <li>
+          X-axis: Variables must have exactly 2 unique values to calculate odds
+          ratios and relative risk for the resulting contingency table.
+        </li>
+
+        <li>
+          Y-axis: Variables must have exactly 2 unique values to calculate odds
+          ratios and relative risk for the resulting contingency table.
+        </li>
+      </ul>
+
+      <h2>Mosaic Plot: RxC Table</h2>
+
+      <ul>
+        <li>
+          X-axis: Variables must have 10 or fewer unique values to ensure
+          legibility of the X-axis ticks.
+        </li>
+
+        <li>
+          Y-axis: Variables must have 8 or fewer unique values to associate each
+          value with a color-blind friendly color.
+        </li>
+      </ul>
+
+      <br />
+
+      <p>
+        Some variable constraints, like the dependency order of visual elements,
+        are consistent across all visualizations. This constraint specifies the
+        relationship of selected variables based on the data tables, or entities
+        to which those variables belong. Plotting two variables from parent and
+        child entities in the same visualization requires duplication of the
+        data from the parent entity. The dependency order was introduced to
+        ensure that duplication of data happens only on visual elements where it
+        makes sense. For example, we do not want to inadvertently create a Box
+        Plot where the Y-axis variable belongs to a parent entity while the
+        X-axis variable belongs to a child entity and the summary statistics on
+        the Y-axis are calculated over duplicated data. We recognize there may
+        be valid use cases for this type of duplication and mean to explore
+        those further and support them explicitly if necessary in the future.
+      </p>
+
+      <p>
+        The dependency order is specified so that each subsequent visual element
+        is constrained to variables of the same or parent entity of the previous
+        visual element:
+        <pre style={{ textAlign: 'center' }}>
+          Y-axis variable : X-axis variable : Overlay variable : Facet variables
+        </pre>
+      </p>
+    </div>
+  );
+}
+
+export default Document;

--- a/src/lib/core/components/variableTrees/VariableList.tsx
+++ b/src/lib/core/components/variableTrees/VariableList.tsx
@@ -45,6 +45,9 @@ import { ShowHideVariableContext } from '../../utils/show-hide-variable-context'
 import { cx } from '../../../workspace/Utils';
 import { pruneEmptyFields } from '../../utils/wdk-filter-param-adapter';
 
+import { Tooltip as VarTooltip } from '../docs/variable-constraints';
+import { useActiveDocument } from '../docs/DocumentationContainer';
+
 interface VariableField {
   type?: string;
   term: string;
@@ -152,6 +155,7 @@ export default function VariableList({
   } = useContext(ShowHideVariableContext);
 
   const [searchTerm, setSearchTerm] = useState<string>('');
+  const { setActiveDocument } = useActiveDocument();
   const getPathToField = useCallback(
     (field?: Field) => {
       if (field == null) return [];
@@ -432,19 +436,18 @@ export default function VariableList({
 
   const tooltipContent = (
     <>
-      Some variables cannot be used here. Use this to toggle their presence
-      below.
+      <VarTooltip />
       <br />
       <br />
       <strong>
         <Link
-          to=""
-          onClick={(e) => {
-            e.preventDefault();
-            alert('Comming soon');
+          to="../../../../documentation/variable-constraints"
+          onClick={(event) => {
+            event.preventDefault();
+            setActiveDocument('variable-constraints');
           }}
         >
-          <Icon fa="info-circle" /> Learn more
+          Learn more
         </Link>
       </strong>{' '}
       about variable compatibility
@@ -480,8 +483,8 @@ export default function VariableList({
               );
             }}
           >
-            <Toggle on={showOnlyCompatibleVariables} />
-            Only show compatible variables
+            <Toggle on={showOnlyCompatibleVariables} /> Only show compatible
+            variables
           </button>
         </HtmlTooltip>
       </div>

--- a/src/lib/workspace/AllAnalyses.tsx
+++ b/src/lib/workspace/AllAnalyses.tsx
@@ -6,7 +6,6 @@ import { Link, useHistory, useLocation } from 'react-router-dom';
 import {
   Button,
   Checkbox,
-  createMuiTheme,
   FormControlLabel,
   Icon,
   IconButton,
@@ -14,7 +13,6 @@ import {
   makeStyles,
   Switch,
   TextField,
-  ThemeProvider,
   Tooltip,
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
@@ -42,7 +40,6 @@ import {
   usePinnedAnalyses,
 } from '../core';
 import SubsettingClient from '../core/api/SubsettingClient';
-import { workspaceTheme } from '../core/components/workspaceTheme';
 import { useDebounce } from '../core/hooks/debouncing';
 import { useWdkStudyRecords } from '../core/hooks/study';
 import {
@@ -554,63 +551,58 @@ export function AllAnalyses(props: Props) {
       user,
     ]
   );
-  const theme = createMuiTheme(workspaceTheme);
 
   useSetDocumentTitle('My Analyses');
 
   return (
-    <ThemeProvider theme={theme}>
-      <div className={classes.root}>
-        <h1>My Analyses</h1>
-        {error && <ContentError>{error}</ContentError>}
-        {analyses && datasets && user ? (
-          <Mesa.Mesa state={tableState}>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '1ex',
+    <div className={classes.root}>
+      <h1>My Analyses</h1>
+      {error && <ContentError>{error}</ContentError>}
+      {analyses && datasets && user ? (
+        <Mesa.Mesa state={tableState}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '1ex',
+            }}
+          >
+            <TextField
+              variant="outlined"
+              size="small"
+              label="Search analyses"
+              inputProps={{ size: 50 }}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      aria-label="Clear search text"
+                      onClick={() => setSearchText('')}
+                      style={{
+                        visibility:
+                          debouncedSearchText.length > 0 ? 'visible' : 'hidden',
+                      }}
+                      edge="end"
+                      size="small"
+                    >
+                      <CloseIcon />
+                    </IconButton>
+                  </InputAdornment>
+                ),
               }}
-            >
-              <TextField
-                variant="outlined"
-                size="small"
-                label="Search analyses"
-                inputProps={{ size: 50 }}
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position="end">
-                      <IconButton
-                        aria-label="Clear search text"
-                        onClick={() => setSearchText('')}
-                        style={{
-                          visibility:
-                            debouncedSearchText.length > 0
-                              ? 'visible'
-                              : 'hidden',
-                        }}
-                        edge="end"
-                        size="small"
-                      >
-                        <CloseIcon />
-                      </IconButton>
-                    </InputAdornment>
-                  ),
-                }}
-                value={searchText}
-                onChange={onFilterFieldChange}
-              />
-              <span>
-                Showing {filteredAnalysesAndDatasets?.length} of{' '}
-                {analyses.length} analyses
-              </span>
-            </div>
-            {(loading || datasets == null) && <Loading />}
-          </Mesa.Mesa>
-        ) : (
-          <Loading />
-        )}
-      </div>
-    </ThemeProvider>
+              value={searchText}
+              onChange={onFilterFieldChange}
+            />
+            <span>
+              Showing {filteredAnalysesAndDatasets?.length} of {analyses.length}{' '}
+              analyses
+            </span>
+          </div>
+          {(loading || datasets == null) && <Loading />}
+        </Mesa.Mesa>
+      ) : (
+        <Loading />
+      )}
+    </div>
   );
 }

--- a/src/lib/workspace/PublicAnalyses.tsx
+++ b/src/lib/workspace/PublicAnalyses.tsx
@@ -5,8 +5,6 @@ import {
   FormControlLabel,
   Switch,
   TextField,
-  ThemeProvider,
-  createMuiTheme,
   makeStyles,
 } from '@material-ui/core';
 import { keyBy, orderBy } from 'lodash';
@@ -28,7 +26,6 @@ import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { stripHTML } from '@veupathdb/wdk-client/lib/Utils/DomUtils';
 import { OverflowingTextCell } from '@veupathdb/wdk-client/lib/Views/Strategy/OverflowingTextCell';
 
-import { workspaceTheme } from '../core/components/workspaceTheme';
 import { useDebounce } from '../core/hooks/debouncing';
 import {
   AnalysisClient,
@@ -71,29 +68,26 @@ export function PublicAnalyses({
   ...tableProps
 }: Props) {
   const styles = useStyles();
-  const theme = createMuiTheme(workspaceTheme);
   const user = useWdkService((wdkService) => wdkService.getCurrentUser(), []);
 
   return (
-    <ThemeProvider theme={theme}>
-      <div className={styles.root}>
-        <h1>Public Analyses</h1>
-        <PromiseResult state={publicAnalysisListState}>
-          {(publicAnalysisList) =>
-            studyRecords == null || user == null ? (
-              <Loading />
-            ) : (
-              <PublicAnalysesTable
-                {...tableProps}
-                userId={user.id}
-                studyRecords={studyRecords}
-                publicAnalysisList={publicAnalysisList}
-              />
-            )
-          }
-        </PromiseResult>
-      </div>
-    </ThemeProvider>
+    <div className={styles.root}>
+      <h1>Public Analyses</h1>
+      <PromiseResult state={publicAnalysisListState}>
+        {(publicAnalysisList) =>
+          studyRecords == null || user == null ? (
+            <Loading />
+          ) : (
+            <PublicAnalysesTable
+              {...tableProps}
+              userId={user.id}
+              studyRecords={studyRecords}
+              publicAnalysisList={publicAnalysisList}
+            />
+          )
+        }
+      </PromiseResult>
+    </div>
   );
 }
 

--- a/src/lib/workspace/Subsetting/index.tsx
+++ b/src/lib/workspace/Subsetting/index.tsx
@@ -131,7 +131,7 @@ export default function Subsetting({
         />
       </div>
       <div className="TabularDownload">
-        <SwissArmyButton
+        {/* <SwissArmyButton
           text="View and download"
           tooltip={`View and download current subset of ${
             entity.displayNamePlural ?? entity.displayName
@@ -146,7 +146,7 @@ export default function Subsetting({
               },
             });
           }}
-        />
+        /> */}
       </div>
       <div className="Filter">
         <VariableDetails

--- a/src/lib/workspace/WorkspaceRouter.tsx
+++ b/src/lib/workspace/WorkspaceRouter.tsx
@@ -1,3 +1,5 @@
+import { createTheme, ThemeProvider } from '@material-ui/core';
+import React from 'react';
 import {
   Route,
   RouteComponentProps,
@@ -5,6 +7,9 @@ import {
   useRouteMatch,
   Redirect,
 } from 'react-router';
+import { Documentation } from '../core/components/docs/Documentation';
+import { DocumentationContainer } from '../core/components/docs/DocumentationContainer';
+import { workspaceTheme } from '../core/components/workspaceTheme';
 
 import {
   useConfiguredAnalysisClient,
@@ -17,6 +22,8 @@ import { LatestAnalysis } from './LatestAnalysis';
 import { PublicAnalysesRoute } from './PublicAnalysesRoute';
 import { StudyList } from './StudyList';
 import { WorkspaceContainer } from './WorkspaceContainer';
+
+const theme = createTheme(workspaceTheme);
 
 type Props = {
   subsettingServiceUrl: string;
@@ -39,109 +46,123 @@ export function WorkspaceRouter({
   const analysisClient = useConfiguredAnalysisClient(userServiceUrl);
 
   return (
-    <Switch>
-      <Route
-        path={path}
-        exact
-        render={() => (
-          <AllAnalyses
-            analysisClient={analysisClient}
-            subsettingClient={subsettingClient}
-            exampleAnalysesAuthor={exampleAnalysesAuthor}
+    <ThemeProvider theme={theme}>
+      <DocumentationContainer>
+        <Switch>
+          <Route
+            path={path}
+            exact
+            render={() => (
+              <AllAnalyses
+                analysisClient={analysisClient}
+                subsettingClient={subsettingClient}
+                exampleAnalysesAuthor={exampleAnalysesAuthor}
+              />
+            )}
           />
-        )}
-      />
-      {/* replacing/redirecting double slashes url with single slash one */}
-      <Route
-        exact
-        strict
-        path="(.*//+.*)"
-        render={({ location }) => (
-          <Redirect to={location.pathname.replace(/\/\/+/g, '/')} />
-        )}
-      />
-      <Route
-        path={`${path}/studies`}
-        exact
-        render={() => (
-          <StudyList
-            baseUrl={url}
-            subsettingServiceUrl={subsettingServiceUrl}
+          {/* replacing/redirecting double slashes url with single slash one */}
+          <Route
+            exact
+            strict
+            path="(.*//+.*)"
+            render={({ location }) => (
+              <Redirect to={location.pathname.replace(/\/\/+/g, '/')} />
+            )}
           />
-        )}
-      />
-      <Route
-        path={`${path}/public`}
-        render={() => (
-          <PublicAnalysesRoute
-            analysisClient={analysisClient}
-            exampleAnalysesAuthor={exampleAnalysesAuthor}
+          <Route
+            path={`${path}/documentation/:name`}
+            exact
+            render={(props: RouteComponentProps<{ name: string }>) => (
+              <Documentation documentName={props.match.params.name} />
+            )}
           />
-        )}
-      />
-      <Route
-        path={`${path}/:studyId`}
-        exact
-        render={(props: RouteComponentProps<{ studyId: string }>) => (
-          <EDAAnalysisList
-            {...props.match.params}
-            subsettingServiceUrl={subsettingServiceUrl}
-            dataServiceUrl={dataServiceUrl}
-            userServiceUrl={userServiceUrl}
+          <Route
+            path={`${path}/studies`}
+            exact
+            render={() => (
+              <StudyList
+                baseUrl={url}
+                subsettingServiceUrl={subsettingServiceUrl}
+              />
+            )}
           />
-        )}
-      />
-      <Route
-        path={`${path}/:studyId/new`}
-        render={(props: RouteComponentProps<{ studyId: string }>) => (
-          <WorkspaceContainer
-            {...props.match.params}
-            subsettingServiceUrl={subsettingServiceUrl}
-            dataServiceUrl={dataServiceUrl}
-            userServiceUrl={userServiceUrl}
+          <Route
+            path={`${path}/public`}
+            render={() => (
+              <PublicAnalysesRoute
+                analysisClient={analysisClient}
+                exampleAnalysesAuthor={exampleAnalysesAuthor}
+              />
+            )}
           />
-        )}
-      />
-      <Route
-        path={`${path}/:studyId/~latest`}
-        render={(props: RouteComponentProps<{ studyId: string }>) => (
-          <LatestAnalysis
-            {...props.match.params}
-            replaceRegexp={/~latest/}
-            analysisClient={analysisClient}
+          <Route
+            path={`${path}/:studyId`}
+            exact
+            render={(props: RouteComponentProps<{ studyId: string }>) => (
+              <EDAAnalysisList
+                {...props.match.params}
+                subsettingServiceUrl={subsettingServiceUrl}
+                dataServiceUrl={dataServiceUrl}
+                userServiceUrl={userServiceUrl}
+              />
+            )}
           />
-        )}
-      />
-      <Route
-        exact
-        path={`${path}/:studyId/:analysisId/import`}
-        render={(
-          props: RouteComponentProps<{
-            studyId: string;
-            analysisId: string;
-          }>
-        ) => {
-          return (
-            <ImportAnalysis
-              {...props.match.params}
-              analysisClient={analysisClient}
-            />
-          );
-        }}
-      />
-      <Route
-        path={`${path}/:studyId/:analysisId`}
-        render={(
-          props: RouteComponentProps<{ studyId: string; analysisId: string }>
-        ) => (
-          <WorkspaceContainer
-            {...props.match.params}
-            subsettingServiceUrl={subsettingServiceUrl}
-            dataServiceUrl={dataServiceUrl}
-            userServiceUrl={userServiceUrl}
+          <Route
+            path={`${path}/:studyId/new`}
+            render={(props: RouteComponentProps<{ studyId: string }>) => (
+              <WorkspaceContainer
+                {...props.match.params}
+                subsettingServiceUrl={subsettingServiceUrl}
+                dataServiceUrl={dataServiceUrl}
+                userServiceUrl={userServiceUrl}
+              />
+            )}
           />
-        )}
-      />
-    </Switch>
+          <Route
+            path={`${path}/:studyId/~latest`}
+            render={(props: RouteComponentProps<{ studyId: string }>) => (
+              <LatestAnalysis
+                {...props.match.params}
+                replaceRegexp={/~latest/}
+                analysisClient={analysisClient}
+              />
+            )}
+          />
+          <Route
+            exact
+            path={`${path}/:studyId/:analysisId/import`}
+            render={(
+              props: RouteComponentProps<{
+                studyId: string;
+                analysisId: string;
+              }>
+            ) => {
+              return (
+                <ImportAnalysis
+                  {...props.match.params}
+                  analysisClient={analysisClient}
+                />
+              );
+            }}
+          />
+          <Route
+            path={`${path}/:studyId/:analysisId`}
+            render={(
+              props: RouteComponentProps<{
+                studyId: string;
+                analysisId: string;
+              }>
+            ) => (
+              <WorkspaceContainer
+                {...props.match.params}
+                subsettingServiceUrl={subsettingServiceUrl}
+                dataServiceUrl={dataServiceUrl}
+                userServiceUrl={userServiceUrl}
+              />
+            )}
+          />
+        </Switch>
+      </DocumentationContainer>
+    </ThemeProvider>
   );
 }


### PR DESCRIPTION
This PR adds basic infrastructure for user-facing documentation.

The design is such that there is a root component which manages which user documentation file is active. The active documentation file is displayed in a modal. The modal contains a link to open the document in a new browser window.

Eventually, the documentation files may be served from an external server, which will require updating the `Documentation` component. For now, the documentation lives in the repository as a React component.

ETA also commented out the view/download button in the subsetting tab to address #729 

closes #731 
closes #729