### PR TITLE
set node version

### DIFF
--- a/.github/workflows/pr-check-ts.yml
+++ b/.github/workflows/pr-check-ts.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
       # Runs a set of commands using the runners shell
       - name: Check TypeScript compilation


### PR DESCRIPTION
CI builds are failing since https://github.com/actions/runner was updated. Hoping setting an explicit node version will address this.