### PR TITLE
axis range controls for histogram, bar, box, and scatter plot vizs

### DIFF
--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -570,6 +570,8 @@ function HistogramPlotWithControls({
         selectedRange={selectedRange}
         selectedRangeBounds={selectedRangeBounds}
         onSelectedRangeChange={handleSelectedRangeChange}
+        //DKDK parentComponentName
+        parentComponentName={'HistogramFilter'}
       />
       <Histogram
         {...histogramProps}
@@ -629,6 +631,8 @@ function HistogramPlotWithControls({
             }}
             allowPartialRange={false}
             containerStyles={{ minWidth: '400px' }}
+            //DKDK parentComponentName
+            parentComponentName={'HistogramFilter'}
           />
           {/* truncation notification */}
           {truncatedDependentAxisWarning ? (
@@ -678,6 +682,8 @@ function HistogramPlotWithControls({
             onRangeChange={handleIndependentAxisRangeChange}
             valueType={data?.valueType}
             containerStyles={{ minWidth: '400px' }}
+            //DKDK parentComponentName
+            parentComponentName={'HistogramFilter'}
           />
           {/* truncation notification */}
           {truncatedIndependentAxisWarning ? (

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -65,21 +65,17 @@ import { ColorPaletteDefault } from '@veupathdb/components/lib/types/plots/addOn
 // a custom hook to preserve the status of checked legend items
 import { useCheckedLegendItemsStatus } from '../../../hooks/checkedLegendItemsStatus';
 
-//DKDK concerning axis range control
+// concerning axis range control
 import { NumberOrDateRange, NumberRange } from '../../../types/general';
 import { NumberRangeInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateRangeInputs';
 // reusable util for computing truncationConfig
-//DKDK temporarily use variant
-// import { truncationConfig } from '../../../utils/truncation-config-utils';
 import { truncationConfig } from '../../../utils/truncation-config-utils-viz';
 // use Notification for truncation warning message
 import Notification from '@veupathdb/components/lib/components/widgets//Notification';
 import Button from '@veupathdb/components/lib/components/widgets/Button';
-import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
-import { UIState } from '../../filter/HistogramFilter';
 import { useDefaultDependentAxisRange } from '../../../hooks/computeDefaultDependentAxisRange';
 
-//DKDK export
+// export
 export type BarplotDataWithStatistics = (
   | BarplotData
   | FacetedData<BarplotData>
@@ -129,7 +125,7 @@ type ValueSpec = t.TypeOf<typeof ValueSpec>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 const ValueSpec = t.keyof({ count: null, proportion: null });
 
-//DKDK export
+// export
 export type BarplotConfig = t.TypeOf<typeof BarplotConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const BarplotConfig = t.intersection([
@@ -144,7 +140,7 @@ export const BarplotConfig = t.intersection([
     showMissingness: t.boolean,
     // for custom legend: vizconfig.checkedLegendItems
     checkedLegendItems: t.array(t.string),
-    //DKDK dependent axis range control
+    // dependent axis range control
     dependentAxisRange: NumberRange,
   }),
 ]);
@@ -186,7 +182,7 @@ function BarplotViz(props: VisualizationProps) {
     [updateConfiguration, vizConfig]
   );
 
-  //DKDK set the state of truncation warning message
+  // set the state of truncation warning message here
   const [
     truncatedDependentAxisWarning,
     setTruncatedDependentAxisWarning,
@@ -207,7 +203,7 @@ function BarplotViz(props: VisualizationProps) {
         // set undefined for variable change
         checkedLegendItems: undefined,
       });
-      //DKDK close truncation warnings
+      // close truncation warnings
       setTruncatedDependentAxisWarning('');
     },
     [updateVizConfig]
@@ -412,7 +408,7 @@ function BarplotViz(props: VisualizationProps) {
     vizConfig.checkedLegendItems
   );
 
-  // DKDK using custom hook
+  //  using custom hook
   const defaultDependentAxisRange = useDefaultDependentAxisRange(
     data,
     vizConfig,
@@ -420,10 +416,7 @@ function BarplotViz(props: VisualizationProps) {
     'Barplot'
   );
 
-  console.log('defaultDependentAxisRange =', defaultDependentAxisRange);
-  console.log('vizConfig.dependentAxisRange =', vizConfig.dependentAxisRange);
-
-  //DKDK axis range control
+  // axis range control
   const handleDependentAxisRangeChange = useCallback(
     (newRange?: NumberRange) => {
       updateVizConfig({
@@ -437,10 +430,8 @@ function BarplotViz(props: VisualizationProps) {
     updateVizConfig({
       dependentAxisRange: defaultDependentAxisRange,
       dependentAxisLogScale: false,
-      //DKDK valueSpec should not be changed when resetting ?
-      // valueSpec: 'count',
     });
-    //DKDK add reset for truncation message as well
+    // add reset for truncation message as well
     setTruncatedDependentAxisWarning('');
   }, [
     // defaultUIState.dependentAxisLogScale,
@@ -455,7 +446,7 @@ function BarplotViz(props: VisualizationProps) {
     truncationConfigDependentAxisMax,
   } = useMemo(
     () =>
-      //DKDK barplot does not have independent axis range control so send undefined for defaultUIState
+      // barplot does not have independent axis range control so send undefined for defaultUIState
       truncationConfig(undefined, vizConfig, defaultDependentAxisRange),
     [
       vizConfig.xAxisVariable,
@@ -474,14 +465,6 @@ function BarplotViz(props: VisualizationProps) {
       );
     }
   }, [truncationConfigDependentAxisMin, truncationConfigDependentAxisMax]);
-
-  console.log(
-    'truncationConfig = ',
-    truncationConfigIndependentAxisMin,
-    truncationConfigIndependentAxisMax,
-    truncationConfigDependentAxisMin,
-    truncationConfigDependentAxisMax
-  );
 
   const plotRef = useUpdateThumbnailEffect(
     updateThumbnail,
@@ -505,10 +488,10 @@ function BarplotViz(props: VisualizationProps) {
     showSpinner: data.pending || filteredCounts.pending,
     dependentAxisLogScale: vizConfig.dependentAxisLogScale,
     // set dependent axis range for log scale
-    //DKDK truncation axis range control
+    // truncation axis range control
     dependentAxisRange: vizConfig.dependentAxisRange,
     displayLibraryControls: false,
-    //DKDK for faceted plot, add axisTruncationConfig props here
+    // for faceted plot, add axisTruncationConfig props here
     axisTruncationConfig: {
       independentAxis: {
         min: truncationConfigIndependentAxisMin,
@@ -543,9 +526,9 @@ function BarplotViz(props: VisualizationProps) {
           ref={plotRef}
           // for custom legend: pass checkedLegendItems to PlotlyPlot
           checkedLegendItems={checkedLegendItems}
-          //DKDK axis range control
+          // axis range control
           dependentAxisRange={vizConfig.dependentAxisRange}
-          //DKDK pass axisTruncationConfig
+          // pass axisTruncationConfig
           axisTruncationConfig={{
             independentAxis: {
               min: truncationConfigIndependentAxisMin,
@@ -581,16 +564,16 @@ function BarplotViz(props: VisualizationProps) {
               }}
             />
           </div>
-          {/* DKDK Y-axis range control */}
+          {/* Y-axis range control */}
           <NumberRangeInput
             label="Range"
-            //DKDK add range
+            // add range
             range={vizConfig.dependentAxisRange ?? defaultDependentAxisRange}
             onRangeChange={(newRange?: NumberOrDateRange) => {
               handleDependentAxisRangeChange(newRange as NumberRange);
             }}
             allowPartialRange={false}
-            //DKDK set maxWidth
+            // set maxWidth
             containerStyles={{ maxWidth: '350px' }}
           />
           {/* truncation notification */}
@@ -604,13 +587,12 @@ function BarplotViz(props: VisualizationProps) {
                 setTruncatedDependentAxisWarning('');
               }}
               showWarningIcon={true}
-              //DKDK change maxWidth
+              // change maxWidth
               containerStyles={{ maxWidth: '350px' }}
             />
           ) : null}
           <Button
             type={'outlined'}
-            //DKDK change text
             text={'Reset to defaults'}
             onClick={handleDependentAxisSettingsReset}
             containerStyles={{

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -72,24 +72,20 @@ import { ColorPaletteDefault } from '@veupathdb/components/lib/types/plots/addOn
 // a custom hook to preserve the status of checked legend items
 import { useCheckedLegendItemsStatus } from '../../../hooks/checkedLegendItemsStatus';
 
-//DKDK concerning axis range control
+// concerning axis range control
 import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
 import { NumberOrDateRange, NumberRange } from '../../../types/general';
 import { NumberRangeInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateRangeInputs';
 // reusable util for computing truncationConfig
-//DKDK temporarily use variant
-// import { truncationConfig } from '../../../utils/truncation-config-utils';
 import { truncationConfig } from '../../../utils/truncation-config-utils-viz';
 // use Notification for truncation warning message
 import Notification from '@veupathdb/components/lib/components/widgets//Notification';
 import Button from '@veupathdb/components/lib/components/widgets/Button';
-import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
-import { UIState } from '../../filter/HistogramFilter';
 import { useDefaultDependentAxisRange } from '../../../hooks/computeDefaultDependentAxisRange';
 
 type BoxplotData = { series: BoxplotSeries };
 
-//DKDK export
+// export
 export type BoxplotDataWithCoverage = (BoxplotData | FacetedData<BoxplotData>) &
   CoverageStatistics;
 
@@ -129,7 +125,7 @@ function createDefaultConfig(): BoxplotConfig {
   return {};
 }
 
-//DKDK export
+// export
 export type BoxplotConfig = t.TypeOf<typeof BoxplotConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const BoxplotConfig = t.partial({
@@ -140,7 +136,7 @@ export const BoxplotConfig = t.partial({
   showMissingness: t.boolean,
   // for custom legend: vizconfig.checkedLegendItems
   checkedLegendItems: t.array(t.string),
-  //DKDK dependent axis range control: NumberRange or NumberOrDateRange
+  // dependent axis range control: NumberRange or NumberOrDateRange
   dependentAxisRange: NumberOrDateRange,
 });
 
@@ -181,7 +177,7 @@ function BoxplotViz(props: VisualizationProps) {
     [updateConfiguration, vizConfig]
   );
 
-  //DKDK set the state of truncation warning message
+  // set the state of truncation warning message
   const [
     truncatedDependentAxisWarning,
     setTruncatedDependentAxisWarning,
@@ -204,7 +200,7 @@ function BoxplotViz(props: VisualizationProps) {
         // set undefined for variable change
         checkedLegendItems: undefined,
       });
-      //DKDK close truncation warnings
+      // close truncation warnings
       setTruncatedDependentAxisWarning('');
     },
     [updateVizConfig]
@@ -395,7 +391,7 @@ function BoxplotViz(props: VisualizationProps) {
       ? data.value?.completeCasesAllVars
       : data.value?.completeCasesAxesVars;
 
-  //DKDK use custom hook
+  // use custom hook
   const defaultDependentAxisRange = useDefaultDependentAxisRange(
     data,
     vizConfig,
@@ -474,13 +470,13 @@ function BoxplotViz(props: VisualizationProps) {
       legendItems={legendItems}
       checkedLegendItems={checkedLegendItems}
       onCheckedLegendItemsChange={onCheckedLegendItemsChange}
-      //DKDK axis range control
+      // axis range control
       vizConfig={vizConfig}
       updateVizConfig={updateVizConfig}
       // add dependent axis range for better displaying tick labels in log-scale
       defaultDependentAxisRange={defaultDependentAxisRange}
       dependentAxisRange={vizConfig.dependentAxisRange}
-      //DKDK pass useState of truncation warnings
+      // pass useState of truncation warnings
       truncatedDependentAxisWarning={truncatedDependentAxisWarning}
       setTruncatedDependentAxisWarning={setTruncatedDependentAxisWarning}
     />
@@ -614,11 +610,11 @@ type BoxplotWithControlsProps = Omit<BoxplotProps, 'data'> & {
   legendItems: LegendItemsProps[];
   checkedLegendItems: string[] | undefined;
   onCheckedLegendItemsChange: (checkedLegendItems: string[]) => void;
-  //DKDK define types for axis range control
+  // define types for axis range control
   vizConfig: BoxplotConfig;
   updateVizConfig: (newConfig: Partial<BoxplotConfig>) => void;
   defaultDependentAxisRange: NumberRange | undefined;
-  //DKDK pass useState of truncation warnings
+  // pass useState of truncation warnings
   truncatedDependentAxisWarning: string;
   setTruncatedDependentAxisWarning: (
     truncatedDependentAxisWarning: string
@@ -632,11 +628,11 @@ function BoxplotWithControls({
   legendItems,
   checkedLegendItems,
   onCheckedLegendItemsChange,
-  //DKDK for axis range control
+  // for axis range control
   vizConfig,
   updateVizConfig,
   defaultDependentAxisRange,
-  //DKDK pass useState of truncation warnings
+  // pass useState of truncation warnings
   truncatedDependentAxisWarning,
   setTruncatedDependentAxisWarning,
   ...boxplotComponentProps
@@ -647,10 +643,7 @@ function BoxplotWithControls({
     [data, checkedLegendItems]
   );
 
-  console.log('defaultDependentAxisRange =', defaultDependentAxisRange);
-  console.log('vizConfig.dependentAxisRange =', vizConfig.dependentAxisRange);
-
-  //DKDK axis range control
+  // axis range control
   const handleDependentAxisRangeChange = useCallback(
     (newRange?: NumberRange) => {
       updateVizConfig({
@@ -664,7 +657,7 @@ function BoxplotWithControls({
     updateVizConfig({
       dependentAxisRange: defaultDependentAxisRange,
     });
-    //DKDK add reset for truncation message as well
+    // add reset for truncation message as well
     setTruncatedDependentAxisWarning('');
   }, [
     // defaultUIState.dependentAxisLogScale,
@@ -679,7 +672,7 @@ function BoxplotWithControls({
     truncationConfigDependentAxisMax,
   } = useMemo(
     () =>
-      //DKDK barplot does not have independent axis range control so send undefined for defaultUIState
+      // boxplot does not have independent axis range control so send undefined for defaultUIState
       truncationConfig(undefined, vizConfig, defaultDependentAxisRange),
     [
       vizConfig.xAxisVariable,
@@ -699,18 +692,10 @@ function BoxplotWithControls({
     }
   }, [truncationConfigDependentAxisMin, truncationConfigDependentAxisMax]);
 
-  console.log(
-    'truncationConfig = ',
-    truncationConfigIndependentAxisMin,
-    truncationConfigIndependentAxisMax,
-    truncationConfigDependentAxisMin,
-    truncationConfigDependentAxisMax
-  );
-
-  //DKDK send boxplotComponentProps with axisTruncationConfig
+  // send boxplotComponentProps with axisTruncationConfig
   const boxplotFacetProps = {
     ...boxplotComponentProps,
-    //DKDK pass axisTruncationConfig to faceted plot
+    // pass axisTruncationConfig to faceted plot
     axisTruncationConfig: {
       independentAxis: {
         min: truncationConfigIndependentAxisMin,
@@ -735,7 +720,7 @@ function BoxplotWithControls({
               data: data?.series,
             })),
           }}
-          //DKDK pass boxplotFacetProps
+          // pass boxplotFacetProps
           componentProps={boxplotFacetProps}
           modalComponentProps={{
             independentAxisLabel: boxplotComponentProps.independentAxisLabel,
@@ -753,9 +738,9 @@ function BoxplotWithControls({
           ref={plotRef}
           // for custom legend: pass checkedLegendItems to PlotlyPlot
           checkedLegendItems={checkedLegendItems}
-          //DKDK axis range control
+          // axis range control
           dependentAxisRange={vizConfig.dependentAxisRange}
-          //DKDK pass axisTruncationConfig
+          // pass axisTruncationConfig
           axisTruncationConfig={{
             independentAxis: {
               min: truncationConfigIndependentAxisMin,
@@ -773,10 +758,10 @@ function BoxplotWithControls({
 
       <div style={{ display: 'flex', flexDirection: 'row' }}>
         <LabelledGroup label="Y-axis">
-          {/* DKDK Y-axis range control */}
+          {/* Y-axis range control */}
           <NumberRangeInput
             label="Range"
-            //DKDK add range: for now, handle number only
+            // add range: for now, handle number only
             range={
               (vizConfig.dependentAxisRange as NumberRange) ??
               defaultDependentAxisRange
@@ -785,7 +770,7 @@ function BoxplotWithControls({
               handleDependentAxisRangeChange(newRange as NumberRange);
             }}
             allowPartialRange={false}
-            //DKDK set maxWidth
+            // set maxWidth
             containerStyles={{ maxWidth: '350px' }}
           />
           {/* truncation notification */}
@@ -799,13 +784,13 @@ function BoxplotWithControls({
                 setTruncatedDependentAxisWarning('');
               }}
               showWarningIcon={true}
-              //DKDK change maxWidth
+              // change maxWidth
               containerStyles={{ maxWidth: '350px' }}
             />
           ) : null}
           <Button
             type={'outlined'}
-            //DKDK change text
+            // change text
             text={'Reset to defaults'}
             onClick={handleDependentAxisSettingsReset}
             containerStyles={{

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -880,8 +880,14 @@ function HistogramPlotWithControls({
       )}
 
       <div style={{ display: 'flex', flexDirection: 'row' }}>
-        {/* DKDK make switch and radiobutton single line with space */}
-        <LabelledGroup label="Y-axis">
+        {/* DKDK make switch and radiobutton single line with space
+                 also marginRight at LabelledGroup is set to 0.5625em: default - 1.5625em*/}
+        <LabelledGroup
+          label="Y-axis"
+          containerStyles={{
+            marginRight: '0.5625em',
+          }}
+        >
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <Switch
               label="Log scale"
@@ -948,7 +954,12 @@ function HistogramPlotWithControls({
             }}
           />
         </LabelledGroup>
-        <LabelledGroup label="X-axis">
+        <LabelledGroup
+          label="X-axis"
+          containerStyles={{
+            marginRight: '0em',
+          }}
+        >
           <BinWidthControl
             binWidth={data0?.binWidth}
             onBinWidthChange={onBinWidthChange}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -82,7 +82,7 @@ import { EntityCounts } from '../../../hooks/entityCounts';
 // a custom hook to preserve the status of checked legend items
 import { useCheckedLegendItemsStatus } from '../../../hooks/checkedLegendItemsStatus';
 
-//DKDK concerning axis range control
+// concerning axis range control
 import {
   NumberOrDateRange,
   NumberRange,
@@ -90,20 +90,17 @@ import {
 } from '../../../types/general';
 import { padISODateTime } from '../../../utils/date-conversion';
 import { NumberRangeInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateRangeInputs';
-// reusable util for computing truncationConfig
-//DKDK temporarily use variant
-// import { truncationConfig } from '../../../utils/truncation-config-utils';
+// use variant
 import { truncationConfig } from '../../../utils/truncation-config-utils-viz';
 // use Notification for truncation warning message
 import Notification from '@veupathdb/components/lib/components/widgets//Notification';
 import Button from '@veupathdb/components/lib/components/widgets/Button';
 import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
 import { UIState } from '../../filter/HistogramFilter';
-//DKDKDK change defaultIndependentAxisRange to hook
+// change defaultIndependentAxisRange to hook
 import { useDefaultIndependentAxisRange } from '../../../hooks/computeDefaultIndependentAxisRange';
 import { useDefaultDependentAxisRange } from '../../../hooks/computeDefaultDependentAxisRange';
 
-//DKDK
 export type HistogramDataWithCoverageStatistics = (
   | HistogramData
   | FacetedData<HistogramData>
@@ -171,7 +168,7 @@ export const HistogramConfig = t.intersection([
     showMissingness: t.boolean,
     // for custom legend: vizconfig.checkedLegendItems
     checkedLegendItems: t.array(t.string),
-    //DKDK axis range control
+    // axis range control
     independentAxisRange: NumberOrDateRange,
     dependentAxisRange: NumberRange,
   }),
@@ -214,7 +211,7 @@ function HistogramViz(props: VisualizationProps) {
     [updateConfiguration, vizConfig]
   );
 
-  //DKDK set the state of truncation warning message
+  // set the state of truncation warning message here
   const [
     truncatedIndependentAxisWarning,
     setTruncatedIndependentAxisWarning,
@@ -241,10 +238,10 @@ function HistogramViz(props: VisualizationProps) {
         binWidthTimeUnit: keepBin ? vizConfig.binWidthTimeUnit : undefined,
         // set undefined for variable change
         checkedLegendItems: undefined,
-        //DKDKDK set independentAxisRange undefined
+        // set independentAxisRange undefined
         independentAxisRange: undefined,
       });
-      //DKDK close truncation warnings
+      // close truncation warnings if exists
       setTruncatedIndependentAxisWarning('');
       setTruncatedDependentAxisWarning('');
     },
@@ -422,23 +419,24 @@ function HistogramViz(props: VisualizationProps) {
       overlayVariable,
       facetVariable,
       valueType,
-      //DKDK get data when changing independentAxisRange
+      // get data when changing independentAxisRange
       vizConfig.independentAxisRange,
     ])
   );
 
-  //DKDK use hook
+  // use custom hook
   const defaultIndependentRange = useDefaultIndependentAxisRange(
     xAxisVariable,
     'histogram',
     updateVizConfig
   );
 
-  // DKDK using custom hook
+  // use custom hook
   const defaultDependentAxisRange = useDefaultDependentAxisRange(
     data,
     vizConfig,
-    updateVizConfig
+    updateVizConfig,
+    'Histogram'
   );
 
   // custom legend items for checkbox
@@ -487,7 +485,7 @@ function HistogramViz(props: VisualizationProps) {
     vizConfig.checkedLegendItems
   );
 
-  //DKDK axis range control
+  // axis range control
   // get as much default axis range from variable annotations as possible
   const defaultUIState: UIState = useMemo(() => {
     if (xAxisVariable != null) {
@@ -517,7 +515,6 @@ function HistogramViz(props: VisualizationProps) {
         ...otherDefaults,
       };
     } else {
-      //DKDK this may need a better refinement
       return {
         binWidth: 0,
         binWidthTimeUnit: undefined,
@@ -615,7 +612,7 @@ function HistogramViz(props: VisualizationProps) {
         onCheckedLegendItemsChange={onCheckedLegendItemsChange}
         totalCounts={totalCounts}
         filteredCounts={filteredCounts}
-        //DKDK axis range control
+        // axis range control
         vizConfig={vizConfig}
         updateVizConfig={updateVizConfig}
         valueType={valueType}
@@ -623,7 +620,7 @@ function HistogramViz(props: VisualizationProps) {
         defaultIndependentRange={defaultIndependentRange}
         // add dependent axis range for better displaying tick labels in log-scale
         defaultDependentAxisRange={defaultDependentAxisRange}
-        //DKDK pass useState of truncation warnings
+        // pass truncation warning props
         truncatedIndependentAxisWarning={truncatedIndependentAxisWarning}
         setTruncatedIndependentAxisWarning={setTruncatedIndependentAxisWarning}
         truncatedDependentAxisWarning={truncatedDependentAxisWarning}
@@ -655,14 +652,14 @@ type HistogramPlotWithControlsProps = Omit<HistogramProps, 'data'> & {
   onCheckedLegendItemsChange: (checkedLegendItems: string[]) => void;
   totalCounts: PromiseHookState<EntityCounts>;
   filteredCounts: PromiseHookState<EntityCounts>;
-  //DKDK define types for axis range control
+  // define types for axis range control
   vizConfig: HistogramConfig;
   updateVizConfig: (newConfig: Partial<HistogramConfig>) => void;
   valueType: 'number' | 'date';
   defaultUIState: UIState;
   defaultIndependentRange: NumberOrDateRange | undefined;
   defaultDependentAxisRange: NumberRange | undefined;
-  //DKDK pass useState of truncation warnings
+  // pass truncation warning props
   truncatedIndependentAxisWarning: string;
   setTruncatedIndependentAxisWarning: (
     truncatedIndependentAxisWarning: string
@@ -698,14 +695,14 @@ function HistogramPlotWithControls({
   onCheckedLegendItemsChange,
   totalCounts,
   filteredCounts,
-  //DKDK for axis range control
+  // for axis range control
   vizConfig,
   updateVizConfig,
   valueType,
   defaultUIState,
   defaultIndependentRange,
   defaultDependentAxisRange,
-  //DKDK pass useState of truncation warnings
+  // pass truncation warning props
   truncatedIndependentAxisWarning,
   setTruncatedIndependentAxisWarning,
   truncatedDependentAxisWarning,
@@ -734,12 +731,7 @@ function HistogramPlotWithControls({
         ?.data
     : data;
 
-  // console.log('defaultIndependentRange =', defaultIndependentRange)
-  // console.log('vizConfig.independentAxisRange =', vizConfig.independentAxisRange)
-  console.log('defaultDependentAxisRange =', defaultDependentAxisRange);
-  console.log('vizConfig.dependentAxisRange =', vizConfig.dependentAxisRange);
-
-  //DKDK axis range control
+  // axis range control
   const handleIndependentAxisRangeChange = useCallback(
     (newRange?: NumberOrDateRange) => {
       updateVizConfig({
@@ -756,6 +748,8 @@ function HistogramPlotWithControls({
                 : newRange.max,
           } as NumberOrDateRange),
       });
+      // need to close TruncatedDependentAxisWarning
+      setTruncatedDependentAxisWarning('');
     },
     [updateVizConfig]
   );
@@ -763,11 +757,10 @@ function HistogramPlotWithControls({
   const handleIndependentAxisSettingsReset = useCallback(() => {
     updateVizConfig({
       independentAxisRange: defaultUIState.independentAxisRange,
-      //DKDK this needs to be considered... ?
       binWidth: defaultUIState.binWidth,
       binWidthTimeUnit: defaultUIState.binWidthTimeUnit,
     });
-    //DKDK add reset for truncation message: including dependent axis warning as well
+    // add reset for truncation message: including dependent axis warning as well
     setTruncatedIndependentAxisWarning('');
     setTruncatedDependentAxisWarning('');
   }, [
@@ -790,15 +783,10 @@ function HistogramPlotWithControls({
     updateVizConfig({
       dependentAxisRange: defaultDependentAxisRange,
       dependentAxisLogScale: false,
-      //DKDK valueSpec should not be changed when resetting ?
-      // valueSpec: 'count',
     });
-    //DKDK add reset for truncation message as well
+    // add reset for truncation message as well
     setTruncatedDependentAxisWarning('');
-  }, [
-    // defaultUIState.dependentAxisLogScale,
-    updateVizConfig,
-  ]);
+  }, [updateVizConfig]);
 
   // set truncation flags: will see if this is reusable with other application
   const {
@@ -841,22 +829,13 @@ function HistogramPlotWithControls({
     }
   }, [truncationConfigDependentAxisMin, truncationConfigDependentAxisMax]);
 
-  console.log(
-    'truncationConfig = ',
-    truncationConfigIndependentAxisMin,
-    truncationConfigIndependentAxisMax,
-    truncationConfigDependentAxisMin,
-    truncationConfigDependentAxisMax
-  );
-
-  //DKDK send histogramProps with additional props
-  console.log('histogramProps =', histogramProps);
+  // send histogramProps with additional props
   const histogramPlotProps = {
     ...histogramProps,
-    //DKDK axis range control
+    // axis range control
     independentAxisRange: vizConfig.independentAxisRange,
     dependentAxisRange: vizConfig.dependentAxisRange,
-    //DKDK pass axisTruncationConfig
+    // pass axisTruncationConfig props
     axisTruncationConfig: {
       independentAxis: {
         min: truncationConfigIndependentAxisMin,
@@ -874,7 +853,7 @@ function HistogramPlotWithControls({
       {isFaceted(data) ? (
         <FacetedHistogram
           data={data}
-          //DKDK send histogramProps with additional props
+          // send histogramProps with additional props
           componentProps={histogramPlotProps}
           modalComponentProps={{
             independentAxisLabel: histogramProps.independentAxisLabel,
@@ -896,10 +875,10 @@ function HistogramPlotWithControls({
           showValues={false}
           // for custom legend: pass checkedLegendItems to PlotlyPlot
           checkedLegendItems={checkedLegendItems}
-          //DKDK axis range control
+          // axis range control
           independentAxisRange={vizConfig.independentAxisRange}
           dependentAxisRange={vizConfig.dependentAxisRange}
-          //DKDK pass axisTruncationConfig
+          // pass axisTruncationConfig
           axisTruncationConfig={{
             independentAxis: {
               min: truncationConfigIndependentAxisMin,
@@ -914,7 +893,7 @@ function HistogramPlotWithControls({
       )}
 
       <div style={{ display: 'flex', flexDirection: 'row' }}>
-        {/* DKDK make switch and radiobutton single line with space
+        {/* make switch and radiobutton single line with space
                  also marginRight at LabelledGroup is set to 0.5625em: default - 1.5625em*/}
         <LabelledGroup
           label="Y-axis"
@@ -944,18 +923,15 @@ function HistogramPlotWithControls({
               }}
             />
           </div>
-          {/* DKDK Y-axis range control */}
+          {/* Y-axis range control */}
           <NumberRangeInput
             label="Range"
-            //DKDK ???
             range={vizConfig.dependentAxisRange ?? defaultDependentAxisRange}
-            // range={defaultDependentAxisRange}
-            // range={vizConfig.dependentAxisRange}
             onRangeChange={(newRange?: NumberOrDateRange) => {
               handleDependentAxisRangeChange(newRange as NumberRange);
             }}
             allowPartialRange={false}
-            //DKDK set maxWidth
+            // set maxWidth
             containerStyles={{ maxWidth: '350px' }}
           />
           {/* truncation notification */}
@@ -969,13 +945,12 @@ function HistogramPlotWithControls({
                 setTruncatedDependentAxisWarning('');
               }}
               showWarningIcon={true}
-              //DKDK change maxWidth
+              // change maxWidth
               containerStyles={{ maxWidth: '350px' }}
             />
           ) : null}
           <Button
             type={'outlined'}
-            //DKDK change text
             text={'Reset to defaults'}
             onClick={handleDependentAxisSettingsReset}
             containerStyles={{
@@ -1009,18 +984,18 @@ function HistogramPlotWithControls({
             }
             containerStyles={{
               minHeight: widgetHeight,
-              //DKDK set maxWidth
+              // set maxWidth
               maxWidth: valueType === 'date' ? '250px' : '350px',
             }}
           />
 
-          {/* DKDK X-Axis range control - temp block to check date  */}
+          {/* X-Axis range control - temp block to check date  */}
           <AxisRangeControl
             label="Range"
             range={vizConfig.independentAxisRange ?? defaultIndependentRange}
             onRangeChange={handleIndependentAxisRangeChange}
             valueType={valueType}
-            //DKDK set maxWidth
+            // set maxWidth
             containerStyles={{ maxWidth: '350px' }}
           />
           {/* truncation notification */}
@@ -1034,7 +1009,7 @@ function HistogramPlotWithControls({
                 setTruncatedIndependentAxisWarning('');
               }}
               showWarningIcon={true}
-              //DKDKDK need to check this...
+              // set maxWidth per type
               containerStyles={{
                 maxWidth: valueType === 'date' ? '350px' : '350px',
               }}
@@ -1042,7 +1017,6 @@ function HistogramPlotWithControls({
           ) : null}
           <Button
             type={'outlined'}
-            //DKDK change text
             text={'Reset to defaults'}
             onClick={handleIndependentAxisSettingsReset}
             containerStyles={{

--- a/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
@@ -6,7 +6,14 @@ import {
   HistogramConfig,
   findMinMaxOfStackedArray,
 } from '../components/visualizations/implementations/HistogramVisualization';
-import { HistogramData } from '@veupathdb/components/lib/types/plots';
+import {
+  HistogramData,
+  BarplotData,
+} from '@veupathdb/components/lib/types/plots';
+import {
+  BarplotDataWithStatistics,
+  BarplotConfig,
+} from '../components/visualizations/implementations/BarplotVisualization';
 import { min, max, map } from 'lodash';
 
 /**
@@ -21,35 +28,36 @@ type defaultDependentAxisRangeProps =
   | undefined;
 
 export function useDefaultDependentAxisRange(
-  data: PromiseHookState<HistogramDataWithCoverageStatistics | undefined>,
-  vizConfig: HistogramConfig,
-  updateVizConfig: (newConfig: Partial<HistogramConfig>) => void
+  data: PromiseHookState<
+    HistogramDataWithCoverageStatistics | BarplotDataWithStatistics | undefined
+  >,
+  vizConfig: HistogramConfig | BarplotConfig,
+  updateVizConfig: (
+    newConfig: Partial<HistogramConfig | BarplotConfig>
+  ) => void,
+  plotType?: 'Histogram' | 'Barplot' | undefined
 ): defaultDependentAxisRangeProps {
   // find max of stacked array, especially with overlayVariable
   const defaultDependentAxisMinMax = useMemo(() => {
-    if (isFaceted(data.value)) {
-      const facetMinMaxes =
-        data?.value?.facets != null
-          ? data.value.facets
-              .map((facet) => facet.data)
-              .filter(
-                (data): data is HistogramData =>
-                  data != null && data.series != null
-              )
-              .map((data) => findMinMaxOfStackedArray(data.series))
-          : undefined;
-      return (
-        facetMinMaxes && {
-          min: min(map(facetMinMaxes, 'min')),
-          max: max(map(facetMinMaxes, 'max')),
-        }
+    if (plotType == null || plotType == 'Histogram') {
+      return histogramDefaultDependentAxisMinMax(
+        data as PromiseHookState<
+          HistogramDataWithCoverageStatistics | undefined
+        >
       );
-    } else {
-      return data.value && data.value.series.length > 0
-        ? findMinMaxOfStackedArray(data.value.series)
-        : undefined;
+    } else if (plotType == 'Barplot') {
+      //DKDK barplot only computes max value
+      return {
+        min: 0,
+        max: barplotDefaultDependentAxisMax(
+          data as PromiseHookState<BarplotDataWithStatistics | undefined>
+        ),
+      };
     }
   }, [data]);
+
+  // //DKDK
+  // console.log('defaultDependentAxisMinMax =', defaultDependentAxisMinMax)
 
   // DKDK set useMemo to avoid infinite loop
   // set default dependent axis range for better displaying tick labels in log-scale
@@ -63,6 +71,8 @@ export function useDefaultDependentAxisRange(
               ? 0
               : vizConfig.dependentAxisLogScale
               ? // determine min based on data for log-scale at proportion
+                // need to check defaultDependentAxisMinMax.min !== 0
+                defaultDependentAxisMinMax.min !== 0 &&
                 defaultDependentAxisMinMax.min < 0.001
                 ? defaultDependentAxisMinMax.min * 0.8
                 : 0.001
@@ -84,10 +94,62 @@ export function useDefaultDependentAxisRange(
 
   // update vizConfig.dependentAxisRange as it is necessary for set range correctly
   useLayoutEffect(() => {
-    updateVizConfigRef.current({
-      dependentAxisRange: defaultDependentAxisRange,
-    });
+    //DKDKDK data.pending
+    if (!data.pending)
+      updateVizConfigRef.current({
+        dependentAxisRange: defaultDependentAxisRange,
+      });
+    else
+      updateVizConfigRef.current({
+        dependentAxisRange: undefined,
+      });
   }, [data, defaultDependentAxisRange]);
 
   return defaultDependentAxisRange;
+}
+
+function histogramDefaultDependentAxisMinMax(
+  data: PromiseHookState<HistogramDataWithCoverageStatistics | undefined>
+): any {
+  if (isFaceted(data.value)) {
+    const facetMinMaxes =
+      data?.value?.facets != null
+        ? data.value.facets
+            .map((facet) => facet.data)
+            .filter(
+              (data): data is HistogramData =>
+                data != null && data.series != null
+            )
+            .map((data) => findMinMaxOfStackedArray(data.series))
+        : undefined;
+    return (
+      facetMinMaxes && {
+        min: min(map(facetMinMaxes, 'min')),
+        max: max(map(facetMinMaxes, 'max')),
+      }
+    );
+  } else {
+    return data.value && data.value.series.length > 0
+      ? findMinMaxOfStackedArray(data.value.series)
+      : undefined;
+  }
+}
+
+//DKDK compute max only
+function barplotDefaultDependentAxisMax(
+  data: PromiseHookState<BarplotDataWithStatistics | undefined>
+): any {
+  if (isFaceted(data?.value)) {
+    return data?.value?.facets != null
+      ? max(
+          data.value.facets
+            .filter((facet) => facet.data != null)
+            .flatMap((facet) => facet.data?.series.flatMap((o) => o.value))
+        )
+      : undefined;
+  } else {
+    return data?.value?.series != null
+      ? max(data.value.series.flatMap((o) => o.value))
+      : undefined;
+  }
 }

--- a/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
@@ -89,13 +89,5 @@ export function useDefaultDependentAxisRange(
     });
   }, [data, defaultDependentAxisRange]);
 
-  // //DKDKDK will this work ???
-  // const updateDependentAxisRange = useCallback(() => {
-  //   updateVizConfigRef.current({
-  //     dependentAxisRange: defaultDependentAxisRange,
-  //   });
-  // }, [data, defaultDependentAxisRange, vizConfig.valueSpec])
-  // updateDependentAxisRange();
-
   return defaultDependentAxisRange;
 }

--- a/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
@@ -1,0 +1,101 @@
+import { useMemo, useRef, useLayoutEffect, useCallback } from 'react';
+import { PromiseHookState } from './promise';
+import { isFaceted } from '@veupathdb/components/lib/types/guards';
+import {
+  HistogramDataWithCoverageStatistics,
+  HistogramConfig,
+  findMinMaxOfStackedArray,
+} from '../components/visualizations/implementations/HistogramVisualization';
+import { HistogramData } from '@veupathdb/components/lib/types/plots';
+import { min, max, map } from 'lodash';
+
+/**
+ * A custom hook to compute default dependent axis range
+ */
+
+type defaultDependentAxisRangeProps =
+  | {
+      min: number;
+      max: number;
+    }
+  | undefined;
+
+export function useDefaultDependentAxisRange(
+  data: PromiseHookState<HistogramDataWithCoverageStatistics | undefined>,
+  vizConfig: HistogramConfig,
+  updateVizConfig: (newConfig: Partial<HistogramConfig>) => void
+): defaultDependentAxisRangeProps {
+  // find max of stacked array, especially with overlayVariable
+  const defaultDependentAxisMinMax = useMemo(() => {
+    if (isFaceted(data.value)) {
+      const facetMinMaxes =
+        data?.value?.facets != null
+          ? data.value.facets
+              .map((facet) => facet.data)
+              .filter(
+                (data): data is HistogramData =>
+                  data != null && data.series != null
+              )
+              .map((data) => findMinMaxOfStackedArray(data.series))
+          : undefined;
+      return (
+        facetMinMaxes && {
+          min: min(map(facetMinMaxes, 'min')),
+          max: max(map(facetMinMaxes, 'max')),
+        }
+      );
+    } else {
+      return data.value && data.value.series.length > 0
+        ? findMinMaxOfStackedArray(data.value.series)
+        : undefined;
+    }
+  }, [data]);
+
+  // DKDK set useMemo to avoid infinite loop
+  // set default dependent axis range for better displaying tick labels in log-scale
+  const defaultDependentAxisRange = useMemo(() => {
+    return defaultDependentAxisMinMax?.min != null &&
+      defaultDependentAxisMinMax?.max != null
+      ? {
+          // set min as 0 (count, proportion) for non-logscale
+          min:
+            vizConfig.valueSpec === 'count'
+              ? 0
+              : vizConfig.dependentAxisLogScale
+              ? // determine min based on data for log-scale at proportion
+                defaultDependentAxisMinMax.min < 0.001
+                ? defaultDependentAxisMinMax.min * 0.8
+                : 0.001
+              : 0,
+          max: defaultDependentAxisMinMax.max * 1.05,
+        }
+      : undefined;
+  }, [
+    defaultDependentAxisMinMax,
+    vizConfig.valueSpec,
+    vizConfig.dependentAxisLogScale,
+  ]);
+
+  // DKDK use this to avoid infinite loop: also use useLayoutEffect to avoid async/ghost issue
+  const updateVizConfigRef = useRef(updateVizConfig);
+  useLayoutEffect(() => {
+    updateVizConfigRef.current = updateVizConfig;
+  }, [updateVizConfig]);
+
+  // update vizConfig.dependentAxisRange as it is necessary for set range correctly
+  useLayoutEffect(() => {
+    updateVizConfigRef.current({
+      dependentAxisRange: defaultDependentAxisRange,
+    });
+  }, [data, defaultDependentAxisRange]);
+
+  // //DKDKDK will this work ???
+  // const updateDependentAxisRange = useCallback(() => {
+  //   updateVizConfigRef.current({
+  //     dependentAxisRange: defaultDependentAxisRange,
+  //   });
+  // }, [data, defaultDependentAxisRange, vizConfig.valueSpec])
+  // updateDependentAxisRange();
+
+  return defaultDependentAxisRange;
+}

--- a/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useLayoutEffect, useCallback } from 'react';
+import { useMemo, useRef, useLayoutEffect } from 'react';
 import { PromiseHookState } from './promise';
 import { isFaceted } from '@veupathdb/components/lib/types/guards';
 import {
@@ -6,10 +6,7 @@ import {
   HistogramConfig,
   findMinMaxOfStackedArray,
 } from '../components/visualizations/implementations/HistogramVisualization';
-import {
-  HistogramData,
-  BarplotData,
-} from '@veupathdb/components/lib/types/plots';
+import { HistogramData } from '@veupathdb/components/lib/types/plots';
 import {
   BarplotDataWithStatistics,
   BarplotConfig,
@@ -40,7 +37,7 @@ export function useDefaultDependentAxisRange(
     | undefined
   >,
   vizConfig: HistogramConfig | BarplotConfig | BoxplotConfig,
-  //DKDK HistogramConfig contains most options
+  // HistogramConfig contains most options
   updateVizConfig: (newConfig: Partial<HistogramConfig>) => void,
   plotType?: 'Histogram' | 'Barplot' | 'Boxplot' | undefined,
   yAxisVariable?: Variable
@@ -54,14 +51,14 @@ export function useDefaultDependentAxisRange(
         >
       );
     else if (plotType == 'Barplot')
-      //DKDK barplot only computes max value
+      // barplot only computes max value
       return {
         min: 0,
         max: barplotDefaultDependentAxisMax(
           data as PromiseHookState<BarplotDataWithStatistics | undefined>
         ),
       };
-    //DKDK to-do
+    // boxplot
     else if (plotType === 'Boxplot')
       return boxplotDefaultDependentAxisMinMax(
         data as PromiseHookState<BoxplotDataWithCoverage | undefined>,
@@ -69,17 +66,14 @@ export function useDefaultDependentAxisRange(
       );
   }, [data]);
 
-  // //DKDK
-  // console.log('defaultDependentAxisMinMax =', defaultDependentAxisMinMax)
-
-  // DKDK set useMemo to avoid infinite loop
+  // set useMemo to avoid infinite loop
   // set default dependent axis range for better displaying tick labels in log-scale
   const defaultDependentAxisRange = useMemo(() => {
     if (plotType === 'Histogram' || plotType === 'Barplot')
       return defaultDependentAxisMinMax?.min != null &&
         defaultDependentAxisMinMax?.max != null
         ? {
-            // set min as 0 (count, proportion) for non-logscale
+            // set min as 0 (count, proportion) for non-logscale for histogram/barplot
             min:
               (vizConfig as HistogramConfig | BarplotConfig).valueSpec ===
               'count'
@@ -96,7 +90,7 @@ export function useDefaultDependentAxisRange(
             max: defaultDependentAxisMinMax.max * 1.05,
           }
         : undefined;
-    //DKDK to-do
+    // boxplot
     else if (plotType === 'Boxplot')
       return defaultDependentAxisMinMax?.min != null &&
         defaultDependentAxisMinMax?.max != null
@@ -111,7 +105,7 @@ export function useDefaultDependentAxisRange(
     (vizConfig as HistogramConfig | BarplotConfig).dependentAxisLogScale,
   ]);
 
-  // DKDK use this to avoid infinite loop: also use useLayoutEffect to avoid async/ghost issue
+  // use this to avoid infinite loop: also use useLayoutEffect to avoid async/ghost issue
   const updateVizConfigRef = useRef(updateVizConfig);
   useLayoutEffect(() => {
     updateVizConfigRef.current = updateVizConfig;
@@ -119,7 +113,6 @@ export function useDefaultDependentAxisRange(
 
   // update vizConfig.dependentAxisRange as it is necessary for set range correctly
   useLayoutEffect(() => {
-    //DKDKDK data.pending
     if (!data.pending)
       updateVizConfigRef.current({
         dependentAxisRange: defaultDependentAxisRange,
@@ -160,7 +153,7 @@ function histogramDefaultDependentAxisMinMax(
   }
 }
 
-//DKDK compute max only
+// compute max only
 function barplotDefaultDependentAxisMax(
   data: PromiseHookState<BarplotDataWithStatistics | undefined>
 ) {

--- a/src/lib/core/hooks/computeDefaultIndependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultIndependentAxisRange.ts
@@ -1,0 +1,80 @@
+import { useMemo, useRef, useLayoutEffect } from 'react';
+import { DateVariable, NumberVariable, Variable } from '../types/study';
+import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
+import { HistogramConfig } from '../components/visualizations/implementations/HistogramVisualization';
+
+export function defaultIndependentAxisRangeFunction(
+  variable: Variable | undefined,
+  plotName: string
+): NumberOrDateRange | undefined {
+  // make universal range variable
+  if (variable != null) {
+    if (NumberVariable.is(variable)) {
+      return variable.displayRangeMin != null &&
+        variable.displayRangeMax != null
+        ? {
+            min: Math.min(variable.displayRangeMin, variable.rangeMin),
+            max: Math.max(variable.displayRangeMax, variable.rangeMax),
+          }
+        : {
+            // separate histogram following the criterion at histogram filter
+            min:
+              plotName === 'histogram'
+                ? Math.min(0, variable.rangeMin)
+                : variable.rangeMin,
+            max: variable.rangeMax,
+          };
+    } else if (DateVariable.is(variable)) {
+      return variable.displayRangeMin != null &&
+        variable.displayRangeMax != null
+        ? {
+            min:
+              [variable.displayRangeMin, variable.rangeMin].reduce(function (
+                a,
+                b
+              ) {
+                return a < b ? a : b;
+              }) + 'T00:00:00Z',
+            max:
+              [variable.displayRangeMax, variable.rangeMax].reduce(function (
+                a,
+                b
+              ) {
+                return a > b ? a : b;
+              }) + 'T00:00:00Z',
+          }
+        : {
+            min: variable.rangeMin + 'T00:00:00Z',
+            max: variable.rangeMax + 'T00:00:00Z',
+          };
+    }
+  } else return undefined;
+}
+
+export function useDefaultIndependentAxisRange(
+  variable: Variable | undefined,
+  plotName: string,
+  updateVizConfig: (newConfig: Partial<HistogramConfig>) => void
+): NumberOrDateRange | undefined {
+  const defaultIndependentAxisRange:
+    | NumberOrDateRange
+    | undefined = useMemo(
+    () => defaultIndependentAxisRangeFunction(variable, plotName),
+    [variable, plotName]
+  );
+
+  //DKDK use this to avoid infinite loop: also use useLayoutEffect to avoid async/ghost issue
+  const updateVizConfigRefInd = useRef(updateVizConfig);
+  useLayoutEffect(() => {
+    updateVizConfigRefInd.current = updateVizConfig;
+  }, [updateVizConfig]);
+
+  // update vizConfig.dependentAxisRange as it is necessary for set range correctly
+  useLayoutEffect(() => {
+    updateVizConfigRefInd.current({
+      independentAxisRange: defaultIndependentAxisRange,
+    });
+  }, [defaultIndependentAxisRange]);
+
+  return defaultIndependentAxisRange;
+}

--- a/src/lib/core/hooks/computeDefaultIndependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultIndependentAxisRange.ts
@@ -2,6 +2,8 @@ import { useMemo, useRef, useLayoutEffect } from 'react';
 import { DateVariable, NumberVariable, Variable } from '../types/study';
 import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
 import { HistogramConfig } from '../components/visualizations/implementations/HistogramVisualization';
+// adding margin for scatter plot range
+import { axisRangeMargin } from '../utils/axis-range-margin';
 
 export function defaultIndependentAxisRangeFunction(
   variable: Variable | undefined,
@@ -56,14 +58,20 @@ export function useDefaultIndependentAxisRange(
   plotName: string,
   updateVizConfig: (newConfig: Partial<HistogramConfig>) => void
 ): NumberOrDateRange | undefined {
+  // consider both histogram and scatterplot at once
   const defaultIndependentAxisRange:
     | NumberOrDateRange
-    | undefined = useMemo(
-    () => defaultIndependentAxisRangeFunction(variable, plotName),
-    [variable, plotName]
-  );
+    | undefined = useMemo(() => {
+    const defaultIndependentRange = defaultIndependentAxisRangeFunction(
+      variable,
+      plotName
+    );
+    return plotName === 'scatterplot'
+      ? axisRangeMargin(defaultIndependentRange, variable?.type)
+      : defaultIndependentRange;
+  }, [variable, plotName]);
 
-  //DKDK use this to avoid infinite loop: also use useLayoutEffect to avoid async/ghost issue
+  // use this to avoid infinite loop: also use useLayoutEffect to avoid async/ghost issue
   const updateVizConfigRefInd = useRef(updateVizConfig);
   useLayoutEffect(() => {
     updateVizConfigRefInd.current = updateVizConfig;

--- a/src/lib/core/hooks/computeNumberDateDefaultDependentAxisRange.ts
+++ b/src/lib/core/hooks/computeNumberDateDefaultDependentAxisRange.ts
@@ -1,0 +1,59 @@
+import { useMemo, useRef, useLayoutEffect } from 'react';
+import { PromiseHookState } from './promise';
+import {
+  XYPlotDataWithCoverage,
+  ScatterplotConfig,
+} from '../components/visualizations/implementations/ScatterplotVisualization';
+import { Variable } from '../types/study';
+// for scatter plot
+import { numberDateDefaultDependentAxisRange } from '../utils/default-dependent-axis-range';
+import { axisRangeMargin } from '../utils/axis-range-margin';
+import { NumberOrDateRange } from '../types/general';
+
+/**
+ * A custom hook to compute default dependent axis range
+ */
+
+export function useDefaultDependentAxisRange(
+  data: PromiseHookState<XYPlotDataWithCoverage | undefined>,
+  vizConfig: ScatterplotConfig,
+  updateVizConfig: (newConfig: Partial<ScatterplotConfig>) => void,
+  yAxisVariable?: Variable
+): NumberOrDateRange | undefined {
+  // find max of stacked array, especially with overlayVariable
+  const defaultDependentAxisRange = useMemo(() => {
+    //K set yMinMaxRange using yMin/yMax obtained from processInputData()
+    const yMinMaxRange =
+      data.value != null
+        ? { min: data.value.yMin, max: data.value?.yMax }
+        : undefined;
+
+    const defaultDependentRange = numberDateDefaultDependentAxisRange(
+      yAxisVariable,
+      'scatterplot',
+      yMinMaxRange
+    );
+
+    return axisRangeMargin(defaultDependentRange, yAxisVariable?.type);
+  }, [data, yAxisVariable, vizConfig.valueSpecConfig]);
+
+  // use this to avoid infinite loop: also use useLayoutEffect to avoid async/ghost issue
+  const updateVizConfigRef = useRef(updateVizConfig);
+  useLayoutEffect(() => {
+    updateVizConfigRef.current = updateVizConfig;
+  }, [updateVizConfig]);
+
+  // update vizConfig.dependentAxisRange as it is necessary for set range correctly
+  useLayoutEffect(() => {
+    if (!data.pending)
+      updateVizConfigRef.current({
+        dependentAxisRange: defaultDependentAxisRange,
+      });
+    else
+      updateVizConfigRef.current({
+        dependentAxisRange: undefined,
+      });
+  }, [data, defaultDependentAxisRange]);
+
+  return defaultDependentAxisRange;
+}

--- a/src/lib/core/hooks/findOutputEntity.ts
+++ b/src/lib/core/hooks/findOutputEntity.ts
@@ -2,13 +2,21 @@ import { useMemo } from 'react';
 import { VariableDescriptor } from '../types/variable';
 import { StudyEntity } from '../types/study';
 import { useFindEntityAndVariable } from './study';
+// add NumberRange
+import { NumberOrDateRange } from '../types/general';
 
 export function useFindOutputEntity(
   dataElementDependencyOrder: string[] | undefined,
   // need to add string at Record's Type due to valueSpecConfig
   dataElementVariables: Record<
     string,
-    VariableDescriptor | string | boolean | string[] | undefined
+    // add NumberRange
+    | VariableDescriptor
+    | string
+    | boolean
+    | string[]
+    | NumberOrDateRange
+    | undefined
   >,
   defaultVariableName: string,
   entities: StudyEntity[]

--- a/src/lib/core/utils/axis-range-margin.ts
+++ b/src/lib/core/utils/axis-range-margin.ts
@@ -6,40 +6,42 @@ export function axisRangeMargin(
   valueType?: string | undefined
 ): NumberOrDateRange | undefined {
   // compute truncated axis with 5 % area from the range of min and max
-  if (valueType != null && valueType === 'date') {
-    // find date diff (days) between range.min and range.max, take 5 % of range, and round up!
-    const dateRangeDiff = Math.round(
-      DateMath.diff(
+  if (valueType != null) {
+    if (valueType === 'date') {
+      // find date diff (days) between range.min and range.max, take 5 % of range, and round up!
+      const dateRangeDiff = Math.round(
+        DateMath.diff(
+          new Date(axisRange?.min as string),
+          new Date(axisRange?.max as string),
+          'day'
+        ) * 0.05
+      ); // unit in days
+
+      const axisLowerExtensionStart = DateMath.subtract(
         new Date(axisRange?.min as string),
-        new Date(axisRange?.max as string),
+        dateRangeDiff,
         'day'
-      ) * 0.05
-    ); // unit in days
+      ).toISOString();
+      const axisUpperExtensionEnd = DateMath.add(
+        new Date(axisRange?.max as string),
+        dateRangeDiff,
+        'day'
+      ).toISOString();
 
-    const axisLowerExtensionStart = DateMath.subtract(
-      new Date(axisRange?.min as string),
-      dateRangeDiff,
-      'day'
-    ).toISOString();
-    const axisUpperExtensionEnd = DateMath.add(
-      new Date(axisRange?.max as string),
-      dateRangeDiff,
-      'day'
-    ).toISOString();
+      return {
+        min: axisLowerExtensionStart,
+        max: axisUpperExtensionEnd,
+      };
+    } else {
+      const axisLowerExtensionStart =
+        (axisRange?.min as number) * 1.05 - (axisRange?.max as number) * 0.05;
+      const axisUpperExtensionEnd =
+        (axisRange?.max as number) * 1.05 - (axisRange?.min as number) * 0.05;
 
-    return {
-      min: axisLowerExtensionStart,
-      max: axisUpperExtensionEnd,
-    };
-  } else {
-    const axisLowerExtensionStart =
-      (axisRange?.min as number) * 1.05 - (axisRange?.max as number) * 0.05;
-    const axisUpperExtensionEnd =
-      (axisRange?.max as number) * 1.05 - (axisRange?.min as number) * 0.05;
-
-    return {
-      min: axisLowerExtensionStart,
-      max: axisUpperExtensionEnd,
-    };
-  }
+      return {
+        min: axisLowerExtensionStart,
+        max: axisUpperExtensionEnd,
+      };
+    }
+  } else return undefined;
 }

--- a/src/lib/core/utils/default-dependent-axis-range.ts
+++ b/src/lib/core/utils/default-dependent-axis-range.ts
@@ -1,7 +1,7 @@
 import { Variable } from '../types/study';
 import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
 
-export function defaultDependentAxisRange(
+export function numberDateDefaultDependentAxisRange(
   variable: Variable | undefined,
   plotName: string,
   yMinMaxRange:

--- a/src/lib/core/utils/truncation-config-utils-viz.ts
+++ b/src/lib/core/utils/truncation-config-utils-viz.ts
@@ -1,34 +1,36 @@
 import { UIState } from '../components/filter/HistogramFilter';
 import { HistogramConfig } from '../components/visualizations/implementations/HistogramVisualization';
 import { NumberRange } from '../types/general';
+import { BarplotConfig } from '../components/visualizations/implementations/BarplotVisualization';
+import { BoxplotConfig } from '../components/visualizations/implementations/BoxplotVisualization';
 
 // function to compute truncation flags for Histogram-like
 // visualizations (continuous x-axis with known bounds, y-axis showing non-negative counts)
 export function truncationConfig(
   defaultUIState: UIState | undefined,
-  vizConfig: HistogramConfig,
+  vizConfig: HistogramConfig | BarplotConfig | BoxplotConfig,
   defaultDependentAxisRange: NumberRange | undefined
 ) {
   const truncationConfigIndependentAxisMin =
     defaultUIState == null
       ? false
-      : vizConfig?.independentAxisRange?.min == null
+      : (vizConfig as HistogramConfig)?.independentAxisRange?.min == null
       ? false
       : defaultUIState.independentAxisRange.min !==
-          vizConfig.independentAxisRange.min &&
+          (vizConfig as HistogramConfig)?.independentAxisRange?.min &&
         defaultUIState.independentAxisRange.min <
-          vizConfig.independentAxisRange.min
+          (vizConfig as HistogramConfig)?.independentAxisRange?.min!
       ? true
       : false;
   const truncationConfigIndependentAxisMax =
     defaultUIState == null
       ? false
-      : vizConfig?.independentAxisRange?.max == null
+      : (vizConfig as HistogramConfig)?.independentAxisRange?.max == null
       ? false
       : defaultUIState.independentAxisRange.max !==
-          vizConfig.independentAxisRange.max &&
+          (vizConfig as HistogramConfig)?.independentAxisRange?.max &&
         defaultUIState.independentAxisRange.max >
-          vizConfig.independentAxisRange.max
+          (vizConfig as HistogramConfig)?.independentAxisRange?.max!
       ? true
       : false;
 

--- a/src/lib/core/utils/truncation-config-utils-viz.ts
+++ b/src/lib/core/utils/truncation-config-utils-viz.ts
@@ -1,0 +1,54 @@
+import { UIState } from '../components/filter/HistogramFilter';
+import { HistogramConfig } from '../components/visualizations/implementations/HistogramVisualization';
+import { NumberRange } from '../types/general';
+
+// function to compute truncation flags for Histogram-like
+// visualizations (continuous x-axis with known bounds, y-axis showing non-negative counts)
+export function truncationConfig(
+  defaultUIState: UIState,
+  vizConfig: HistogramConfig,
+  defaultDependentAxisRange: NumberRange | undefined
+) {
+  // check whether truncated axis is required
+  const truncationConfigIndependentAxisMin =
+    vizConfig?.independentAxisRange?.min == null
+      ? false
+      : defaultUIState.independentAxisRange.min !==
+          vizConfig.independentAxisRange.min &&
+        defaultUIState.independentAxisRange.min <
+          vizConfig.independentAxisRange.min
+      ? true
+      : false;
+  const truncationConfigIndependentAxisMax =
+    vizConfig?.independentAxisRange?.max == null
+      ? false
+      : defaultUIState.independentAxisRange.max !==
+          vizConfig.independentAxisRange.max &&
+        defaultUIState.independentAxisRange.max >
+          vizConfig.independentAxisRange.max
+      ? true
+      : false;
+  const truncationConfigDependentAxisMin =
+    defaultDependentAxisRange?.min == null
+      ? false
+      : vizConfig?.dependentAxisRange?.min == null
+      ? false
+      : defaultDependentAxisRange.min != vizConfig.dependentAxisRange.min &&
+        defaultDependentAxisRange.min < vizConfig.dependentAxisRange.min
+      ? true
+      : false;
+  const truncationConfigDependentAxisMax =
+    defaultDependentAxisRange?.max == null
+      ? false
+      : vizConfig.dependentAxisRange?.max == null
+      ? false
+      : defaultDependentAxisRange.max != vizConfig.dependentAxisRange.max &&
+        defaultDependentAxisRange.max > vizConfig.dependentAxisRange.max;
+
+  return {
+    truncationConfigIndependentAxisMin,
+    truncationConfigIndependentAxisMax,
+    truncationConfigDependentAxisMin,
+    truncationConfigDependentAxisMax,
+  };
+}

--- a/src/lib/core/utils/truncation-config-utils-viz.ts
+++ b/src/lib/core/utils/truncation-config-utils-viz.ts
@@ -5,13 +5,14 @@ import { NumberRange } from '../types/general';
 // function to compute truncation flags for Histogram-like
 // visualizations (continuous x-axis with known bounds, y-axis showing non-negative counts)
 export function truncationConfig(
-  defaultUIState: UIState,
+  defaultUIState: UIState | undefined,
   vizConfig: HistogramConfig,
   defaultDependentAxisRange: NumberRange | undefined
 ) {
-  // check whether truncated axis is required
   const truncationConfigIndependentAxisMin =
-    vizConfig?.independentAxisRange?.min == null
+    defaultUIState == null
+      ? false
+      : vizConfig?.independentAxisRange?.min == null
       ? false
       : defaultUIState.independentAxisRange.min !==
           vizConfig.independentAxisRange.min &&
@@ -20,7 +21,9 @@ export function truncationConfig(
       ? true
       : false;
   const truncationConfigIndependentAxisMax =
-    vizConfig?.independentAxisRange?.max == null
+    defaultUIState == null
+      ? false
+      : vizConfig?.independentAxisRange?.max == null
       ? false
       : defaultUIState.independentAxisRange.max !==
           vizConfig.independentAxisRange.max &&
@@ -28,10 +31,15 @@ export function truncationConfig(
           vizConfig.independentAxisRange.max
       ? true
       : false;
+
+  //DKDK set a hard-corded condition for histogram and barplot for dependentAxisRange.min for now
   const truncationConfigDependentAxisMin =
     defaultDependentAxisRange?.min == null
       ? false
       : vizConfig?.dependentAxisRange?.min == null
+      ? false
+      : defaultDependentAxisRange.min === 0 &&
+        vizConfig.dependentAxisRange.min === 0.001
       ? false
       : defaultDependentAxisRange.min != vizConfig.dependentAxisRange.min &&
         defaultDependentAxisRange.min < vizConfig.dependentAxisRange.min

--- a/src/lib/core/utils/truncation-config-utils-viz.ts
+++ b/src/lib/core/utils/truncation-config-utils-viz.ts
@@ -1,24 +1,24 @@
 import { UIState } from '../components/filter/HistogramFilter';
 import { HistogramConfig } from '../components/visualizations/implementations/HistogramVisualization';
-import { NumberRange } from '../types/general';
+import { NumberRange, NumberOrDateRange } from '../types/general';
 import { BarplotConfig } from '../components/visualizations/implementations/BarplotVisualization';
 import { BoxplotConfig } from '../components/visualizations/implementations/BoxplotVisualization';
 
 // function to compute truncation flags for Histogram-like
 // visualizations (continuous x-axis with known bounds, y-axis showing non-negative counts)
 export function truncationConfig(
-  defaultUIState: UIState | undefined,
+  defaultUIState: Partial<UIState> | undefined,
   vizConfig: HistogramConfig | BarplotConfig | BoxplotConfig,
-  defaultDependentAxisRange: NumberRange | undefined
+  defaultDependentAxisRange: NumberRange | NumberOrDateRange | undefined
 ) {
   const truncationConfigIndependentAxisMin =
     defaultUIState == null
       ? false
       : (vizConfig as HistogramConfig)?.independentAxisRange?.min == null
       ? false
-      : defaultUIState.independentAxisRange.min !==
+      : defaultUIState?.independentAxisRange?.min !==
           (vizConfig as HistogramConfig)?.independentAxisRange?.min &&
-        defaultUIState.independentAxisRange.min <
+        defaultUIState?.independentAxisRange?.min! <
           (vizConfig as HistogramConfig)?.independentAxisRange?.min!
       ? true
       : false;
@@ -27,14 +27,14 @@ export function truncationConfig(
       ? false
       : (vizConfig as HistogramConfig)?.independentAxisRange?.max == null
       ? false
-      : defaultUIState.independentAxisRange.max !==
+      : defaultUIState?.independentAxisRange?.max !==
           (vizConfig as HistogramConfig)?.independentAxisRange?.max &&
-        defaultUIState.independentAxisRange.max >
+        defaultUIState?.independentAxisRange?.max! >
           (vizConfig as HistogramConfig)?.independentAxisRange?.max!
       ? true
       : false;
 
-  //DKDK set a hard-corded condition for histogram and barplot for dependentAxisRange.min for now
+  // set a hard-corded condition for histogram and barplot for dependentAxisRange.min for now
   const truncationConfigDependentAxisMin =
     defaultDependentAxisRange?.min == null
       ? false


### PR DESCRIPTION
Update: To use different size/width of axis range controls between histogram filter and Vizs, some changes are made here and web-components. Thus, now this PR relies on [the PR at web-components](https://github.com/VEuPathDB/web-components/pull/292) (`yarn link` is required)

This is the first step for adding zoom & truncation axis range controls to Vizs: tried to Histogram Viz only. I did not clean up the codes as it needs some updates but it would work out in most cases as of now.

Introduced/converted to custom hooks and functions that are intended for the use at other Vizs: but not that generic now, which will be changed.

Mostly works fine but there are known issues that need to be addressed: a) adjusting input form size as plot area is rather small; b) an instant discrepancy during multiple re-renderings between local value and vizConfig value. I need a help for b) from you, @dmfalke, @jtlong3rd, @bobular and others who are interested.

The issue I have is that computed `defaultIndependentAxisRange` and `defaultDependentAxisRange` have unsync with corresponding `vizConfig` (i.e., `vizConfig.independentAxisRange` and `vizConfig.dependentAxisRange`) at a point among multiple re-renderings. Please note that they eventually become the same at the end of re-rendering, so from the operation viewpoint, it is not an issue. But it causes to pop up an erroneous truncation warning message due to the instant discrepancy. Actually I could resolve the case of the `independentAxisRange` but still has the issue for `dependentAxisRange`. One exemplary use case is when switching the plot option from the Proportion to the Count: it is because the condition to pop up the warning message is `defaultDependentAxisRange` > `vizConfig.dependentAxisRange`. 
 
It would be great if you can check and suggest any idea to overcome the above issue. 