### PR TITLE
Gradient colormap

### DIFF
--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -127,14 +127,6 @@ export function InputVariables(props: Props) {
     onChange({ ...selectedVariables, [inputName]: selectedVariable });
   };
 
-  // Want to go one by one through the variables
-  // Need to know the name of the var and constraints
-  // Don't even want to do this here
-  // const filteredConstraints =
-  //   constraints && filterConstraints(selectedVariables, entities, constraints);
-  // console.log(filteredConstraints);
-  // console.log(inputs);
-
   // Find entities that are excluded for each variable, and union their variables
   // with the disabled variables.
   const disabledVariablesByInputName: Record<
@@ -172,7 +164,7 @@ export function InputVariables(props: Props) {
                   )
                 )
               )
-          : [{ entityId: 'a', variableId: 'b' }]; // Typescript help please!!! I tried [{}] as DataElementConstraintRecord but no luck :/
+          : [{ entityId: '', variableId: '' }]; // Typescript help please!!! I tried [{}] as DataElementConstraintRecord but no luck :/
 
         if (dataElementDependencyOrder == null) {
           map[input.name] = disabledVariables;

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -5,7 +5,7 @@ import { VariableDescriptor } from '../../types/variable';
 import {
   DataElementConstraintRecord,
   excludedVariables,
-  flattenConstraints,
+  filterConstraints,
   VariablesByInputName,
 } from '../../utils/data-element-constraints';
 
@@ -127,9 +127,13 @@ export function InputVariables(props: Props) {
     onChange({ ...selectedVariables, [inputName]: selectedVariable });
   };
   console.log(constraints);
-  const flattenedConstraints =
-    constraints && flattenConstraints(selectedVariables, entities, constraints);
-  console.log(flattenedConstraints);
+  // Want to go one by one through the variables
+  // Need to know the name of the var and constraints
+  // Don't even want to do this here
+  // const filteredConstraints =
+  //   constraints && filterConstraints(selectedVariables, entities, constraints);
+  // console.log(filteredConstraints);
+  // console.log(inputs);
 
   // Find entities that are excluded for each variable, and union their variables
   // with the disabled variables.
@@ -139,10 +143,23 @@ export function InputVariables(props: Props) {
   > = useMemo(
     () =>
       inputs.reduce((map, input) => {
+        console.log('my input name');
         console.log(input.name);
 
-        const disabledVariables = flattenedConstraints
-          ? flattenedConstraints
+        // Going input by input, so only return the constraints that relate to *this* input
+        const filteredConstraints =
+          constraints &&
+          filterConstraints(
+            selectedVariables,
+            entities,
+            constraints,
+            input.name
+          );
+        console.log('filtered constraints');
+        console.log(filteredConstraints);
+
+        const disabledVariables = filteredConstraints
+          ? filteredConstraints
               .map((constraint) => {
                 return excludedVariables(
                   entities[0],
@@ -160,8 +177,6 @@ export function InputVariables(props: Props) {
                 )
               )
           : [{ entityId: 'a', variableId: 'b' }];
-
-        console.log(disabledVariables);
 
         if (dataElementDependencyOrder == null) {
           map[input.name] = disabledVariables;
@@ -235,7 +250,7 @@ export function InputVariables(props: Props) {
     [
       dataElementDependencyOrder,
       entities,
-      flattenedConstraints,
+      constraints,
       inputs,
       selectedVariables,
     ]
@@ -261,7 +276,7 @@ export function InputVariables(props: Props) {
                   rootEntity={entities[0]}
                   disabledVariables={disabledVariablesByInputName[input.name]}
                   customDisabledVariableMessage={
-                    flattenedConstraints?.[0][input.name].description
+                    constraints?.[0][input.name].description // just take first description for now
                   }
                   starredVariables={starredVariables}
                   toggleStarredVariable={toggleStarredVariable}
@@ -293,7 +308,7 @@ export function InputVariables(props: Props) {
                     rootEntity={entities[0]}
                     disabledVariables={disabledVariablesByInputName[input.name]}
                     customDisabledVariableMessage={
-                      flattenedConstraints?.[0][input.name].description
+                      constraints?.[0][input.name].description // just take first description for now
                     }
                     starredVariables={starredVariables}
                     toggleStarredVariable={toggleStarredVariable}

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -126,7 +126,7 @@ export function InputVariables(props: Props) {
   ) => {
     onChange({ ...selectedVariables, [inputName]: selectedVariable });
   };
-  console.log(constraints);
+
   // Want to go one by one through the variables
   // Need to know the name of the var and constraints
   // Don't even want to do this here
@@ -143,10 +143,7 @@ export function InputVariables(props: Props) {
   > = useMemo(
     () =>
       inputs.reduce((map, input) => {
-        console.log('my input name');
-        console.log(input.name);
-
-        // Going input by input, so only return the constraints that relate to *this* input
+        // For each input (ex. xAxisVariable), determine its constraints based on which patterns any other selected variables match.
         const filteredConstraints =
           constraints &&
           filterConstraints(
@@ -155,9 +152,8 @@ export function InputVariables(props: Props) {
             constraints,
             input.name
           );
-        console.log('filtered constraints');
-        console.log(filteredConstraints);
 
+        // Use the input-specific filtered constraints to create an array of disabled variables.
         const disabledVariables = filteredConstraints
           ? filteredConstraints
               .map((constraint) => {
@@ -165,18 +161,18 @@ export function InputVariables(props: Props) {
                   entities[0],
                   constraint && constraint[input.name]
                 );
-                // Take the intersection of all variables (objects with varIds and entityIds)
               })
+              // Keep only those variables (objects with varIds and entityIds) that should be disabled based on *all* constraints
               .reduce((disabledVarArray1, disabledVarArray2) =>
-                disabledVarArray1.filter((value1) =>
+                disabledVarArray1.filter((disabledVar1) =>
                   disabledVarArray2.some(
-                    (value2) =>
-                      value1.variableId === value2.variableId &&
-                      value1.entityId === value2.entityId
+                    (disabledVar2) =>
+                      disabledVar1.variableId === disabledVar2.variableId &&
+                      disabledVar1.entityId === disabledVar2.entityId
                   )
                 )
               )
-          : [{ entityId: 'a', variableId: 'b' }];
+          : [{ entityId: 'a', variableId: 'b' }]; // Typescript help please!!! I tried [{}] as DataElementConstraintRecord but no luck :/
 
         if (dataElementDependencyOrder == null) {
           map[input.name] = disabledVariables;

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -126,8 +126,10 @@ export function InputVariables(props: Props) {
   ) => {
     onChange({ ...selectedVariables, [inputName]: selectedVariable });
   };
+  console.log(constraints);
   const flattenedConstraints =
     constraints && flattenConstraints(selectedVariables, entities, constraints);
+  console.log(flattenedConstraints);
 
   // Find entities that are excluded for each variable, and union their variables
   // with the disabled variables.
@@ -137,10 +139,30 @@ export function InputVariables(props: Props) {
   > = useMemo(
     () =>
       inputs.reduce((map, input) => {
-        const disabledVariables = excludedVariables(
-          entities[0],
-          flattenedConstraints && flattenedConstraints[input.name]
-        );
+        console.log(input.name);
+
+        const disabledVariables = flattenedConstraints
+          ? flattenedConstraints
+              .map((constraint) => {
+                return excludedVariables(
+                  entities[0],
+                  constraint && constraint[input.name]
+                );
+                // Take the intersection of all variables (objects with varIds and entityIds)
+              })
+              .reduce((disabledVarArray1, disabledVarArray2) =>
+                disabledVarArray1.filter((value1) =>
+                  disabledVarArray2.some(
+                    (value2) =>
+                      value1.variableId === value2.variableId &&
+                      value1.entityId === value2.entityId
+                  )
+                )
+              )
+          : [{ entityId: 'a', variableId: 'b' }];
+
+        console.log(disabledVariables);
+
         if (dataElementDependencyOrder == null) {
           map[input.name] = disabledVariables;
           return map;
@@ -239,7 +261,7 @@ export function InputVariables(props: Props) {
                   rootEntity={entities[0]}
                   disabledVariables={disabledVariablesByInputName[input.name]}
                   customDisabledVariableMessage={
-                    flattenedConstraints?.[input.name].description
+                    flattenedConstraints?.[0][input.name].description
                   }
                   starredVariables={starredVariables}
                   toggleStarredVariable={toggleStarredVariable}
@@ -271,7 +293,7 @@ export function InputVariables(props: Props) {
                     rootEntity={entities[0]}
                     disabledVariables={disabledVariablesByInputName[input.name]}
                     customDisabledVariableMessage={
-                      flattenedConstraints?.[input.name].description
+                      flattenedConstraints?.[0][input.name].description
                     }
                     starredVariables={starredVariables}
                     toggleStarredVariable={toggleStarredVariable}

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -147,24 +147,8 @@ export function InputVariables(props: Props) {
 
         // Use the input-specific filtered constraints to create an array of disabled variables.
         const disabledVariables = filteredConstraints
-          ? filteredConstraints
-              .map((constraint) => {
-                return excludedVariables(
-                  entities[0],
-                  constraint && constraint[input.name]
-                );
-              })
-              // Keep only those variables (objects with varIds and entityIds) that should be disabled based on *all* constraints
-              .reduce((disabledVarArray1, disabledVarArray2) =>
-                disabledVarArray1.filter((disabledVar1) =>
-                  disabledVarArray2.some(
-                    (disabledVar2) =>
-                      disabledVar1.variableId === disabledVar2.variableId &&
-                      disabledVar1.entityId === disabledVar2.entityId
-                  )
-                )
-              )
-          : [{ entityId: '', variableId: '' }]; // Typescript help please!!! I tried [{}] as DataElementConstraintRecord but no luck :/
+          ? excludedVariables(entities[0], input.name, filteredConstraints)
+          : [];
 
         if (dataElementDependencyOrder == null) {
           map[input.name] = disabledVariables;

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -274,7 +274,9 @@ function ScatterplotViz(props: VisualizationProps) {
         facetVariable,
         // set valueSpec as Raw when yAxisVariable = date
         valueSpecConfig:
-          findEntityAndVariable(yAxisVariable)?.variable.type === 'date'
+          findEntityAndVariable(yAxisVariable)?.variable.type === 'date' ||
+          findEntityAndVariable(overlayVariable)?.variable.type === 'number' ||
+          findEntityAndVariable(overlayVariable)?.variable.type === 'integer'
             ? 'Raw'
             : vizConfig.valueSpecConfig,
         // set undefined for variable change
@@ -491,7 +493,7 @@ function ScatterplotViz(props: VisualizationProps) {
         legendMax: data.value?.overlayMax,
         legendMin: data.value?.overlayMin,
         gradientColorscaleType: data.value?.gradientColorscaleType,
-        nTicks: 3, // MUST be odd!
+        nTicks: 5, // MUST be odd! Probably should be a clever function of the box size and font or something...
         legendTitle: axisLabelWithUnit(overlayVariable),
         // hasMissingData: hasMissingData
       };
@@ -499,7 +501,6 @@ function ScatterplotViz(props: VisualizationProps) {
       return {
         legendMax: 0,
         legendMin: 0,
-        gradientColorscaleType: 'sequential',
       };
     }
   }, [
@@ -759,7 +760,11 @@ function ScatterplotViz(props: VisualizationProps) {
       dependentAxisRange={data.value ? defaultDependentRangeMargin : undefined}
       // set valueSpec as Raw when yAxisVariable = date
       valueSpec={
-        yAxisVariable?.type === 'date' ? 'Raw' : vizConfig.valueSpecConfig
+        yAxisVariable?.type === 'date' ||
+        overlayVariable?.type === 'number' ||
+        overlayVariable?.type === 'integer'
+          ? 'Raw'
+          : vizConfig.valueSpecConfig
       }
       onValueSpecChange={onValueSpecChange}
       // send visualization.type here
@@ -770,7 +775,9 @@ function ScatterplotViz(props: VisualizationProps) {
       plotOptions={['Raw', 'Smoothed mean with raw', 'Best fit line with raw']}
       // disabledList prop is used to disable radio options (grayed out)
       disabledList={
-        yAxisVariable?.type === 'date'
+        yAxisVariable?.type === 'date' ||
+        overlayVariable?.type === 'number' ||
+        overlayVariable?.type === 'integer'
           ? ['Smoothed mean with raw', 'Best fit line with raw']
           : []
       }
@@ -787,6 +794,7 @@ function ScatterplotViz(props: VisualizationProps) {
   );
 
   console.log(gradientLegendItems);
+  console.log(overlayVariable);
 
   const legendNode =
     !data.pending &&

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -493,6 +493,7 @@ function ScatterplotViz(props: VisualizationProps) {
         gradientColorscaleType: data.value?.gradientColorscaleType,
         nTicks: 3, // MUST be odd!
         legendTitle: axisLabelWithUnit(overlayVariable),
+        // hasMissingData: hasMissingData
       };
     } else {
       return {
@@ -1381,12 +1382,16 @@ function processInputData<T extends number | string>(
           console.log('diverging');
           // Diverging colorscale, assume 0 is midpoint. Colorscale must be symmetric around the midpoint
           const maxAbsOverlay =
-            overlayMin > overlayMax ? overlayMin : overlayMax;
+            Math.abs(overlayMin) > overlayMax
+              ? Math.abs(overlayMin)
+              : overlayMax;
           // For each point, normalize the data to [-1, 1], then retrieve the corresponding color
           normalize.domain([-maxAbsOverlay, maxAbsOverlay]).range([-1, 1]);
           markerColorsGradient = seriesGradientColorscale.map((a: number) =>
             gradientDivergingColorscaleMap(normalize(a))
           );
+          overlayMax = maxAbsOverlay;
+          overlayMin = -maxAbsOverlay;
           gradientColorscaleType = 'diverging';
         } else if (seriesGradientColorscale.some((a: number) => a < 0)) {
           console.log('sequential backwards');

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -409,6 +409,25 @@ function ScatterplotViz(props: VisualizationProps) {
         overlayVariable?.vocabulary,
         overlayVariable
       );
+
+      // If numeric overlay, record the min and max
+      const overlayMin =
+        overlayVariable?.type === 'integer' ||
+        overlayVariable?.type === 'number'
+          ? overlayVariable.displayRangeMin
+            ? overlayVariable.displayRangeMin
+            : overlayVariable?.rangeMin
+          : undefined;
+      const overlayMax =
+        overlayVariable?.type === 'integer' ||
+        overlayVariable?.type === 'number'
+          ? overlayVariable.displayRangeMax
+            ? overlayVariable.displayRangeMax
+            : overlayVariable?.rangeMax
+          : undefined;
+
+      console.log([overlayMin, overlayMax]);
+
       const facetVocabulary = fixLabelsForNumberVariables(
         facetVariable?.vocabulary,
         facetVariable
@@ -421,6 +440,8 @@ function ScatterplotViz(props: VisualizationProps) {
         showMissingOverlay,
         overlayVocabulary,
         overlayVariable,
+        overlayMin,
+        overlayMax,
         showMissingFacet,
         facetVocabulary,
         facetVariable
@@ -484,6 +505,7 @@ function ScatterplotViz(props: VisualizationProps) {
   // gradient colorscale legend
   const gradientLegendItems: PlotLegendGradientProps = useMemo(() => {
     console.log(data.value);
+    console.log(vizConfig.showMissingness);
     if (
       data.value?.overlayMax &&
       data.value?.overlayMin &&
@@ -495,7 +517,7 @@ function ScatterplotViz(props: VisualizationProps) {
         gradientColorscaleType: data.value?.gradientColorscaleType,
         nTicks: 5, // MUST be odd! Probably should be a clever function of the box size and font or something...
         legendTitle: axisLabelWithUnit(overlayVariable),
-        // hasMissingData: hasMissingData
+        showMissingness: vizConfig.showMissingness,
       };
     } else {
       return {
@@ -1063,6 +1085,8 @@ export function scatterplotResponseToData(
   showMissingOverlay: boolean = false,
   overlayVocabulary: string[] = [],
   overlayVariable?: Variable,
+  overlayMin?: number,
+  overlayMax?: number,
   showMissingFacet: boolean = false,
   facetVocabulary: string[] = [],
   facetVariable?: Variable
@@ -1087,8 +1111,6 @@ export function scatterplotResponseToData(
       dataSetProcess,
       yMin,
       yMax,
-      overlayMin,
-      overlayMax,
       gradientColorscaleType,
     } = processInputData(
       reorderResponseScatterplotData(
@@ -1104,6 +1126,8 @@ export function scatterplotResponseToData(
       showMissingOverlay,
       hasMissingData,
       overlayVariable,
+      overlayMin,
+      overlayMax,
       // pass facetVariable to determine either scatter or scattergl
       facetVariable
     );
@@ -1118,11 +1142,11 @@ export function scatterplotResponseToData(
     };
   });
 
+  console.log(processedData);
+
   const yMin = min(map(processedData, ({ yMin }) => yMin));
   const yMax = max(map(processedData, ({ yMax }) => yMax));
 
-  const overlayMin = min(map(processedData, ({ overlayMin }) => overlayMin));
-  const overlayMax = max(map(processedData, ({ overlayMax }) => overlayMax));
   const gradientColorscaleType = max(
     map(processedData, ({ gradientColorscaleType }) => gradientColorscaleType)
   );
@@ -1238,6 +1262,8 @@ function processInputData<T extends number | string>(
   showMissingness: boolean,
   hasMissingData: boolean,
   overlayVariable?: Variable,
+  overlayMin?: number | undefined,
+  overlayMax?: number | undefined,
   // pass facetVariable to determine either scatter or scattergl
   facetVariable?: Variable
 ) {
@@ -1249,8 +1275,8 @@ function processInputData<T extends number | string>(
   let yMax: number | string | undefined;
 
   // set variables for overlay ranges
-  let overlayMin: number | undefined;
-  let overlayMax: number | undefined;
+  // let overlayMin: number | undefined;
+  // let overlayMax: number | undefined;
   let gradientColorscaleType: string | undefined;
 
   // catch the case when the back end has returned valid but completely empty data

--- a/src/lib/core/utils/data-element-constraints.ts
+++ b/src/lib/core/utils/data-element-constraints.ts
@@ -44,14 +44,19 @@ export function filterVariablesByConstraint(
  */
 export function excludedVariables(
   rootEntity: StudyEntity,
-  constraint?: DataElementConstraint
+  inputName: string,
+  constraints?: DataElementConstraintRecord[]
 ): VariableDescriptor[] {
-  if (constraint == null) return [];
+  if (constraints == null) return [];
+
   return Seq.from(preorder(rootEntity, (e) => e.children ?? []))
     .flatMap((e) =>
       e.variables
-        .filter(
-          (variable) => !variableConstraintPredicate(constraint, variable)
+        .filter((variable) =>
+          constraints.every(
+            (constraint) =>
+              !variableConstraintPredicate(constraint[inputName], variable)
+          )
         )
         .map((v) => ({ entityId: e.id, variableId: v.id }))
     )

--- a/src/lib/core/utils/data-element-constraints.ts
+++ b/src/lib/core/utils/data-element-constraints.ts
@@ -106,7 +106,7 @@ export function flattenConstraints(
   variables: VariablesByInputName,
   entities: StudyEntity[],
   constraints: DataElementConstraintRecord[]
-): DataElementConstraintRecord {
+): DataElementConstraintRecord[] {
   // Find all compatible constraints
   const compatibleConstraints = constraints.filter((constraintRecord) =>
     Object.entries(constraintRecord).every(([variableName, constraint]) => {
@@ -155,10 +155,12 @@ export function flattenConstraints(
     );
   // Combine compatible constraints into a single constraint, concatenating
   // allowed shapes and types.
-  return compatibleConstraints.reduce(
-    mergeConstraints,
-    {} as DataElementConstraintRecord
-  );
+  // But what if it just doesn't flatten the constraints? We still get all the benefits?
+  return compatibleConstraints;
+  // .reduce(
+  //   mergeConstraints,
+  //   {} as DataElementConstraintRecord
+  // );
 }
 
 export function mergeConstraints(


### PR DESCRIPTION
With plot.data [PR #124](https://github.com/VEuPathDB/plot.data/pull/124), data service [PR #138](https://github.com/VEuPathDB/EdaDataService/pull/138), and web-components [PR #275](https://github.com/VEuPathDB/web-components/pull/275), resolves #306.

When the scatter response contains a 'seriesGradientColorscale' column, we now map that number to a color using the appropriate colormap.

Note that we have a bit of a var constraint mess to sort out. If using a gradient colorscale, then we want to disable trend lines. Currently here I'm using dataType. plot.data is using dataShape=continuous. Not a terrible issue and not hard to fix, just one we need to discuss as a group :) 

Other troubles I ran into:
- Making sure the colormap type and range are set *outside* the processInputData function, because they have to stay the same for all facets.
- How to represent no data from plot.data's perspective. See the PR mentioned above for details. Basically there will be one new row for no data, containing x, y as usual, then NaN for overlay.

Leaving the following features to future cards:
- User-defined colorscale type, min, max, midpoint
- passing dates to overlay
- Tooltip show correct name and overlay value
