### PR TITLE
Handle dependent range without further useEffects

### DIFF
--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -570,8 +570,6 @@ function HistogramPlotWithControls({
         selectedRange={selectedRange}
         selectedRangeBounds={selectedRangeBounds}
         onSelectedRangeChange={handleSelectedRangeChange}
-        //DKDK parentComponentName
-        parentComponentName={'HistogramFilter'}
       />
       <Histogram
         {...histogramProps}
@@ -631,8 +629,6 @@ function HistogramPlotWithControls({
             }}
             allowPartialRange={false}
             containerStyles={{ minWidth: '400px' }}
-            //DKDK parentComponentName
-            parentComponentName={'HistogramFilter'}
           />
           {/* truncation notification */}
           {truncatedDependentAxisWarning ? (
@@ -682,8 +678,6 @@ function HistogramPlotWithControls({
             onRangeChange={handleIndependentAxisRangeChange}
             valueType={data?.valueType}
             containerStyles={{ minWidth: '400px' }}
-            //DKDK parentComponentName
-            parentComponentName={'HistogramFilter'}
           />
           {/* truncation notification */}
           {truncatedIndependentAxisWarning ? (

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -452,10 +452,7 @@ function BarplotViz(props: VisualizationProps) {
   );
 
   useEffect(() => {
-    if (
-      (truncationConfigDependentAxisMin || truncationConfigDependentAxisMax) &&
-      !data.pending
-    ) {
+    if (truncationConfigDependentAxisMin || truncationConfigDependentAxisMax) {
       setTruncatedDependentAxisWarning(
         'Data may have been truncated by range selection, as indicated by the light gray shading'
       );

--- a/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
@@ -105,24 +105,6 @@ export function useDefaultDependentAxisRange(
     (vizConfig as HistogramConfig | BarplotConfig).dependentAxisLogScale,
   ]);
 
-  // use this to avoid infinite loop: also use useLayoutEffect to avoid async/ghost issue
-  const updateVizConfigRef = useRef(updateVizConfig);
-  useLayoutEffect(() => {
-    updateVizConfigRef.current = updateVizConfig;
-  }, [updateVizConfig]);
-
-  // update vizConfig.dependentAxisRange as it is necessary for set range correctly
-  useLayoutEffect(() => {
-    if (!data.pending)
-      updateVizConfigRef.current({
-        dependentAxisRange: defaultDependentAxisRange,
-      });
-    else
-      updateVizConfigRef.current({
-        dependentAxisRange: undefined,
-      });
-  }, [data, defaultDependentAxisRange]);
-
   return defaultDependentAxisRange;
 }
 

--- a/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useLayoutEffect } from 'react';
+import { useMemo } from 'react';
 import { PromiseHookState } from './promise';
 import { isFaceted } from '@veupathdb/components/lib/types/guards';
 import {

--- a/src/lib/core/hooks/computeDefaultIndependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultIndependentAxisRange.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useLayoutEffect } from 'react';
+import { useMemo } from 'react';
 import { DateVariable, NumberVariable, Variable } from '../types/study';
 import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
 import { HistogramConfig } from '../components/visualizations/implementations/HistogramVisualization';
@@ -70,19 +70,6 @@ export function useDefaultIndependentAxisRange(
       ? axisRangeMargin(defaultIndependentRange, variable?.type)
       : defaultIndependentRange;
   }, [variable, plotName]);
-
-  // use this to avoid infinite loop: also use useLayoutEffect to avoid async/ghost issue
-  const updateVizConfigRefInd = useRef(updateVizConfig);
-  useLayoutEffect(() => {
-    updateVizConfigRefInd.current = updateVizConfig;
-  }, [updateVizConfig]);
-
-  // update vizConfig.dependentAxisRange as it is necessary for set range correctly
-  useLayoutEffect(() => {
-    updateVizConfigRefInd.current({
-      independentAxisRange: defaultIndependentAxisRange,
-    });
-  }, [defaultIndependentAxisRange]);
 
   return defaultIndependentAxisRange;
 }

--- a/src/lib/core/hooks/computeNumberDateDefaultDependentAxisRange.ts
+++ b/src/lib/core/hooks/computeNumberDateDefaultDependentAxisRange.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useLayoutEffect } from 'react';
+import { useMemo } from 'react';
 import { PromiseHookState } from './promise';
 import {
   XYPlotDataWithCoverage,
@@ -36,24 +36,6 @@ export function useDefaultDependentAxisRange(
 
     return axisRangeMargin(defaultDependentRange, yAxisVariable?.type);
   }, [data, yAxisVariable, vizConfig.valueSpecConfig]);
-
-  // use this to avoid infinite loop: also use useLayoutEffect to avoid async/ghost issue
-  const updateVizConfigRef = useRef(updateVizConfig);
-  useLayoutEffect(() => {
-    updateVizConfigRef.current = updateVizConfig;
-  }, [updateVizConfig]);
-
-  // update vizConfig.dependentAxisRange as it is necessary for set range correctly
-  useLayoutEffect(() => {
-    if (!data.pending)
-      updateVizConfigRef.current({
-        dependentAxisRange: defaultDependentAxisRange,
-      });
-    else
-      updateVizConfigRef.current({
-        dependentAxisRange: undefined,
-      });
-  }, [data, defaultDependentAxisRange]);
 
   return defaultDependentAxisRange;
 }


### PR DESCRIPTION
Suggestion how to avoid the useRef and useLayoutEffect and keep things simple

The main things I did were
1. pass `vizConfig.dependentAxisRange ?? defaultDependentAxisRange` to both the plot component and plot controls - this means we can reset vizConfig.dependentAxisRange to undefined which makes things cleaner.
2. add a new flag to the onChangeHandlerFactory to reset the dependentAxisRange for valueSpec and showMissingness handlers (onVariableChange also resets the dependent axis range, which I think is a good idea)

I also updated the thumbnail dependencies.