### PR TITLE
Stand alone study page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.3.14",
+  "version": "1.4.0",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -138,7 +138,7 @@ initialize({
         return (
           <DevLoginFormContext.Provider value={loginFormContext}>
             <DataRestrictionDaemon
-              makeStudyPageRoute={(id: string) => `/eda/${id}/details`}
+              makeStudyPageRoute={(id: string) => `/eda/${id}`}
             />
             <UIThemeProvider
               theme={{

--- a/src/lib/core/components/EDAWorkspaceContainer.tsx
+++ b/src/lib/core/components/EDAWorkspaceContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import SubsettingClient from '../api/SubsettingClient';
 import DataClient from '../api/DataClient';
@@ -12,7 +12,7 @@ import { Loading } from '@veupathdb/wdk-client/lib/Components';
 
 export interface Props {
   studyId: string;
-  children: React.ReactChild | React.ReactChild[];
+  children: ReactNode;
   className?: string;
   analysisClient: AnalysisClient;
   subsettingClient: SubsettingClient;

--- a/src/lib/core/hooks/study.ts
+++ b/src/lib/core/hooks/study.ts
@@ -24,6 +24,7 @@ import {
 import SubsettingClient from '../api/SubsettingClient';
 import { VariableDescriptor } from '../types/variable';
 import { findEntityAndVariable } from '../utils/study-metadata';
+import { getStudyAccess } from '@veupathdb/study-data-access/lib/shared/studies';
 
 const STUDY_RECORD_CLASS_NAME = 'dataset';
 
@@ -97,8 +98,8 @@ const DEFAULT_STUDY_ATTRIBUTES = ['dataset_id', 'eda_study_id'];
 const DEFAULT_STUDY_TABLES: string[] = [];
 
 export function useWdkStudyRecords(
-  attributes: AnswerJsonFormatConfig['attributes'] = DEFAULT_STUDY_ATTRIBUTES,
-  tables: AnswerJsonFormatConfig['tables'] = DEFAULT_STUDY_TABLES
+  attributes: AnswerJsonFormatConfig['attributes'] = [],
+  tables: AnswerJsonFormatConfig['tables'] = []
 ): StudyRecord[] | undefined {
   return useWdkService(
     (wdkService) =>
@@ -110,8 +111,8 @@ export function useWdkStudyRecords(
           },
         },
         {
-          attributes,
-          tables,
+          attributes: DEFAULT_STUDY_ATTRIBUTES.concat(attributes),
+          tables: DEFAULT_STUDY_TABLES.concat(tables),
           sorting: [
             {
               attributeName: 'display_name',
@@ -124,18 +125,35 @@ export function useWdkStudyRecords(
   )?.records;
 }
 
+export const STUB_ENTITY: StudyEntity = {
+  id: '__STUB__',
+  idColumnName: 'stub',
+  displayName: 'stub',
+  description: 'This is a stub entity. It does not exist in the database.',
+  variables: [],
+};
+
+export function isStubEntity(entity: StudyEntity) {
+  return entity === STUB_ENTITY;
+}
+
 export function useStudyMetadata(datasetId: string, client: SubsettingClient) {
   return useWdkServiceWithRefresh(
     async (wdkService) => {
       const studyRecord = await wdkService.getRecord(
         STUDY_RECORD_CLASS_NAME,
         [{ name: 'dataset_id', value: datasetId }],
-        { attributes: ['dataset_id', 'eda_study_id'] }
+        { attributes: ['dataset_id', 'eda_study_id', 'study_access'] }
       );
       if (typeof studyRecord.attributes.eda_study_id !== 'string')
         throw new Error(
           'Could not find study with associated dataset id `' + datasetId + '`.'
         );
+      if (getStudyAccess(studyRecord) === 'prerelease')
+        return {
+          id: studyRecord.attributes.eda_study_id,
+          rootEntity: STUB_ENTITY,
+        };
       return client.getStudyMetadata(studyRecord.attributes.eda_study_id);
     },
     [datasetId, client]

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -41,7 +41,6 @@ import NotesTab from './NotesTab';
 import DownloadsTab from './DownloadsTab';
 import { Alert } from '@material-ui/lab';
 import ShareFromAnalysis from './sharing/ShareFromAnalysis';
-import { string } from 'fp-ts';
 import { useWorkspaceAnalysis } from './hooks/analyses';
 import { ApprovalStatus } from '@veupathdb/study-data-access/lib/data-restriction/dataRestrictionHooks';
 import { RestrictedPage } from '@veupathdb/study-data-access/lib/data-restriction/RestrictedPage';

--- a/src/lib/workspace/EDAWorkspace.tsx
+++ b/src/lib/workspace/EDAWorkspace.tsx
@@ -1,39 +1,20 @@
-import { isNewAnalysis } from '../core/utils/analysis';
-
 import { EDAWorkspaceHeading } from './EDAWorkspaceHeading';
-import { AnalysisPanel } from './AnalysisPanel';
 import { useWorkspaceAnalysis } from './hooks/analyses';
+import { ReactNode } from 'react';
 
 interface Props {
   studyId: string;
   analysisId?: string;
-  /**
-   * The base of the URL from which to being sharing links.
-   * This is passed down through several component layers. */
-  sharingUrlPrefix: string;
-  /**
-   * A callback to open a login form.
-   * This is also passed down through several component layers. */
-  showLoginForm: () => void;
+  children: ReactNode;
 }
 
-export const EDAWorkspace = ({
-  studyId,
-  analysisId,
-  sharingUrlPrefix,
-  showLoginForm,
-}: Props) => {
+export const EDAWorkspace = ({ studyId, analysisId, children }: Props) => {
   const analysisState = useWorkspaceAnalysis(studyId, analysisId);
 
   return (
     <>
       <EDAWorkspaceHeading analysisState={analysisState} />
-      <AnalysisPanel
-        analysisState={analysisState}
-        hideCopyAndSave={isNewAnalysis(analysisState.analysis)}
-        sharingUrlPrefix={sharingUrlPrefix}
-        showLoginForm={showLoginForm}
-      />
+      {children}
     </>
   );
 };

--- a/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -15,13 +15,10 @@ import AddIcon from '@material-ui/icons/Add';
 
 // Hooks
 import { useStudyRecord } from '../core/hooks/workspace';
-// import { useAttemptActionCallback } from '@veupathdb/study-data-access/lib/data-restriction/dataRestrictionHooks';
 
 // Definitions & Utilities
 import { cx } from './Utils';
 import { AnalysisState, DEFAULT_ANALYSIS_NAME } from '../core';
-// import { LinkAttributeValue } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
-// import { Action } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUiActions';
 import { getAnalysisId, isSavedAnalysis } from '../core/utils/analysis';
 
 interface EDAWorkspaceHeadingProps {
@@ -55,24 +52,6 @@ export function EDAWorkspaceHeading({
       <div className={cx('-Heading')}>
         <h1>{safeHtml(studyRecord.displayName)}</h1>
         <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-          {/* {studyRecord.attributes.bulk_download_url && (
-            <div>
-              <FloatingButton
-                text="Download"
-                tooltip="Download study files"
-                icon={Download}
-                onPress={() => {
-                  attemptAction(Action.download, {
-                    studyId: studyRecord.id[0].value,
-                    onAllow: () => {
-                      window.location.href = (studyRecord.attributes
-                        .bulk_download_url as LinkAttributeValue).url;
-                    },
-                  });
-                }}
-              />
-            </div>
-          )} */}
           <div>
             <FloatingButton
               themeRole="primary"

--- a/src/lib/workspace/StudyList.tsx
+++ b/src/lib/workspace/StudyList.tsx
@@ -4,7 +4,10 @@ import {
   useSetDocumentTitle,
 } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 
+import { usePermissions } from '@veupathdb/study-data-access/lib/data-restriction/permissionsHooks';
+
 import { useWdkStudyRecords } from '../core/hooks/study';
+import { getStudyAccess } from '@veupathdb/study-data-access/lib/shared/studies';
 
 interface StudyListProps {
   subsettingServiceUrl: string;
@@ -15,11 +18,13 @@ interface StudyListProps {
  */
 export function StudyList(props: StudyListProps) {
   const { baseUrl } = props;
-  const datasets = useWdkStudyRecords();
+  const datasets = useWdkStudyRecords(['study_access']);
+
+  const permissions = usePermissions();
 
   useSetDocumentTitle('All studies');
 
-  if (datasets == null) return <Loading />;
+  if (datasets == null || permissions.loading) return <Loading />;
   return (
     <div>
       <h1>EDA Workspace</h1>
@@ -30,8 +35,9 @@ export function StudyList(props: StudyListProps) {
           .map((dataset) => {
             return (
               <li key={dataset.attributes.dataset_id as string}>
-                <Link to={`${baseUrl}/${dataset.attributes.dataset_id}`}>
-                  {safeHtml(dataset.displayName)}
+                <Link to={`${baseUrl}/${dataset.attributes.dataset_id}/new`}>
+                  {safeHtml(dataset.displayName)} [
+                  <b>{getStudyAccess(dataset)}</b>]
                 </Link>
               </li>
             );

--- a/src/lib/workspace/WorkspaceContainer.tsx
+++ b/src/lib/workspace/WorkspaceContainer.tsx
@@ -1,10 +1,8 @@
-import { useCallback } from 'react';
+import { ReactNode, useCallback } from 'react';
 import { useRouteMatch } from 'react-router';
 
 import { find } from '@veupathdb/wdk-client/lib/Utils/IterableUtils';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
-import { RestrictedPage } from '@veupathdb/study-data-access/lib/data-restriction/RestrictedPage';
-import { useApprovalStatus } from '@veupathdb/study-data-access/lib/data-restriction/dataRestrictionHooks';
 import { EDAWorkspaceContainer, StudyMetadata } from '../core';
 import {
   useConfiguredAnalysisClient,
@@ -31,14 +29,7 @@ interface Props {
   subsettingServiceUrl: string;
   dataServiceUrl: string;
   userServiceUrl: string;
-  /**
-   * The base of the URL from which to being sharing links.
-   * This is passed down through several component layers. */
-  sharingUrlPrefix: string;
-  /**
-   * A callback to open a login form.
-   * This is also passed down through several component layers. */
-  showLoginForm: () => void;
+  children: ReactNode;
 }
 
 /** Allows a user to create a new analysis or edit an existing one. */
@@ -48,8 +39,7 @@ export function WorkspaceContainer({
   subsettingServiceUrl,
   dataServiceUrl,
   userServiceUrl,
-  sharingUrlPrefix,
-  showLoginForm,
+  children,
 }: Props) {
   const { url } = useRouteMatch();
   const subsettingClient = useConfiguredSubsettingClient(subsettingServiceUrl);
@@ -80,26 +70,18 @@ export function WorkspaceContainer({
     },
     [url]
   );
-  const approvalStatus = useApprovalStatus(studyId, 'analysis');
   const classes = useStyles();
 
   return (
-    <RestrictedPage approvalStatus={approvalStatus}>
-      <EDAWorkspaceContainer
-        studyId={studyId}
-        className={`${cx()} ${classes.workspace}`}
-        analysisClient={analysisClient}
-        dataClient={dataClient}
-        subsettingClient={subsettingClient}
-        makeVariableLink={makeVariableLink}
-      >
-        <EDAWorkspace
-          studyId={studyId}
-          analysisId={analysisId}
-          sharingUrlPrefix={sharingUrlPrefix}
-          showLoginForm={showLoginForm}
-        />
-      </EDAWorkspaceContainer>
-    </RestrictedPage>
+    <EDAWorkspaceContainer
+      studyId={studyId}
+      className={`${cx()} ${classes.workspace}`}
+      analysisClient={analysisClient}
+      dataClient={dataClient}
+      subsettingClient={subsettingClient}
+      makeVariableLink={makeVariableLink}
+    >
+      {children}
+    </EDAWorkspaceContainer>
   );
 }

--- a/src/lib/workspace/WorkspaceRouter.tsx
+++ b/src/lib/workspace/WorkspaceRouter.tsx
@@ -139,6 +139,7 @@ export function WorkspaceRouter({
                   {...props.match.params}
                   sharingUrlPrefix={sharingUrlPrefix}
                   showLoginForm={showLoginForm}
+                  hideSavedAnalysisButtons
                 />
               </WorkspaceContainer>
             )}

--- a/src/lib/workspace/WorkspaceRouter.tsx
+++ b/src/lib/workspace/WorkspaceRouter.tsx
@@ -16,12 +16,14 @@ import {
   useConfiguredSubsettingClient,
 } from '../core/hooks/client';
 import { AllAnalyses } from './AllAnalyses';
-import { EDAAnalysisList } from './EDAAnalysisList';
 import { ImportAnalysis } from './ImportAnalysis';
 import { LatestAnalysis } from './LatestAnalysis';
 import { PublicAnalysesRoute } from './PublicAnalysesRoute';
 import { StudyList } from './StudyList';
 import { WorkspaceContainer } from './WorkspaceContainer';
+import { AnalysisPanel } from './AnalysisPanel';
+import { RecordController } from '@veupathdb/wdk-client/lib/Controllers';
+import { EDAWorkspaceHeading } from './EDAWorkspaceHeading';
 
 const theme = createTheme(workspaceTheme);
 
@@ -110,12 +112,18 @@ export function WorkspaceRouter({
             path={`${path}/:studyId`}
             exact
             render={(props: RouteComponentProps<{ studyId: string }>) => (
-              <EDAAnalysisList
+              <WorkspaceContainer
                 {...props.match.params}
                 subsettingServiceUrl={subsettingServiceUrl}
                 dataServiceUrl={dataServiceUrl}
                 userServiceUrl={userServiceUrl}
-              />
+              >
+                <EDAWorkspaceHeading />
+                <RecordController
+                  recordClass="dataset"
+                  primaryKey={props.match.params.studyId}
+                />
+              </WorkspaceContainer>
             )}
           />
           <Route
@@ -126,9 +134,13 @@ export function WorkspaceRouter({
                 subsettingServiceUrl={subsettingServiceUrl}
                 dataServiceUrl={dataServiceUrl}
                 userServiceUrl={userServiceUrl}
-                sharingUrlPrefix={sharingUrlPrefix}
-                showLoginForm={showLoginForm}
-              />
+              >
+                <AnalysisPanel
+                  {...props.match.params}
+                  sharingUrlPrefix={sharingUrlPrefix}
+                  showLoginForm={showLoginForm}
+                />
+              </WorkspaceContainer>
             )}
           />
           <Route
@@ -184,9 +196,13 @@ export function WorkspaceRouter({
                 subsettingServiceUrl={subsettingServiceUrl}
                 dataServiceUrl={dataServiceUrl}
                 userServiceUrl={userServiceUrl}
-                sharingUrlPrefix={sharingUrlPrefix}
-                showLoginForm={showLoginForm}
-              />
+              >
+                <AnalysisPanel
+                  {...props.match.params}
+                  sharingUrlPrefix={sharingUrlPrefix}
+                  showLoginForm={showLoginForm}
+                />
+              </WorkspaceContainer>
             )}
           />
         </Switch>


### PR DESCRIPTION
This PR introduces a standalone study page route, in the context of the EDA workspace application.

**Details:**
- For private and prerelease, if the user does not have access, they will be redirected from the analysis page to the standalone study page
- For private and prerelease, the "New analysis" and "My analyses" buttons are removed

**Other things to consider:**
- What should be the behavior for importing/sharing? I'm not able to test right now due to instability on the backend, but I believe we will currently show the more traditional modal.