### PR TITLE
Handle entities without categories

### DIFF
--- a/src/lib/workspace/Utils.ts
+++ b/src/lib/workspace/Utils.ts
@@ -24,7 +24,7 @@ export function findFirstVariable(variables: VariableTreeNode[]): Variable {
     throw new Error('Tree is broken: cannot determine root nodes.');
 
   // Traverse first branch of tree and find first non-category node
-  // If the branch only consists of the root, and the root is not a category, return the root variable.
+  // If the root is not a category, then it is a variable. In this case, return the root variable.
   const variable = roots
     .map((root) =>
       root.type !== 'category'

--- a/src/lib/workspace/Utils.ts
+++ b/src/lib/workspace/Utils.ts
@@ -24,10 +24,17 @@ export function findFirstVariable(variables: VariableTreeNode[]): Variable {
     throw new Error('Tree is broken: cannot determine root nodes.');
 
   // Traverse first branch of tree and find first non-category node
-  const variable = findFirstNonCategory(
-    groupBy(variables, (v) => v.parentId),
-    roots[0]
-  );
+  // If the branch only consists of the root, and the root is not a category, return the root variable.
+  const variable = roots
+    .map((root) =>
+      root.type !== 'category'
+        ? root
+        : findFirstNonCategory(
+            groupBy(variables, (v) => v.parentId),
+            root
+          )
+    )
+    .find((variable) => variable != null);
 
   // if no nodes have the specified parent, tree is broken because entity or category has no children
   if (variable == null) {


### PR DESCRIPTION
After learning that mbio has some entities that have no categories (and sometimes no variables!), we looked for a way to gracefully handle the situation.

This PR implements a change that searches all roots, instead of just the first root, for a good variable (credit @jtlong3rd and @dmfalke). Additionally, if the root is not a category, then it is a variable and so should be returned as-is. 

@jtlong3rd @dmfalke is there a reason we wouldn't want to include these top level variables (non-category variables that sit directly under the entity)? It would be great to fix this problem for mbio, but if we're breaking how we expect the data to look, i'm happy to wait for the data to be reloaded without this entity.

