### PR TITLE
v1.1.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.1.49",
+  "version": "1.1.50",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",


### PR DESCRIPTION
Version bump for https://github.com/VEuPathDB/web-eda/pull/792. That PR had a version bump, but 1.1.49 was [already claimed](https://github.com/VEuPathDB/web-eda/pull/785/commits/ed7070a47103dfb5dc0b8e53ec69b2dd7205f323). (Lesson learned: don't forget to sync-merge before merging a PR!)