### PR TITLE
Integer-based bin slider limits for integer vars, reduced precision of limit labels, max binwidth now half what it was

### DIFF
--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -791,6 +791,13 @@ function computeBinSlider(
       return { min: 1, max: 60, step: 1 };
     }
     case 'integer':
+      const { min: rangeMin, max: rangeMax } = range as NumberRange;
+      const rangeSize = rangeMax - rangeMin;
+      const maxBins = 100;
+      const stepSize = Math.floor(rangeSize / maxBins);
+      const min = stepSize < 1 ? 1 : stepSize;
+      const max = Math.floor(rangeSize / 2);
+      return { min, max, step: min };
     case 'number': {
       const { min: rangeMin, max: rangeMax } = range as NumberRange;
       const rangeSize = Math.round((rangeMax - rangeMin) * 100) / 100;

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -786,6 +786,7 @@ function computeBinSlider(
   type: HistogramVariable['type'],
   range: NumberOrDateRange
 ) {
+  const [minBins, maxBins] = [2, 1000];
   switch (type) {
     case 'date': {
       return { min: 1, max: 60, step: 1 };
@@ -793,17 +794,16 @@ function computeBinSlider(
     case 'integer': {
       const { min: rangeMin, max: rangeMax } = range as NumberRange;
       const rangeSize = rangeMax - rangeMin;
-      const maxBins = 100;
       const stepSize = Math.floor(rangeSize / maxBins);
       const min = stepSize < 1 ? 1 : stepSize;
-      const max = rangeSize;
+      const max = Math.floor(rangeSize / minBins);
       return { min, max, step: min };
     }
     case 'number': {
       const { min: rangeMin, max: rangeMax } = range as NumberRange;
-      const rangeSize = Math.round((rangeMax - rangeMin) * 100) / 100;
-      const max = rangeSize;
-      const min = rangeSize / 1000;
+      const rangeSize = rangeMax - rangeMin;
+      const max = Number((rangeSize / minBins).toPrecision(2));
+      const min = Number((rangeSize / maxBins).toPrecision(2));
       return { min, max, step: min };
     }
   }

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -790,7 +790,7 @@ function computeBinSlider(
     case 'date': {
       return { min: 1, max: 60, step: 1 };
     }
-    case 'integer':
+    case 'integer': {
       const { min: rangeMin, max: rangeMax } = range as NumberRange;
       const rangeSize = rangeMax - rangeMin;
       const maxBins = 100;
@@ -798,6 +798,7 @@ function computeBinSlider(
       const min = stepSize < 1 ? 1 : stepSize;
       const max = rangeSize;
       return { min, max, step: min };
+    }
     case 'number': {
       const { min: rangeMin, max: rangeMax } = range as NumberRange;
       const rangeSize = Math.round((rangeMax - rangeMin) * 100) / 100;

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -796,7 +796,7 @@ function computeBinSlider(
       const maxBins = 100;
       const stepSize = Math.floor(rangeSize / maxBins);
       const min = stepSize < 1 ? 1 : stepSize;
-      const max = Math.floor(rangeSize / 2);
+      const max = rangeSize;
       return { min, max, step: min };
     case 'number': {
       const { min: rangeMin, max: rangeMax } = range as NumberRange;


### PR DESCRIPTION
Resolves #871 
Resolves #873 

@chowington - note that variables like GEMS1A PRM Age are `type==='integer'` - so this PR will take precedence over your changes in #869 

Actually I can't find a problem with 1000 bins with floating point variables but will comment on your ticket about that.