### PR TITLE
Update client to use the new hideFrom property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/core/components/filter/MultiFilter.tsx
+++ b/src/lib/core/components/filter/MultiFilter.tsx
@@ -74,7 +74,7 @@ export function MultiFilter(props: Props) {
       // This function uses {entity.id}/{variable.id} to generate a field's term
       // and parent property value. That is not desired here, so we have to do
       // some post-processing to use {variable.id} for those properties.
-      entitiesToFields([entity])
+      entitiesToFields([entity], 'variableTree')
         .filter((field) => !field.term.startsWith('entity:'))
         .map((field) => ({
           ...field,

--- a/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
+++ b/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
@@ -34,7 +34,7 @@ export default function MultiSelectVariableTree({
 }: MultiSelectVariableTreeProps) {
   const entities = useStudyEntities(rootEntity);
   const valuesMap = useValuesMap(entities);
-  const flattenedFields = useFlattenedFields(entities);
+  const flattenedFields = useFlattenedFields(entities, 'variableTree');
   const fieldsByTerm = useFlattenFieldsByTerm(flattenedFields);
   const fieldTree = useFieldTree(flattenedFields);
 

--- a/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
+++ b/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { Field } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/Types';
 
-import { StudyEntity } from '../../types/study';
+import { StudyEntity, VariableScope } from '../../types/study';
 import { VariableDescriptor } from '../../types/variable';
 import VariableList from './VariableList';
 import './VariableTree.scss';
@@ -17,6 +17,8 @@ import {
 export interface MultiSelectVariableTreeProps {
   /** The entity from which to derive the tree structure. */
   rootEntity: StudyEntity;
+  /** The "scope" of variables which should be offered. */
+  scope: VariableScope;
   /** Which variables have been selected? */
   selectedVariableDescriptors: Array<VariableDescriptor>;
   /** Callback to invoke when selected variables change. */
@@ -29,12 +31,13 @@ export interface MultiSelectVariableTreeProps {
  */
 export default function MultiSelectVariableTree({
   rootEntity,
+  scope,
   selectedVariableDescriptors,
   onSelectedVariablesChange,
 }: MultiSelectVariableTreeProps) {
   const entities = useStudyEntities(rootEntity);
   const valuesMap = useValuesMap(entities);
-  const flattenedFields = useFlattenedFields(entities, 'variableTree');
+  const flattenedFields = useFlattenedFields(entities, scope);
   const fieldsByTerm = useFlattenFieldsByTerm(flattenedFields);
   const fieldTree = useFieldTree(flattenedFields);
 

--- a/src/lib/core/components/variableTrees/VariableTree.tsx
+++ b/src/lib/core/components/variableTrees/VariableTree.tsx
@@ -42,7 +42,7 @@ export default function VariableTree({
   const valuesMap = useValuesMap(entities);
   const flattenedFields = useFlattenedFields(entities, 'variableTree');
   const fieldsByTerm = useFlattenFieldsByTerm(flattenedFields);
-  const featuredFields = useFeaturedFields(entities);
+  const featuredFields = useFeaturedFields(entities, 'variableTree');
   const fieldTree = useFieldTree(flattenedFields);
 
   const disabledFields = useMemo(

--- a/src/lib/core/components/variableTrees/VariableTree.tsx
+++ b/src/lib/core/components/variableTrees/VariableTree.tsx
@@ -40,7 +40,7 @@ export default function VariableTree({
 }: VariableTreeProps) {
   const entities = useStudyEntities(rootEntity);
   const valuesMap = useValuesMap(entities);
-  const flattenedFields = useFlattenedFields(entities);
+  const flattenedFields = useFlattenedFields(entities, 'variableTree');
   const fieldsByTerm = useFlattenFieldsByTerm(flattenedFields);
   const featuredFields = useFeaturedFields(entities);
   const fieldTree = useFieldTree(flattenedFields);

--- a/src/lib/core/components/variableTrees/VariableTree.tsx
+++ b/src/lib/core/components/variableTrees/VariableTree.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { StudyEntity } from '../../types/study';
+import { StudyEntity, VariableScope } from '../../types/study';
 import { VariableDescriptor } from '../../types/variable';
 import VariableList from './VariableList';
 import './VariableTree.scss';
@@ -25,6 +25,8 @@ export interface VariableTreeProps {
   onChange: (variable?: VariableDescriptor) => void;
   /** Indicate whether or not variables with children   */
   showMultiFilterDescendants?: boolean;
+  /** The "scope" of variables which should be offered. */
+  scope: VariableScope;
 }
 
 export default function VariableTree({
@@ -37,12 +39,13 @@ export default function VariableTree({
   variableId,
   onChange,
   showMultiFilterDescendants = false,
+  scope,
 }: VariableTreeProps) {
   const entities = useStudyEntities(rootEntity);
   const valuesMap = useValuesMap(entities);
-  const flattenedFields = useFlattenedFields(entities, 'variableTree');
+  const flattenedFields = useFlattenedFields(entities, scope);
   const fieldsByTerm = useFlattenFieldsByTerm(flattenedFields);
-  const featuredFields = useFeaturedFields(entities, 'variableTree');
+  const featuredFields = useFeaturedFields(entities, scope);
   const fieldTree = useFieldTree(flattenedFields);
 
   const disabledFields = useMemo(

--- a/src/lib/core/components/variableTrees/hooks.ts
+++ b/src/lib/core/components/variableTrees/hooks.ts
@@ -8,6 +8,7 @@ import { StudyEntity, VariableScope } from '../../types/study';
 import {
   edaVariableToWdkField,
   entitiesToFields,
+  shouldHideVariableInScope,
 } from '../../utils/wdk-filter-param-adapter';
 import { keyBy } from 'lodash';
 
@@ -57,12 +58,18 @@ export const useFlattenedFields = (
  * Similiarly to the `useFlattenedFields` hook, this hook will return
  * a flat list of Field objects.
  */
-export const useFeaturedFields = (entities: StudyEntity[]): Field[] =>
+export const useFeaturedFields = (
+  entities: StudyEntity[],
+  scope: VariableScope
+): Field[] =>
   useMemo(() => {
     return entities.flatMap((entity) =>
       entity.variables
         .filter(
-          (variable) => variable.type !== 'category' && variable.isFeatured
+          (variable) =>
+            !shouldHideVariableInScope(scope, variable) &&
+            variable.type !== 'category' &&
+            variable.isFeatured
         )
         .map((variable) => ({
           ...variable,
@@ -71,7 +78,7 @@ export const useFeaturedFields = (entities: StudyEntity[]): Field[] =>
         }))
         .map((variable) => edaVariableToWdkField(variable))
     );
-  }, [entities]);
+  }, [entities, scope]);
 
 /**
  * Construct a hierarchical representation of variable fields from

--- a/src/lib/core/components/variableTrees/hooks.ts
+++ b/src/lib/core/components/variableTrees/hooks.ts
@@ -1,13 +1,12 @@
 import { useMemo } from 'react';
 
 import { Field } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/Types';
-import { getTree } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/AttributeFilterUtils';
-import { pruneDescendantNodes } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 
 import { StudyEntity, VariableScope } from '../../types/study';
 import {
   edaVariableToWdkField,
   entitiesToFields,
+  makeFieldTree,
   makeHiddenVariablesInScope,
   shouldHideVariable,
 } from '../../utils/wdk-filter-param-adapter';
@@ -91,16 +90,7 @@ export const useFeaturedFields = (
  * or variable) in a visual hierachy to the user.
  */
 export const useFieldTree = (flattenedFields: Array<Field>) =>
-  useMemo(() => {
-    const initialTree = getTree(flattenedFields, {
-      hideSingleRoot: false,
-    });
-    const tree = pruneDescendantNodes(
-      (node) => node.field.type != null || node.children.length > 0,
-      initialTree
-    );
-    return tree;
-  }, [flattenedFields]);
+  useMemo(() => makeFieldTree(flattenedFields), [flattenedFields]);
 
 /**
  * Simple transformation of useFlattenFields output from an array

--- a/src/lib/core/components/variableTrees/hooks.ts
+++ b/src/lib/core/components/variableTrees/hooks.ts
@@ -8,7 +8,8 @@ import { StudyEntity, VariableScope } from '../../types/study';
 import {
   edaVariableToWdkField,
   entitiesToFields,
-  shouldHideVariableInScope,
+  makeHiddenVariablesInScope,
+  shouldHideVariable,
 } from '../../utils/wdk-filter-param-adapter';
 import { keyBy } from 'lodash';
 
@@ -63,11 +64,13 @@ export const useFeaturedFields = (
   scope: VariableScope
 ): Field[] =>
   useMemo(() => {
-    return entities.flatMap((entity) =>
-      entity.variables
+    return entities.flatMap((entity) => {
+      const hiddenVariablesInScope = makeHiddenVariablesInScope(entity, scope);
+
+      return entity.variables
         .filter(
           (variable) =>
-            !shouldHideVariableInScope(scope, variable) &&
+            !shouldHideVariable(hiddenVariablesInScope, variable) &&
             variable.type !== 'category' &&
             variable.isFeatured
         )
@@ -76,8 +79,8 @@ export const useFeaturedFields = (
           id: `${entity.id}/${variable.id}`,
           displayName: `<span class="Entity">${entity.displayName}</span>: ${variable.displayName}`,
         }))
-        .map((variable) => edaVariableToWdkField(variable))
-    );
+        .map((variable) => edaVariableToWdkField(variable));
+    });
   }, [entities, scope]);
 
 /**

--- a/src/lib/core/components/variableTrees/hooks.ts
+++ b/src/lib/core/components/variableTrees/hooks.ts
@@ -4,7 +4,7 @@ import { Field } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/Type
 import { getTree } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/AttributeFilterUtils';
 import { pruneDescendantNodes } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 
-import { StudyEntity } from '../../types/study';
+import { StudyEntity, VariableScope } from '../../types/study';
 import {
   edaVariableToWdkField,
   entitiesToFields,
@@ -45,8 +45,10 @@ export const useValuesMap = (entities: StudyEntity[]) =>
 /**
  * Memoized hook that delegates to {@link entitiesToFields}
  */
-export const useFlattenedFields = (entities: StudyEntity[]) =>
-  useMemo(() => entitiesToFields(entities), [entities]);
+export const useFlattenedFields = (
+  entities: StudyEntity[],
+  scope: VariableScope
+) => useMemo(() => entitiesToFields(entities, scope), [entities, scope]);
 
 /**
  * Identity "fields" from the entity hierarchy which have been marked

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -235,6 +235,7 @@ export function InputVariables(props: Props) {
               >
                 <div className={classes.label}>{input.label}</div>
                 <VariableTreeDropdown
+                  scope="variableTree"
                   showMultiFilterDescendants
                   rootEntity={entities[0]}
                   disabledVariables={disabledVariablesByInputName[input.name]}
@@ -267,6 +268,7 @@ export function InputVariables(props: Props) {
                 >
                   <div className={classes.label}>{input.label}</div>
                   <VariableTreeDropdown
+                    scope="variableTree"
                     showMultiFilterDescendants
                     rootEntity={entities[0]}
                     disabledVariables={disabledVariablesByInputName[input.name]}

--- a/src/lib/core/types/study.ts
+++ b/src/lib/core/types/study.ts
@@ -46,11 +46,18 @@ const VariableDisplayType = t.keyof({
   hidden: null,
 });
 
+export type VariableScope = t.TypeOf<typeof VariableScope>;
+export const VariableScope = t.keyof({
+  downloads: null,
+  variableTree: null,
+});
+
 export const VariableTreeNode_Base = t.intersection([
   t.type({
     id: t.string,
     providerLabel: t.string,
     displayName: t.string,
+    hideFrom: t.array(t.union([VariableScope, t.literal('everywhere')])),
   }),
   t.partial({
     parentId: t.string,

--- a/src/lib/core/types/study.ts
+++ b/src/lib/core/types/study.ts
@@ -48,7 +48,7 @@ const VariableDisplayType = t.keyof({
 
 export type VariableScope = t.TypeOf<typeof VariableScope>;
 export const VariableScope = t.keyof({
-  downloads: null,
+  download: null,
   variableTree: null,
 });
 

--- a/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
@@ -70,7 +70,7 @@ export default function SubsettingDataGridModal({
   const studyRecord = useStudyRecord();
   const studyMetadata = useStudyMetadata();
   const subsettingClient = useSubsettingClient();
-  const featuredFields = useFeaturedFields(entities);
+  const featuredFields = useFeaturedFields(entities, 'downloads');
   const flattenedFields = useFlattenedFields(entities, 'downloads');
 
   const [currentEntity, setCurrentEntity] = useState<StudyEntity | undefined>(
@@ -353,6 +353,7 @@ export default function SubsettingDataGridModal({
               // we only want a user to be able to select variables from a single
               // entity at a time.
               rootEntity={{ ...currentEntity, children: [] }}
+              scope="downloads"
               selectedVariableDescriptors={selectedVariableDescriptors}
               onSelectedVariablesChange={handleSelectedVariablesChange}
             />

--- a/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
@@ -70,8 +70,8 @@ export default function SubsettingDataGridModal({
   const studyRecord = useStudyRecord();
   const studyMetadata = useStudyMetadata();
   const subsettingClient = useSubsettingClient();
-  const featuredFields = useFeaturedFields(entities, 'downloads');
-  const flattenedFields = useFlattenedFields(entities, 'downloads');
+  const featuredFields = useFeaturedFields(entities, 'download');
+  const flattenedFields = useFlattenedFields(entities, 'download');
 
   const [currentEntity, setCurrentEntity] = useState<StudyEntity | undefined>(
     undefined
@@ -353,7 +353,7 @@ export default function SubsettingDataGridModal({
               // we only want a user to be able to select variables from a single
               // entity at a time.
               rootEntity={{ ...currentEntity, children: [] }}
-              scope="downloads"
+              scope="download"
               selectedVariableDescriptors={selectedVariableDescriptors}
               onSelectedVariablesChange={handleSelectedVariablesChange}
             />

--- a/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
@@ -71,7 +71,7 @@ export default function SubsettingDataGridModal({
   const studyMetadata = useStudyMetadata();
   const subsettingClient = useSubsettingClient();
   const featuredFields = useFeaturedFields(entities);
-  const flattenedFields = useFlattenedFields(entities);
+  const flattenedFields = useFlattenedFields(entities, 'downloads');
 
   const [currentEntity, setCurrentEntity] = useState<StudyEntity | undefined>(
     undefined

--- a/src/lib/workspace/Subsetting/index.tsx
+++ b/src/lib/workspace/Subsetting/index.tsx
@@ -99,6 +99,7 @@ export default function Subsetting({
       />
       <div className="Variables">
         <VariableTree
+          scope="variableTree"
           rootEntity={entities[0]}
           entityId={entity.id}
           starredVariables={analysisState.analysis?.descriptor.starredVariables}


### PR DESCRIPTION
Resolves #801 

For example, in Amazonia ICEMR Brazil Cohort, the `Settlement` variable has `hideFrom: ["variableTree"]`, so it is downloadable in the "view and download" modal, but does not appear in the variable trees for the subsetting and visualization tabs.