### PR TITLE
Reverse the order of entity nodes in diagram, but not in variable tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/core/components/EntityDiagram.tsx
+++ b/src/lib/core/components/EntityDiagram.tsx
@@ -34,7 +34,7 @@ export function EntityDiagram(props: Props) {
       (entity) => entity.children ?? [],
       studyMetadata.rootEntity
     );
-  }, []);
+  }, [studyMetadata.rootEntity]);
   const [lastVariableMap, setLastVariableMap] = useState<
     Record<string, string>
   >({});

--- a/src/lib/core/components/EntityDiagram.tsx
+++ b/src/lib/core/components/EntityDiagram.tsx
@@ -5,7 +5,10 @@ import EntityDiagramComponent, {
 } from '@veupathdb/components/lib/EntityDiagram/EntityDiagram';
 import { StudyEntity } from '../types/study';
 import { VariableLink } from './VariableLink';
-import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
+import {
+  mapStructure,
+  preorder,
+} from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { reduce } from '@veupathdb/wdk-client/lib/Utils/IterableUtils';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -22,6 +25,16 @@ interface Props {
 export function EntityDiagram(props: Props) {
   const { selectedEntity, selectedVariable } = props;
   const studyMetadata = useStudyMetadata();
+  const entityTree = useMemo((): StudyEntity => {
+    return mapStructure(
+      (node, children) => ({
+        ...node,
+        children: children.slice().reverse(),
+      }),
+      (entity) => entity.children ?? [],
+      studyMetadata.rootEntity
+    );
+  }, []);
   const [lastVariableMap, setLastVariableMap] = useState<
     Record<string, string>
   >({});
@@ -56,7 +69,7 @@ export function EntityDiagram(props: Props) {
   };
 
   const dimensions = getDimensions(
-    studyMetadata.rootEntity,
+    entityTree,
     props.orientation,
     props.expanded
   );
@@ -67,7 +80,7 @@ export function EntityDiagram(props: Props) {
   return (
     <EntityDiagramComponent
       isExpanded={props.expanded}
-      treeData={studyMetadata.rootEntity as StudyData}
+      treeData={entityTree as StudyData}
       highlightedEntityID={props.selectedEntity}
       orientation={props.orientation}
       filteredEntities={props.filteredEntities}

--- a/src/lib/core/components/EntityTree.tsx
+++ b/src/lib/core/components/EntityTree.tsx
@@ -1,7 +1,0 @@
-import { StudyEntity } from '../types/study';
-
-interface Props {
-  entityTree: StudyEntity;
-}
-
-export function EntityTree(props: Props) {}

--- a/src/lib/core/hooks/study.ts
+++ b/src/lib/core/hooks/study.ts
@@ -158,10 +158,7 @@ export function useFindEntityAndVariable(entities: StudyEntity[]) {
 
 export function useStudyEntities(rootEntity: StudyEntity) {
   return useMemo(
-    () =>
-      Array.from(
-        preorder(rootEntity, (e) => e.children?.slice().reverse() ?? [])
-      ),
+    () => Array.from(preorder(rootEntity, (e) => e.children ?? [])),
     [rootEntity]
   );
 }


### PR DESCRIPTION
The ordering of nodes has been stabilized on the backend, when constructing the entity tree. This requires an adjustment to how the tree is traversed when displaying the variable tree and the entity diagram.

fixes #859 