### PR TITLE
findFirstVariable: search only "scoped" variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/core/components/EDAWorkspaceContainer.tsx
+++ b/src/lib/core/components/EDAWorkspaceContainer.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode, useMemo } from 'react';
 
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
+import { TreeNode } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/Types';
 
-import { StudyMetadata } from '..';
 import SubsettingClient from '../api/SubsettingClient';
 import DataClient from '../api/DataClient';
 import { AnalysisClient } from '../api/analysis-api';
@@ -12,9 +12,14 @@ import {
 } from '../context/WorkspaceContext';
 import {
   HookValue as WdkStudyRecord,
+  useStudyEntities,
   useStudyMetadata,
   useWdkStudyRecord,
 } from '../hooks/study';
+
+import { FieldWithMetadata, StudyMetadata } from '..';
+
+import { useFieldTree, useFlattenedFields } from './variableTrees/hooks';
 
 export interface Props {
   studyId: string;
@@ -24,7 +29,7 @@ export interface Props {
   subsettingClient: SubsettingClient;
   dataClient: DataClient;
   initializeMakeVariableLink?: (
-    studyMetadata: StudyMetadata
+    fieldTree: TreeNode<FieldWithMetadata>
   ) => MakeVariableLink;
 }
 
@@ -59,10 +64,13 @@ function EDAWorkspaceContainerWithLoadedData({
   wdkStudyRecord,
   studyMetadata,
 }: LoadedDataProps) {
+  const entities = useStudyEntities(studyMetadata.rootEntity);
+  const variableTreeFields = useFlattenedFields(entities, 'variableTree');
+  const variableTree = useFieldTree(variableTreeFields);
+
   const makeVariableLink = useMemo(
-    () =>
-      initializeMakeVariableLink && initializeMakeVariableLink(studyMetadata),
-    [initializeMakeVariableLink, studyMetadata]
+    () => initializeMakeVariableLink?.(variableTree),
+    [initializeMakeVariableLink, variableTree]
   );
 
   return (

--- a/src/lib/core/components/VariableLink.tsx
+++ b/src/lib/core/components/VariableLink.tsx
@@ -1,9 +1,9 @@
 /*
  * Link to the page for a variable
  */
-import React from 'react';
+import { useMemo } from 'react';
 import { Link, LinkProps } from 'react-router-dom';
-import { useStudyMetadata, useMakeVariableLink } from '../hooks/workspace';
+import { useMakeVariableLink } from '../hooks/workspace';
 
 export interface Props<S = unknown> extends Omit<LinkProps<S>, 'to'> {
   entityId?: string;
@@ -12,13 +12,15 @@ export interface Props<S = unknown> extends Omit<LinkProps<S>, 'to'> {
 
 export function VariableLink(props: Props) {
   const { entityId, variableId, ...rest } = props;
-  const studyMetadata = useStudyMetadata();
   const makeVariableLink = useMakeVariableLink();
-  return (
-    <Link
-      {...rest}
-      replace
-      to={makeVariableLink({ entityId, variableId }, studyMetadata)}
-    />
+  const variableLink = useMemo(
+    () =>
+      makeVariableLink({
+        entityId,
+        variableId,
+      }),
+    [makeVariableLink, entityId, variableId]
   );
+
+  return <Link {...rest} replace to={variableLink} />;
 }

--- a/src/lib/core/context/WorkspaceContext.ts
+++ b/src/lib/core/context/WorkspaceContext.ts
@@ -6,10 +6,7 @@ import { StudyMetadata, StudyRecord, StudyRecordClass } from '../types/study';
 import { VariableDescriptor } from '../types/variable';
 
 export interface MakeVariableLink {
-  (
-    variableDescriptor: Partial<VariableDescriptor>,
-    studyMetadata: StudyMetadata
-  ): string;
+  (variableDescriptor: Partial<VariableDescriptor>): string;
 }
 export interface WorkspaceContextValue {
   studyRecordClass: StudyRecordClass;

--- a/src/lib/core/hooks/study.ts
+++ b/src/lib/core/hooks/study.ts
@@ -36,7 +36,7 @@ interface StudyState {
 
 export const StudyContext = createContext<StudyState | undefined>(undefined);
 
-interface HookValue {
+export interface HookValue {
   studyRecordClass: StudyRecordClass;
   studyRecord: StudyRecord;
 }

--- a/src/lib/core/hooks/workspace.ts
+++ b/src/lib/core/hooks/workspace.ts
@@ -34,10 +34,10 @@ export function useMakeVariableLink(): MakeVariableLink {
   );
 }
 
-function defaultMakeVariableLink(
-  { variableId, entityId }: Partial<VariableDescriptor>,
-  studyMetadata: StudyMetadata
-): string {
+function defaultMakeVariableLink({
+  variableId,
+  entityId,
+}: Partial<VariableDescriptor>): string {
   return variableId && entityId
     ? `/variables/${entityId}/${variableId}`
     : entityId

--- a/src/lib/workspace/DefaultVariableRedirect.tsx
+++ b/src/lib/workspace/DefaultVariableRedirect.tsx
@@ -29,7 +29,9 @@ export function DefaultVariableRedirect(props: Props) {
       ? entities.find((e) => e.id === entityId)
       : entities[0];
     finalEntityId = entity?.id;
-    finalVariableId = entity && findFirstVariable(entity.variables).id;
+    finalVariableId =
+      entity &&
+      findFirstVariable(fieldTree, entity.id)?.field.term.split('/')[1];
   } else {
     // Use the first featured variable
     [finalEntityId, finalVariableId] = featuredFields[0].term.split('/');

--- a/src/lib/workspace/Subsetting/index.tsx
+++ b/src/lib/workspace/Subsetting/index.tsx
@@ -112,9 +112,7 @@ export default function Subsetting({
           onChange={(variable) => {
             if (variable) {
               const { entityId, variableId } = variable;
-              history.replace(
-                makeVariableLink({ entityId, variableId }, studyMetadata)
-              );
+              history.replace(makeVariableLink({ entityId, variableId }));
             } else history.replace('..');
           }}
         />

--- a/src/lib/workspace/Utils.ts
+++ b/src/lib/workspace/Utils.ts
@@ -1,63 +1,40 @@
+import { isFilterField } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/AttributeFilterUtils';
+import { TreeNode } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/Types';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
-import { groupBy } from 'lodash';
-import { Variable, VariableTreeNode } from '../core/types/study';
+import { preorderSeq } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
+
+import { FieldWithMetadata } from '../core/types/study';
 
 import './EDAWorkspace.scss';
 export const cx = makeClassNameHelper('EDAWorkspace');
 
 /**
- * Returns the first featured var; if none exist, then returns the
- * first non-category var in the tree using depth first search.
+ * Given a field tree and entity ID, return either:
+ *
+ * 1. The "first" featured variable for that entity, or, if none exist,
+ * 2. The "first" selectable variable for that entity, or if none exist,
+ * 3. undefined
+ *
+ * (Here, we mean "first" in the sense of preorder traversal of the field tree.)
  */
-export function findFirstVariable(variables: VariableTreeNode[]): Variable {
-  // look for featured variables and return the first if any
-  const featuredVariable = variables.find(
-    (v): v is Variable => v.type !== 'category' && v.isFeatured
+export function findFirstVariable(
+  fieldTree: TreeNode<FieldWithMetadata>,
+  entityId: string,
+  isSelectable = (node: TreeNode<FieldWithMetadata>) =>
+    isFilterField(node.field)
+): TreeNode<FieldWithMetadata> | undefined {
+  const entitySubtree = preorderSeq(fieldTree).find(
+    (node) => node.field.term === `entity:${entityId}`
   );
 
-  if (featuredVariable) return featuredVariable;
-
-  // Find root variables. These are variables whose parent is not present in the provided array.
-  const roots = findRootVariables(variables);
-
-  if (roots.length === 0)
-    throw new Error('Tree is broken: cannot determine root nodes.');
-
-  // Traverse first branch of tree and find first non-category node
-  const variable = findFirstNonCategory(
-    groupBy(variables, (v) => v.parentId),
-    roots[0]
-  );
-
-  // if no nodes have the specified parent, tree is broken because entity or category has no children
-  if (variable == null) {
-    // TODO: return undefined here instead?
+  if (entitySubtree == null) {
     throw new Error(
-      'Tree is broken: could not find a non-category node in first branch.'
+      'Tried to find the first variable of an nonexistent entity'
     );
   }
 
-  return variable;
-}
-
-function findRootVariables(variables: VariableTreeNode[]): VariableTreeNode[] {
-  // A variable is a root if its parent variable is not in the provided array.
-  // This can happen if parentId == null, or if the parentId refers to a variable
-  // that is not included.
-  const variableIds = new Set(variables.map((v) => v.id));
-  return variables.filter(
-    (v) => v.parentId == null || !variableIds.has(v.parentId)
+  return (
+    preorderSeq(entitySubtree).find((node) => node.field.isFeatured === true) ??
+    preorderSeq(entitySubtree).find(isSelectable)
   );
-}
-
-function findFirstNonCategory(
-  variablesByParentId: Record<string, VariableTreeNode[] | undefined>,
-  root: VariableTreeNode
-): Variable | undefined {
-  const children = variablesByParentId[root.id];
-  const firstChild = children && children[0];
-  if (firstChild == null) return undefined;
-  if (firstChild.type === 'category')
-    return findFirstNonCategory(variablesByParentId, firstChild);
-  return firstChild;
 }

--- a/src/lib/workspace/WorkspaceContainer.tsx
+++ b/src/lib/workspace/WorkspaceContainer.tsx
@@ -1,16 +1,15 @@
 import { ReactNode, useCallback } from 'react';
 import { useRouteMatch } from 'react-router';
 
-import { find } from '@veupathdb/wdk-client/lib/Utils/IterableUtils';
-import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
-import { EDAWorkspaceContainer, StudyMetadata } from '../core';
+import { TreeNode } from '@veupathdb/wdk-client/lib/Components/AttributeFilter/Types';
+
+import { EDAWorkspaceContainer, FieldWithMetadata } from '../core';
 import {
   useConfiguredAnalysisClient,
   useConfiguredDataClient,
   useConfiguredSubsettingClient,
 } from '../core/hooks/client';
 import { VariableDescriptor } from '../core/types/variable';
-import { EDAWorkspace } from './EDAWorkspace';
 import { cx, findFirstVariable } from './Utils';
 
 import { makeStyles } from '@material-ui/core/styles';
@@ -35,7 +34,6 @@ interface Props {
 /** Allows a user to create a new analysis or edit an existing one. */
 export function WorkspaceContainer({
   studyId,
-  analysisId,
   subsettingServiceUrl,
   dataServiceUrl,
   userServiceUrl,
@@ -46,19 +44,17 @@ export function WorkspaceContainer({
   const dataClient = useConfiguredDataClient(dataServiceUrl);
   const analysisClient = useConfiguredAnalysisClient(userServiceUrl);
   const initializeMakeVariableLink = useCallback(
-    (studyMetadata: StudyMetadata) => ({
+    (fieldTree: TreeNode<FieldWithMetadata>) => ({
       entityId: maybeEntityId,
       variableId: maybeVariableId,
     }: Partial<VariableDescriptor>) => {
-      const entityId = maybeEntityId ?? studyMetadata.rootEntity.id;
-      const entity = find(
-        (entity) => entity.id === entityId,
-        preorder(studyMetadata.rootEntity, (e) => e.children ?? [])
-      );
+      const entityId = maybeEntityId ?? fieldTree.field.term.split(':')[1];
+
       const variableId =
         maybeVariableId ??
-        (entity.variables.length !== 0 &&
-          findFirstVariable(entity.variables)?.id);
+        (entityId &&
+          findFirstVariable(fieldTree, entityId)?.field.term.split('/')[1]);
+
       return entityId && variableId
         ? `${url}/variables/${entityId}/${variableId}`
         : entityId

--- a/src/lib/workspace/WorkspaceContainer.tsx
+++ b/src/lib/workspace/WorkspaceContainer.tsx
@@ -45,14 +45,11 @@ export function WorkspaceContainer({
   const subsettingClient = useConfiguredSubsettingClient(subsettingServiceUrl);
   const dataClient = useConfiguredDataClient(dataServiceUrl);
   const analysisClient = useConfiguredAnalysisClient(userServiceUrl);
-  const makeVariableLink = useCallback(
-    (
-      {
-        entityId: maybeEntityId,
-        variableId: maybeVariableId,
-      }: Partial<VariableDescriptor>,
-      studyMetadata: StudyMetadata
-    ) => {
+  const initializeMakeVariableLink = useCallback(
+    (studyMetadata: StudyMetadata) => ({
+      entityId: maybeEntityId,
+      variableId: maybeVariableId,
+    }: Partial<VariableDescriptor>) => {
       const entityId = maybeEntityId ?? studyMetadata.rootEntity.id;
       const entity = find(
         (entity) => entity.id === entityId,
@@ -79,7 +76,7 @@ export function WorkspaceContainer({
       analysisClient={analysisClient}
       dataClient={dataClient}
       subsettingClient={subsettingClient}
-      makeVariableLink={makeVariableLink}
+      initializeMakeVariableLink={initializeMakeVariableLink}
     >
       {children}
     </EDAWorkspaceContainer>


### PR DESCRIPTION
Resolves #861 

Future work: instead of passing a WDK field tree to `findFirstVariable`, pass a variable tree with EDA-specific metadata.