### PR TITLE
Map visualisations - geo variables/entity chooser via geoConfig + per-study disabling of new-viz-icons infrastructure

### DIFF
--- a/src/lib/core/components/computations/PassThroughComputation.tsx
+++ b/src/lib/core/components/computations/PassThroughComputation.tsx
@@ -20,12 +20,14 @@ import { boxplotVisualization } from '../visualizations/implementations/BoxplotV
 import { mapVisualization } from '../visualizations/implementations/MapVisualization';
 import { EntityCounts } from '../../hooks/entityCounts';
 import { PromiseHookState } from '../../hooks/promise';
+import { GeoConfig } from '../../types/geoConfig';
 
 interface Props {
   analysisState: AnalysisState;
   computationAppOverview: ComputationAppOverview;
   totalCounts: PromiseHookState<EntityCounts>;
   filteredCounts: PromiseHookState<EntityCounts>;
+  geoConfigs: GeoConfig[];
 }
 
 /**
@@ -51,6 +53,7 @@ export function PassThroughComputation(props: Props) {
     computationAppOverview,
     totalCounts,
     filteredCounts,
+    geoConfigs,
   } = props;
   const { analysis, setComputations } = analysisState;
   const filters = useMemo(() => analysis?.descriptor.subset.descriptor ?? [], [
@@ -118,6 +121,7 @@ export function PassThroughComputation(props: Props) {
       toggleStarredVariable={toggleStarredVariable}
       totalCounts={totalCounts}
       filteredCounts={filteredCounts}
+      geoConfigs={geoConfigs}
     />
   );
 }

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -31,8 +31,7 @@ export interface VisualizationProps {
 
 export type SelectorProps = VisualizationOverview;
 
-export interface IsEnabledInPickerProps {
-  // it's a function - do we still call its argument 'props'?
+export interface IsEnabledInPickerParams {
   geoConfigs?: GeoConfig[];
   studyMetadata?: StudyMetadata; // not used yet, but you could imagine it being used to determine
   // if a viz tool should be enabled
@@ -42,5 +41,5 @@ export interface VisualizationType {
   fullscreenComponent: React.ComponentType<VisualizationProps>;
   selectorComponent: React.ComponentType<SelectorProps>;
   createDefaultConfig: () => unknown;
-  isEnabledInPicker?: (props: IsEnabledInPickerProps) => boolean;
+  isEnabledInPicker?: (props: IsEnabledInPickerParams) => boolean;
 }

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -26,6 +26,7 @@ export interface VisualizationProps {
   toggleStarredVariable: (targetVariableId: VariableDescriptor) => void;
   totalCounts: PromiseHookState<EntityCounts>;
   filteredCounts: PromiseHookState<EntityCounts>;
+  geoConfigs: GeoConfig[];
 }
 
 export type SelectorProps = VisualizationOverview;

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -1,6 +1,8 @@
 import { EntityCounts } from '../../hooks/entityCounts';
 import { PromiseHookState } from '../../hooks/promise';
 import { Filter } from '../../types/filter';
+import { GeoConfig } from '../../types/geoConfig';
+import { StudyMetadata } from '../../types/study';
 import { VariableDescriptor } from '../../types/variable';
 import {
   Computation,
@@ -28,8 +30,16 @@ export interface VisualizationProps {
 
 export type SelectorProps = VisualizationOverview;
 
+export interface EnableInPickerProps {
+  // it's a function - do we still call its argument 'props'?
+  geoConfigs?: GeoConfig[];
+  studyMetadata?: StudyMetadata; // not used yet, but you could imagine it being used to determine
+  // if a viz tool should be enabled
+}
+
 export interface VisualizationType {
   fullscreenComponent: React.ComponentType<VisualizationProps>;
   selectorComponent: React.ComponentType<SelectorProps>;
   createDefaultConfig: () => unknown;
+  enabledInPicker?: (props: EnableInPickerProps) => boolean;
 }

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -30,7 +30,7 @@ export interface VisualizationProps {
 
 export type SelectorProps = VisualizationOverview;
 
-export interface EnableInPickerProps {
+export interface IsEnabledInPickerProps {
   // it's a function - do we still call its argument 'props'?
   geoConfigs?: GeoConfig[];
   studyMetadata?: StudyMetadata; // not used yet, but you could imagine it being used to determine
@@ -41,5 +41,5 @@ export interface VisualizationType {
   fullscreenComponent: React.ComponentType<VisualizationProps>;
   selectorComponent: React.ComponentType<SelectorProps>;
   createDefaultConfig: () => unknown;
-  enabledInPicker?: (props: EnableInPickerProps) => boolean;
+  isEnabledInPicker?: (props: IsEnabledInPickerProps) => boolean;
 }

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -28,6 +28,7 @@ import { Tooltip } from '@material-ui/core';
 import { isEqual } from 'lodash';
 import { EntityCounts } from '../../hooks/entityCounts';
 import { PromiseHookState } from '../../hooks/promise';
+import { GeoConfig } from '../../types/geoConfig';
 
 const cx = makeClassNameHelper('VisualizationsContainer');
 
@@ -45,6 +46,7 @@ interface Props {
   toggleStarredVariable: (targetVariable: VariableDescriptor) => void;
   totalCounts: PromiseHookState<EntityCounts>;
   filteredCounts: PromiseHookState<EntityCounts>;
+  geoConfigs: GeoConfig[];
 }
 
 /**
@@ -181,6 +183,7 @@ function NewVisualizationPicker(props: Props) {
     visualizationsOverview,
     updateVisualizations,
     computation,
+    geoConfigs,
   } = props;
   const history = useHistory();
   const { computationId } = computation;
@@ -222,7 +225,12 @@ function NewVisualizationPicker(props: Props) {
                     }}
                   >
                     {vizType ? (
-                      <vizType.selectorComponent {...vizOverview} />
+                      vizType.enabledInPicker == null ||
+                      vizType.enabledInPicker({ geoConfigs }) ? (
+                        <vizType.selectorComponent {...vizOverview} />
+                      ) : (
+                        <div>I'm disabled!</div>
+                      )
                     ) : (
                       <PlaceholderIcon name={vizOverview.name} />
                     )}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -275,6 +275,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
     toggleStarredVariable,
     totalCounts,
     filteredCounts,
+    geoConfigs,
   } = props;
   const history = useHistory();
   const viz = computation.visualizations.find((v) => v.visualizationId === id);
@@ -426,6 +427,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
             updateThumbnail={updateThumbnail}
             totalCounts={totalCounts}
             filteredCounts={filteredCounts}
+            geoConfigs={geoConfigs}
           />
         </div>
       )}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -187,6 +187,7 @@ function NewVisualizationPicker(props: Props) {
   } = props;
   const history = useHistory();
   const { computationId } = computation;
+  const enablePickerArgs = { geoConfigs };
   return (
     <div className={cx('-PickerContainer')}>
       <div className={cx('-PickerActions')}>
@@ -208,7 +209,11 @@ function NewVisualizationPicker(props: Props) {
                 <span>
                   <button
                     type="button"
-                    disabled={vizType == null}
+                    disabled={
+                      vizType == null ||
+                      (vizType.isEnabledInPicker != null &&
+                        vizType.isEnabledInPicker(enablePickerArgs) == false)
+                    }
                     onClick={async () => {
                       const visualizationId = uuid();
                       updateVisualizations((visualizations) =>
@@ -225,12 +230,7 @@ function NewVisualizationPicker(props: Props) {
                     }}
                   >
                     {vizType ? (
-                      vizType.enabledInPicker == null ||
-                      vizType.enabledInPicker({ geoConfigs }) ? (
-                        <vizType.selectorComponent {...vizOverview} />
-                      ) : (
-                        <div>I'm disabled!</div>
-                      )
+                      <vizType.selectorComponent {...vizOverview} />
                     ) : (
                       <PlaceholderIcon name={vizOverview.name} />
                     )}
@@ -238,15 +238,23 @@ function NewVisualizationPicker(props: Props) {
                 </span>
               </Tooltip>
               <div className={cx('-PickerEntryName')}>
-                {vizOverview.displayName?.includes(', ') ? (
-                  <div>
-                    {vizOverview.displayName.split(', ')[0]} <br />
-                    {vizOverview.displayName.split(', ')[1]}
-                  </div>
-                ) : (
-                  <div>{vizOverview.displayName}</div>
-                )}
+                <div>
+                  {vizOverview.displayName
+                    ?.split(', ')
+                    .reduce<(string | JSX.Element)[]>(
+                      (all, cur) => [
+                        ...all,
+                        ...(all.length ? [<br />] : []),
+                        cur,
+                      ],
+                      []
+                    )}
+                </div>
                 {vizType == null && <i>(Coming soon!)</i>}
+                {vizType?.isEnabledInPicker != null &&
+                  !vizType?.isEnabledInPicker(enablePickerArgs) && (
+                    <i>(Unavailable in this study)</i>
+                  )}
               </div>
             </div>
           );

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -16,6 +16,9 @@ import { BoundsViewport } from '@veupathdb/components/lib/map/Types';
 import DonutMarker from '@veupathdb/components/lib/map/DonutMarker';
 import { BoundsDriftMarkerProps } from '@veupathdb/components/lib/map/BoundsDriftMarker';
 
+// general ui imports
+import { FormControl, Select, MenuItem, InputLabel } from '@material-ui/core';
+
 // viz-related imports
 import { PlotLayout } from '../../layouts/PlotLayout';
 import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
@@ -24,12 +27,11 @@ import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import DataClient, { MapMarkersRequestParams } from '../../../api/DataClient';
 import { useVizConfig } from '../../../hooks/visualizations';
 import { usePromise } from '../../../hooks/promise';
-import {
-  filtersFromBoundingBox,
-  geohashLevelToVariableId,
-  leafletZoomLevelToGeohashLevel,
-} from '../../../utils/visualization';
+import { filtersFromBoundingBox } from '../../../utils/visualization';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
+import { OutputEntityTitle } from '../OutputEntityTitle';
+import { sumBy } from 'lodash';
+import PluginError from '../PluginError';
 
 export const mapVisualization: VisualizationType = {
   selectorComponent: SelectorComponent,
@@ -70,13 +72,24 @@ const defaultAnimation = {
 
 type MapConfig = t.TypeOf<typeof MapConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-const MapConfig = t.type({
-  mapCenterAndZoom: t.type({
-    latitude: t.number,
-    longitude: t.number,
-    zoomLevel: t.number,
+const MapConfig = t.intersection([
+  t.type({
+    mapCenterAndZoom: t.type({
+      latitude: t.number,
+      longitude: t.number,
+      zoomLevel: t.number,
+    }),
   }),
-});
+  t.partial({
+    geoEntityId: t.string,
+    outputEntityId: t.string,
+  }),
+]);
+
+type MarkerDataWithStatistics = {
+  markers: Array<ReactElement<BoundsDriftMarkerProps>>;
+  totalEntityCount: number;
+};
 
 function MapViz(props: VisualizationProps) {
   const {
@@ -85,10 +98,6 @@ function MapViz(props: VisualizationProps) {
     updateConfiguration,
     updateThumbnail,
     filters,
-    dataElementConstraints,
-    dataElementDependencyOrder,
-    starredVariables,
-    toggleStarredVariable,
     totalCounts,
     filteredCounts,
     geoConfigs,
@@ -124,62 +133,82 @@ function MapViz(props: VisualizationProps) {
     [updateVizConfig]
   );
 
-  const tempOutputEntityId = entities[0].id;
-
   const [boundsZoomLevel, setBoundsZoomLevel] = useState<BoundsViewport>();
 
-  const latitudeVariableDetails = useMemo(
-    () => ({
-      entityId: tempOutputEntityId,
-      variableId: 'OBI_0001620',
-    }),
-    [tempOutputEntityId]
-  );
-  const longitudeVariableDetails = useMemo(
-    () => ({
-      entityId: tempOutputEntityId,
-      variableId: 'OBI_0001621',
-    }),
-    [tempOutputEntityId]
-  );
+  const geoConfig = useMemo(() => {
+    if (vizConfig.geoEntityId == null) return undefined;
+    return geoConfigs.find(
+      (config) => config.entity.id === vizConfig.geoEntityId
+    );
+  }, [vizConfig.geoEntityId]);
 
-  const markers = usePromise<
-    Array<ReactElement<BoundsDriftMarkerProps>> | undefined
-  >(
+  const [geoEntity, outputEntity] = useMemo(() => {
+    const geoEntity =
+      vizConfig.geoEntityId !== null
+        ? entities.find((entity) => entity.id === vizConfig.geoEntityId)
+        : undefined;
+    const outputEntity =
+      vizConfig.outputEntityId !== null
+        ? entities.find((entity) => entity.id === vizConfig.outputEntityId)
+        : undefined;
+    return [geoEntity, outputEntity ?? geoEntity];
+  }, [entities, vizConfig.outputEntityId, vizConfig.geoEntityId]);
+
+  const data = usePromise<MarkerDataWithStatistics | undefined>(
     useCallback(async () => {
-      if (boundsZoomLevel == null) return [];
+      // check all required vizConfigs are provided
+      if (
+        boundsZoomLevel == null ||
+        vizConfig.geoEntityId == null ||
+        geoConfig == null
+      )
+        return undefined;
 
       const { bounds, zoomLevel } = boundsZoomLevel;
+      const geoEntityId = vizConfig.geoEntityId;
+      const outputEntityId = vizConfig.outputEntityId ?? geoEntityId;
 
+      // now prepare the rest of the request params
+      const latitudeVariable = {
+        entityId: geoEntityId,
+        variableId: geoConfig.latitudeVariableId,
+      };
+      const longitudeVariable = {
+        entityId: geoEntityId,
+        variableId: geoConfig.longitudeVariableId,
+      };
       const boundsFilters = filtersFromBoundingBox(
+        // this will need to be memoized outside this usePromise for re-use in pie/histogram requests
         bounds,
-        latitudeVariableDetails,
-        longitudeVariableDetails
+        latitudeVariable,
+        longitudeVariable
       );
-      // TO DO: add bounding box-based filters!
 
       const requestParams: MapMarkersRequestParams = {
         studyId,
         filters: filters ? [...filters, ...boundsFilters] : boundsFilters,
         config: {
-          outputEntityId: tempOutputEntityId,
+          outputEntityId: outputEntityId,
           geoAggregateVariable: {
-            entityId: tempOutputEntityId,
-            variableId: geohashLevelToVariableId(
-              leafletZoomLevelToGeohashLevel(zoomLevel)
-            ),
+            entityId: geoEntityId,
+            variableId:
+              geoConfig.aggregationVariableIds[
+                geoConfig.zoomLevelToAggregationLevel(zoomLevel) - 1
+              ],
           },
-          latitudeVariable: latitudeVariableDetails,
-          longitudeVariable: longitudeVariableDetails,
+          latitudeVariable: latitudeVariable,
+          longitudeVariable: longitudeVariable,
         },
       };
+
+      // now get the data
       const response = await dataClient.getMapMarkers(
         computation.descriptor.type,
         requestParams
       );
 
       // TO DO: find out if MarkerProps.id is obsolete
-      return response.mapElements.map(
+      const markerElements = response.mapElements.map(
         ({
           avgLat,
           avgLon,
@@ -214,19 +243,25 @@ function MapViz(props: VisualizationProps) {
           );
         }
       );
+
+      return {
+        markers: markerElements,
+        totalEntityCount: sumBy(
+          response.mapElements,
+          (elem) => elem.entityCount
+        ),
+      };
     }, [
       studyId,
       filters,
       dataClient,
-      tempOutputEntityId,
-      latitudeVariableDetails,
-      longitudeVariableDetails,
+      vizConfig,
       boundsZoomLevel,
       computation.descriptor.type,
     ])
   );
 
-  const [height, width] = [450, 750];
+  const [height, width] = [600, 1000];
   const { latitude, longitude, zoomLevel } = vizConfig.mapCenterAndZoom;
 
   // Create the ref that we send to the map in web-components
@@ -234,7 +269,7 @@ function MapViz(props: VisualizationProps) {
     updateThumbnail,
     { height, width },
     // The dependencies for needing to generate a new thumbnail
-    [markers.value, latitude, longitude, zoomLevel]
+    [data.value, latitude, longitude, zoomLevel]
   );
 
   const plotNode = (
@@ -242,18 +277,94 @@ function MapViz(props: VisualizationProps) {
       viewport={{ center: [latitude, longitude], zoom: zoomLevel }}
       onViewportChanged={handleViewportChanged}
       onBoundsChanged={setBoundsZoomLevel}
-      markers={markers.value ?? []}
+      markers={data.value?.markers ?? []}
       animation={defaultAnimation}
       height={height}
       width={width}
-      showGrid={true}
-      zoomLevelToGeohashLevel={leafletZoomLevelToGeohashLevel}
+      showGrid={geoConfig?.zoomLevelToAggregationLevel != null}
+      zoomLevelToGeohashLevel={geoConfig?.zoomLevelToAggregationLevel}
       ref={plotRef}
     />
   );
 
+  const handleGeoEntityChange = useCallback(
+    (event: React.ChangeEvent<{ value: unknown }>) => {
+      if (event != null)
+        updateVizConfig({ geoEntityId: event.target.value as string });
+    },
+    [updateVizConfig]
+  );
+
+  const handleOutputEntityChange = useCallback(
+    (event: React.ChangeEvent<{ value: unknown }>) => {
+      if (event != null)
+        updateVizConfig({ outputEntityId: event.target.value as string });
+    },
+    [updateVizConfig]
+  );
+
+  const availableOutputEntities = useMemo(() => {
+    if (geoConfig == null) {
+      return entities;
+    } else {
+      return Array.from(
+        preorder(geoConfig.entity, (entity) => entity.children || [])
+      );
+    }
+  }, [entities, geoConfig]);
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div>
+        <FormControl style={{ minWidth: '450px' }}>
+          <InputLabel>Choose an entity to map the locations of</InputLabel>
+          <Select
+            value={vizConfig.geoEntityId}
+            onChange={handleGeoEntityChange}
+          >
+            {geoConfigs.map((geoConfig) => (
+              <MenuItem key={geoConfig.entity.id} value={geoConfig.entity.id}>
+                {geoConfig.entity.displayNamePlural ??
+                  geoConfig.entity.displayName}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl style={{ minWidth: '450px' }}>
+          <InputLabel>
+            Choose an entity to show the counts of
+            {geoEntity &&
+              ' (default: ' +
+                (geoEntity.displayNamePlural ?? geoEntity.displayName) +
+                ')'}
+          </InputLabel>
+          <Select
+            value={vizConfig.outputEntityId}
+            onChange={handleOutputEntityChange}
+          >
+            {availableOutputEntities.map((entity) => (
+              <MenuItem key={entity.id} value={entity.id}>
+                {entity.displayNamePlural ?? entity.displayName}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <div>
+          <p>
+            (Note: if you want to show counts for anything other than Household,
+            it's best to first subset aggressively and zoom in to a few hundred
+            households.)
+          </p>
+        </div>
+      </div>
+      <PluginError
+        error={data.error}
+        outputSize={data.value?.totalEntityCount}
+      />
+      <OutputEntityTitle
+        entity={outputEntity}
+        outputSize={data.value?.totalEntityCount}
+      />
       <PlotLayout
         isFaceted={false}
         legendNode={null}

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -1,5 +1,5 @@
 import {
-  IsEnabledInPickerProps,
+  IsEnabledInPickerParams,
   VisualizationProps,
   VisualizationType,
 } from '../VisualizationTypes';
@@ -62,7 +62,7 @@ function createDefaultConfig(): MapConfig {
   };
 }
 
-function isEnabledInPicker({ geoConfigs }: IsEnabledInPickerProps): boolean {
+function isEnabledInPicker({ geoConfigs }: IsEnabledInPickerParams): boolean {
   return geoConfigs != null && geoConfigs.length > 0;
 }
 

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -1,5 +1,5 @@
 import {
-  EnableInPickerProps,
+  IsEnabledInPickerProps,
   VisualizationProps,
   VisualizationType,
 } from '../VisualizationTypes';
@@ -34,7 +34,7 @@ export const mapVisualization: VisualizationType = {
   selectorComponent: SelectorComponent,
   fullscreenComponent: MapViz,
   createDefaultConfig: createDefaultConfig,
-  enabledInPicker: enabledInPicker,
+  isEnabledInPicker: isEnabledInPicker,
 };
 
 function SelectorComponent() {
@@ -57,8 +57,7 @@ function createDefaultConfig(): MapConfig {
   };
 }
 
-function enabledInPicker({ geoConfigs }: EnableInPickerProps): boolean {
-  console.log(geoConfigs);
+function isEnabledInPicker({ geoConfigs }: IsEnabledInPickerProps): boolean {
   return geoConfigs != null && geoConfigs.length > 0;
 }
 

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -90,6 +90,7 @@ function MapViz(props: VisualizationProps) {
     toggleStarredVariable,
     totalCounts,
     filteredCounts,
+    geoConfigs,
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
@@ -241,7 +242,7 @@ function MapViz(props: VisualizationProps) {
   );
 
   return (
-    <div>
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
       <PlotLayout
         isFaceted={false}
         legendNode={null}

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -101,8 +101,8 @@ function MapViz(props: VisualizationProps) {
     updateConfiguration,
     updateThumbnail,
     filters,
-    totalCounts,
-    filteredCounts,
+    //    totalCounts,
+    //    filteredCounts,
     geoConfigs,
   } = props;
   const studyMetadata = useStudyMetadata();

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -1,4 +1,8 @@
-import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
+import {
+  EnableInPickerProps,
+  VisualizationProps,
+  VisualizationType,
+} from '../VisualizationTypes';
 import map from './selectorIcons/map.svg';
 import * as t from 'io-ts';
 
@@ -30,6 +34,7 @@ export const mapVisualization: VisualizationType = {
   selectorComponent: SelectorComponent,
   fullscreenComponent: MapViz,
   createDefaultConfig: createDefaultConfig,
+  enabledInPicker: enabledInPicker,
 };
 
 function SelectorComponent() {
@@ -50,6 +55,11 @@ function createDefaultConfig(): MapConfig {
       zoomLevel: 1, // TO DO: check MapVEuMap minZoom hardcoded to 2
     },
   };
+}
+
+function enabledInPicker({ geoConfigs }: EnableInPickerProps): boolean {
+  console.log(geoConfigs);
+  return geoConfigs != null && geoConfigs.length > 0;
 }
 
 const defaultAnimation = {

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -316,7 +316,10 @@ function MapViz(props: VisualizationProps) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <div>
-        <FormControl style={{ minWidth: '450px' }}>
+        <FormControl
+          style={{ minWidth: '450px', paddingRight: '10px' }}
+          variant="filled"
+        >
           <InputLabel>Choose an entity to map the locations of</InputLabel>
           <Select
             value={vizConfig.geoEntityId}
@@ -330,7 +333,7 @@ function MapViz(props: VisualizationProps) {
             ))}
           </Select>
         </FormControl>
-        <FormControl style={{ minWidth: '450px' }}>
+        <FormControl style={{ minWidth: '450px' }} variant="filled">
           <InputLabel>
             Choose an entity to show the counts of
             {geoEntity &&

--- a/src/lib/core/hooks/geoConfig.ts
+++ b/src/lib/core/hooks/geoConfig.ts
@@ -1,10 +1,59 @@
 import { useMemo } from 'react';
 import { StudyEntity } from '../types/study';
-
+import { findGeolocationNode } from '../utils/geoVariables';
 import { leafletZoomLevelToGeohashLevel } from '../utils/visualization';
+import { sortBy } from 'lodash';
 
-type GeoConfig = {};
+/**
+ * GeoConfig is a list that corresponds to (only) entities that have geo-variables
+ *
+ * Temporary implementation that looks for a specific combination of variables underneath a single variable tree node.
+ * Assumes that aggregationVariables are in ID order (e.g. geohash_1 has the lowest ID and geohash_6 the highest)
+ *
+ */
 
-export function useGeoConfig(entities: StudyEntity[]): GeoConfig {
-  return useMemo(() => entities.filter(() => true).map(() => ({})), [entities]);
+type GeoConfig = {
+  entity: StudyEntity;
+  zoomLevelToAggregationLevel: (zoomLevel: number) => number;
+  latitudeVariableId: string;
+  longitudeVariableId: string;
+  aggregationVariableIds: string[];
+};
+
+export function useGeoConfig(entities: StudyEntity[]): GeoConfig[] {
+  return useMemo(
+    () =>
+      entities
+        .map((entity) => {
+          const geolocationNode = findGeolocationNode(entity);
+          if (geolocationNode != null) {
+            const directChildren = entity.variables.filter(
+              (variable) => variable.parentId === geolocationNode.id
+            );
+            return {
+              entity,
+              zoomLevelToAggregationLevel: leafletZoomLevelToGeohashLevel, // default leaflet to geohash mapping
+              latitudeVariableId: directChildren.find(
+                (variable) => variable.type === 'number'
+              )?.id,
+              longitudeVariableId: directChildren.find(
+                (variable) => variable.type === 'longitude'
+              )?.id,
+              aggregationVariableIds: sortBy(
+                directChildren
+                  .filter(
+                    (variable) =>
+                      variable.type === 'string' &&
+                      variable.dataShape === 'continuous'
+                  )
+                  .map((variable) => variable.id)
+              ),
+            };
+          } else {
+            return undefined;
+          }
+        })
+        .filter((item): item is GeoConfig => item != null),
+    [entities]
+  );
 }

--- a/src/lib/core/hooks/geoConfig.ts
+++ b/src/lib/core/hooks/geoConfig.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { StudyEntity } from '../types/study';
 import { findGeolocationNode } from '../utils/geoVariables';
 import { leafletZoomLevelToGeohashLevel } from '../utils/visualization';
+import { GeoConfig } from '../types/geoConfig';
 import { sortBy } from 'lodash';
 
 /**
@@ -12,20 +13,14 @@ import { sortBy } from 'lodash';
  *
  */
 
-type GeoConfig = {
-  entity: StudyEntity;
-  zoomLevelToAggregationLevel: (zoomLevel: number) => number;
-  latitudeVariableId: string;
-  longitudeVariableId: string;
-  aggregationVariableIds: string[];
-};
-
 export function useGeoConfig(entities: StudyEntity[]): GeoConfig[] {
   return useMemo(
     () =>
       entities
         .map((entity) => {
+          console.log(`Checking ${entity.displayName}`);
           const geolocationNode = findGeolocationNode(entity);
+          console.log(geolocationNode != null);
           if (geolocationNode != null) {
             const directChildren = entity.variables.filter(
               (variable) => variable.parentId === geolocationNode.id

--- a/src/lib/core/hooks/geoConfig.ts
+++ b/src/lib/core/hooks/geoConfig.ts
@@ -1,9 +1,8 @@
 import { useMemo } from 'react';
 import { StudyEntity } from '../types/study';
-import { findGeolocationNode } from '../utils/geoVariables';
+import { entityToGeoConfig } from '../utils/geoVariables';
 import { leafletZoomLevelToGeohashLevel } from '../utils/visualization';
 import { GeoConfig } from '../types/geoConfig';
-import { sortBy } from 'lodash';
 
 /**
  * GeoConfig is a list that corresponds to (only) entities that have geo-variables
@@ -17,36 +16,9 @@ export function useGeoConfig(entities: StudyEntity[]): GeoConfig[] {
   return useMemo(
     () =>
       entities
-        .map((entity) => {
-          const geolocationNode = findGeolocationNode(entity);
-          if (geolocationNode != null) {
-            const directChildren = entity.variables.filter(
-              (variable) => variable.parentId === geolocationNode.id
-            );
-            return {
-              entity,
-              zoomLevelToAggregationLevel: leafletZoomLevelToGeohashLevel, // default leaflet to geohash mapping
-              latitudeVariableId: directChildren.find(
-                (variable) => variable.type === 'number'
-              )?.id,
-              longitudeVariableId: directChildren.find(
-                (variable) => variable.type === 'longitude'
-              )?.id,
-              aggregationVariableIds: sortBy(
-                directChildren
-                  .filter(
-                    (variable) =>
-                      variable.type === 'string' &&
-                      (variable.dataShape === 'categorical' ||
-                        variable.dataShape === 'binary')
-                  )
-                  .map((variable) => variable.id)
-              ),
-            };
-          } else {
-            return undefined;
-          }
-        })
+        .map((entity) =>
+          entityToGeoConfig(entity, leafletZoomLevelToGeohashLevel)
+        )
         .filter((item): item is GeoConfig => item != null),
     [entities]
   );

--- a/src/lib/core/hooks/geoConfig.ts
+++ b/src/lib/core/hooks/geoConfig.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react';
+import { StudyEntity } from '../types/study';
+
+import { leafletZoomLevelToGeohashLevel } from '../utils/visualization';
+
+type GeoConfig = {};
+
+export function useGeoConfig(entities: StudyEntity[]): GeoConfig {
+  return useMemo(() => entities.filter(() => true).map(() => ({})), [entities]);
+}

--- a/src/lib/core/hooks/geoConfig.ts
+++ b/src/lib/core/hooks/geoConfig.ts
@@ -18,9 +18,7 @@ export function useGeoConfig(entities: StudyEntity[]): GeoConfig[] {
     () =>
       entities
         .map((entity) => {
-          console.log(`Checking ${entity.displayName}`);
           const geolocationNode = findGeolocationNode(entity);
-          console.log(geolocationNode != null);
           if (geolocationNode != null) {
             const directChildren = entity.variables.filter(
               (variable) => variable.parentId === geolocationNode.id

--- a/src/lib/core/hooks/geoConfig.ts
+++ b/src/lib/core/hooks/geoConfig.ts
@@ -37,7 +37,8 @@ export function useGeoConfig(entities: StudyEntity[]): GeoConfig[] {
                   .filter(
                     (variable) =>
                       variable.type === 'string' &&
-                      variable.dataShape === 'continuous'
+                      (variable.dataShape === 'categorical' ||
+                        variable.dataShape === 'binary')
                   )
                   .map((variable) => variable.id)
               ),

--- a/src/lib/core/types/geoConfig.ts
+++ b/src/lib/core/types/geoConfig.ts
@@ -1,0 +1,9 @@
+import { StudyEntity } from '../types/study';
+
+export type GeoConfig = {
+  entity: StudyEntity;
+  zoomLevelToAggregationLevel: (zoomLevel: number) => number;
+  latitudeVariableId: string;
+  longitudeVariableId: string;
+  aggregationVariableIds: string[];
+};

--- a/src/lib/core/utils/geoVariables.ts
+++ b/src/lib/core/utils/geoVariables.ts
@@ -1,4 +1,4 @@
-import { StudyEntity, VariableTreeNode } from '../types/study';
+import { StudyEntity, Variable, VariableTreeNode } from '../types/study';
 
 /**
  * Given a study, search its variable tree to find a node that has the following direct children
@@ -30,8 +30,13 @@ export function findGeolocationNode(
     if (numberSiblings.length === 1) {
       const stringCategoricals = siblingVariables.filter(
         (variable) =>
-          variable.type === 'string' && variable.dataShape === 'categorical'
+          variable.type === 'string' &&
+          (variable.dataShape === 'categorical' ||
+            variable.dataShape === 'binary')
+        // two lines above, it wouldn't let me do ({ type, dataShape}) => ...
+        // without jumping through more typing hoops - any idea why please?
       );
+
       if (stringCategoricals.length === 6) {
         return entity.variables.find(
           (variable) => variable.id === longitudeVariable.parentId

--- a/src/lib/core/utils/geoVariables.ts
+++ b/src/lib/core/utils/geoVariables.ts
@@ -1,0 +1,43 @@
+import { StudyEntity, VariableTreeNode } from '../types/study';
+
+/**
+ * Given a study, search its variable tree to find a node that has the following direct children
+ *
+ * a longitude variable
+ * a number variable
+ * six string categorical variables
+ * and nothing more!
+ *
+ * returns the VariableTreNode or null
+ *
+ * This is a placeholder implementation, until more direct variable annotations (displayType) are available for b57
+ */
+export function findGeolocationNode(
+  entity: StudyEntity
+): VariableTreeNode | undefined {
+  // first find the longitude variable
+  const longitudeVariables = entity.variables.filter(
+    (variable) => variable.type === 'longitude'
+  );
+  if (longitudeVariables.length === 1) {
+    const longitudeVariable = longitudeVariables[0];
+    const siblingVariables = entity.variables.filter(
+      (variable) => variable.parentId === longitudeVariable.parentId
+    );
+    const numberSiblings = siblingVariables.filter(
+      (variable) => variable.type === 'number'
+    );
+    if (numberSiblings.length === 1) {
+      const stringCategoricals = siblingVariables.filter(
+        (variable) =>
+          variable.type === 'string' && variable.dataShape === 'categorical'
+      );
+      if (stringCategoricals.length === 6) {
+        return entity.variables.find(
+          (variable) => variable.id === longitudeVariable.parentId
+        );
+      }
+    }
+  }
+  return undefined;
+}

--- a/src/lib/core/utils/visualization.ts
+++ b/src/lib/core/utils/visualization.ts
@@ -211,6 +211,11 @@ export function leafletZoomLevelToGeohashLevel(
   }
 }
 
+/**
+ * DEPRECATED since using geoConfig
+ *
+ **/
+
 export function geohashLevelToVariableId(geohashLevel: number): string {
   switch (geohashLevel) {
     case 1:

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -22,6 +22,7 @@ import { usePrevious } from '../core/hooks/previousValue';
 import { useStudyEntities } from '../core/hooks/study';
 import { useSetDocumentTitle } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { useStudyMetadata, useStudyRecord } from '../core';
+import { useGeoConfig } from '../core/hooks/geoConfig';
 
 // Components
 import WorkspaceNavigation from '@veupathdb/wdk-client/lib/Components/Workspace/WorkspaceNavigation';
@@ -101,6 +102,7 @@ export function AnalysisPanel({
   const studyMetadata = useStudyMetadata();
   const entities = useStudyEntities(studyMetadata.rootEntity);
   const filteredEntities = uniq(filters?.map((f) => f.entityId));
+  const geoConfig = useGeoConfig(entities);
   const location = useLocation();
 
   const [lastVarPath, setLastVarPath] = useState('');

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -102,7 +102,7 @@ export function AnalysisPanel({
   const studyMetadata = useStudyMetadata();
   const entities = useStudyEntities(studyMetadata.rootEntity);
   const filteredEntities = uniq(filters?.map((f) => f.entityId));
-  const geoConfig = useGeoConfig(entities);
+  const geoConfigs = useGeoConfig(entities);
   const location = useLocation();
 
   const [lastVarPath, setLastVarPath] = useState('');
@@ -289,6 +289,7 @@ export function AnalysisPanel({
                 analysisState={analysisState}
                 totalCounts={totalCounts}
                 filteredCounts={filteredCounts}
+                geoConfigs={geoConfigs}
               />
             </AnalysisTabErrorBoundary>
           )}

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -6,15 +6,17 @@ import { PassThroughComputation } from '../core/components/computations/PassThro
 import { PromiseResult } from '../core/components/Promise';
 import { EntityCounts } from '../core/hooks/entityCounts';
 import { PromiseHookState, usePromise } from '../core/hooks/promise';
+import { GeoConfig } from '../core/types/geoConfig';
 
 export interface Props {
   analysisState: AnalysisState;
   totalCounts: PromiseHookState<EntityCounts>;
   filteredCounts: PromiseHookState<EntityCounts>;
+  geoConfigs: GeoConfig[];
 }
 
 export function ComputationRoute(props: Props) {
-  const { analysisState, totalCounts, filteredCounts } = props;
+  const { analysisState, totalCounts, filteredCounts, geoConfigs } = props;
   const { url } = useRouteMatch();
   const dataClient = useDataClient();
   const promiseState = usePromise(
@@ -42,6 +44,7 @@ export function ComputationRoute(props: Props) {
               computationAppOverview={computationAppOverview}
               totalCounts={totalCounts}
               filteredCounts={filteredCounts}
+              geoConfigs={geoConfigs}
             />
           </Route>
         </Switch>


### PR DESCRIPTION
Resolves #796 
Resolves #776 

This PR has two prongs.

1. develops the map viz further by adding two dropdown menus to select the mappable entity and the display count entity (wording for these needs to be refined).

2. adds some hopefully general infrastructure for enabling/disabling visualisations from the "new viz picker" when there is no chance that they can be used in a study. 

**Demo/review only with UMSP Study!**
(Although you can check out the disabled map viz icon in other studies.)

Very basic UI added to allow 'geo entity' and 'output/count entity' to be chosen.
The latter cannot be a parent entity of the former (need to double check this is correct).

Uses Material UI `<Select>` but ideally we could have our own core-ui component.

Look and feel is inconsistent with variable tree pickers but for now it's OK. We'll await further work in core-components and revisit.