### PR TITLE
New NPM dependency structure

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -38,6 +38,7 @@ module.exports = function override(config, env) {
         // a dev dependency.
         {
           test: /\.(js|jsx|ts|tsx)$/,
+          include: /node_modules/,
           loader: 'ify-loader',
         },
       ],

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -37,7 +37,7 @@ module.exports = function override(config, env) {
         // This also needs the bubleify packages installed as
         // a dev dependency.
         {
-          test: /node_modules/,
+          test: /\.(js|jsx|ts|tsx)$/,
           loader: 'ify-loader',
         },
       ],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@veupathdb/components": "^0.11.10",
     "@veupathdb/core-components": "^0.4.1",
     "@veupathdb/http-utils": "^1.0.1",
-    "@veupathdb/study-data-access": "^0.1.3",
+    "@veupathdb/study-data-access": "^0.1.5",
     "@veupathdb/wdk-client": "^0.5.2",
     "debounce-promise": "^3.1.2",
     "file-saver": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.1.48",
+  "version": "1.1.49",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@veupathdb/core-components": "^0.4.1",
     "@veupathdb/http-utils": "^1.0.1",
     "@veupathdb/study-data-access": "^0.1.5",
-    "@veupathdb/wdk-client": "^0.5.2",
     "debounce-promise": "^3.1.2",
     "file-saver": "^2.0.5",
     "fp-ts": "^2.9.3",
@@ -27,6 +26,9 @@
     "react-router-dom": "^5.3.0",
     "react-table": "^7.7.0",
     "uuid": "^8.3.2"
+  },
+  "peerDependencies": {
+    "@veupathdb/wdk-client": ">=0.5.4"
   },
   "sideEffects": [
     "*.scss"
@@ -74,6 +76,7 @@
     "@veupathdb/prettier-config": "^1.0.0",
     "@veupathdb/react-scripts": "^1.0.1",
     "@veupathdb/tsconfig": "^1.0.1",
+    "@veupathdb/wdk-client": "^0.5.4",
     "@veupathdb/web-common": "^0.1.12",
     "bubleify": "^2.0.0",
     "http-proxy-middleware": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3586,13 +3586,12 @@
     io-ts "^2.2.16"
     lodash "^4.17.21"
 
-"@veupathdb/study-data-access@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@veupathdb/study-data-access/-/study-data-access-0.1.3.tgz#e9f7d97cf96a35dc4930a482202eeec55ef0cbe5"
-  integrity sha512-NxQqA/xvqWSzvITDmxQ3JvtBk1l1xWVeFbC09yfBoGTYwHoP6wmDBs+huJhyPLxZkPymytYcpg5ZAJga35LiVg==
+"@veupathdb/study-data-access@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@veupathdb/study-data-access/-/study-data-access-0.1.5.tgz#8f0aae7c4c35f001b8f3bff77feeeba3c86df578"
+  integrity sha512-CPoQ03Hg8O35JaAbhx0g22eAHOaDQ14pvydjMEs1oYFQggw6+cckp6tEpOCHhbAlwIBn0rvSdntGeJho2iLY/w==
   dependencies:
     "@veupathdb/http-utils" "^1.0.1"
-    "@veupathdb/wdk-client" "^0.5.2"
     fp-ts "^2.11.5"
     io-ts "^2.2.16"
     lodash "^4.17.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3335,7 +3335,7 @@
     react-transition-group "^4.4.1"
     shape2geohash "^1.2.5"
 
-"@veupathdb/components@^0.11.10":
+"@veupathdb/components@^0.11.10", "@veupathdb/components@^0.11.8":
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.11.10.tgz#3f88b3dac73d0fa98dcf2de56f3f16c2a55c3bc5"
   integrity sha512-7jI10uRxWpezGVUwGuFiHBEYBOAunm8BGelpbn86kWr8JljZs9hC6LmNtbLrCkUGnj9wFjBVYa4wbsjKJi1RXA==
@@ -3379,46 +3379,6 @@
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.11.7.tgz#938f935ef0517076ed96f0d83f11103bc1dd913a"
   integrity sha512-mEaFvOSxZMRe+2+gdLlm04ylw3UsY1k+rEOUmkymisP6Hn7uxn78mEiy+EtAn3nVIfbZmkP7fXDF3MkVgSBV0Q==
-  dependencies:
-    "@emotion/react" "^11.7.0"
-    "@material-ui/core" "^4.11.2"
-    "@material-ui/icons" "^4.11.2"
-    "@material-ui/lab" "^4.0.0-alpha.57"
-    "@types/d3" "^7.1.0"
-    "@types/date-arithmetic" "^4.1.1"
-    "@veupathdb/core-components" "^0.4.0"
-    "@visx/gradient" "^1.0.0"
-    "@visx/group" "^1.0.0"
-    "@visx/hierarchy" "^1.0.0"
-    "@visx/shape" "^1.4.0"
-    "@visx/text" "^1.3.0"
-    "@visx/tooltip" "^1.3.0"
-    "@visx/visx" "^1.1.0"
-    bootstrap "^4.5.2"
-    color-math "^1.1.3"
-    d3 "^7.1.1"
-    date-arithmetic "^4.1.0"
-    debounce-promise "^3.1.2"
-    latlon-geohash "^2.0.0"
-    leaflet "^1.6.0"
-    leaflet-drift-marker "^1.0.3"
-    luxon "^1.25.0"
-    plotly.js "^2.6.0"
-    re-resizable "^6.9.0"
-    react "^16.13.1"
-    react-bootstrap "^1.3.0"
-    react-cool-dimensions "^1.1.11"
-    react-dom "^16.13.1"
-    react-html-parser "^2.0.2"
-    react-leaflet "^2.7.0"
-    react-plotly.js "^2.4.0"
-    react-transition-group "^4.4.1"
-    shape2geohash "^1.2.5"
-
-"@veupathdb/components@^0.11.8":
-  version "0.11.8"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.11.8.tgz#4c843309cfa835c41a8be3821801cf9a99ff78e6"
-  integrity sha512-JSOdvHp6RoWDAGZYndfhG2WLlvDxGamISwMrrwr98GtrrhxfGX01ASTmA92P4XiA/65vWdfhWcE745Bd8zO/6w==
   dependencies:
     "@emotion/react" "^11.7.0"
     "@material-ui/core" "^4.11.2"
@@ -3649,10 +3609,10 @@
     spin.js "^4.0.0"
     uuid "^8.1.0"
 
-"@veupathdb/wdk-client@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.5.2.tgz#3569fc7d0c58a815f5f8fa594ab5e69a3f328549"
-  integrity sha512-BI0hWSnlPeN4NrKh9UGN7PKqBqf2Ghdad9uzUz+Ba2Po6QTRHDZj70u1VJS2NmjoQxCzyuOXOprRKQIXdBGkeg==
+"@veupathdb/wdk-client@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.5.4.tgz#a4e2ecfdaf66f8f6f02fab82c273b120a608fe86"
+  integrity sha512-pEIVIPDvNs8kBJhBen97lT9ixqgDzbjYeYjmvCkM5u5Q3SRLXl5DNs2o0yCkVJBynXSUHbOUg2me3VqsKAGXHw==
   dependencies:
     "@types/datatables.net" "^1.10.5"
     "@types/flot" "^0.0.31"


### PR DESCRIPTION
This PR:

1. Upgrades `@veupathdb/study-data-access` (which, due to https://github.com/VEuPathDB/web-study-data-access/pull/5, eliminates a transitive dependency on `@veupathdb/wdk-client`)
2. Makes `@veupathdb/wdk-client` a peer and dev dependency (to reduce the risk of introducing transitive dependencies of `@veupathdb/wdk-client` to consumers of `@veupathdb/web-eda`)
3. Applies the `ify-loader` to only JS/TS assets. (This resolves an issue where the `ify-loader` was mis-bundling images from `@veupathdb/web-common`.)