### PR TITLE
My analyses: fix search bar when HTML tags are in study name, also solve endless datasets request

### DIFF
--- a/src/lib/core/hooks/study.ts
+++ b/src/lib/core/hooks/study.ts
@@ -96,10 +96,11 @@ export function useWdkStudyRecord(datasetId: string): HookValue | undefined {
 
 const DEFAULT_STUDY_ATTRIBUTES = ['dataset_id', 'eda_study_id'];
 const DEFAULT_STUDY_TABLES: string[] = [];
+const EMPTY_ARRAY: string[] = [];
 
 export function useWdkStudyRecords(
-  attributes: AnswerJsonFormatConfig['attributes'] = [],
-  tables: AnswerJsonFormatConfig['tables'] = []
+  attributes: AnswerJsonFormatConfig['attributes'] = EMPTY_ARRAY,
+  tables: AnswerJsonFormatConfig['tables'] = EMPTY_ARRAY
 ): StudyRecord[] | undefined {
   return useWdkService(
     (wdkService) =>

--- a/src/lib/workspace/AllAnalyses.tsx
+++ b/src/lib/workspace/AllAnalyses.tsx
@@ -94,7 +94,8 @@ export function AllAnalyses(props: Props) {
   const classes = useStyles();
 
   const queryParams = new URLSearchParams(location.search);
-  const searchText = queryParams.get('s') ?? '';
+  const searchParam = queryParams.get('s') ?? '';
+  const searchText = stripHTML(searchParam); // matches stripHTML(dataset.displayName) below
   const debouncedSearchText = useDebounce(searchText, 250);
 
   const setSearchText = useCallback(

--- a/src/lib/workspace/AllAnalyses.tsx
+++ b/src/lib/workspace/AllAnalyses.tsx
@@ -94,8 +94,11 @@ export function AllAnalyses(props: Props) {
   const classes = useStyles();
 
   const queryParams = new URLSearchParams(location.search);
-  const searchParam = queryParams.get('s') ?? '';
-  const searchText = stripHTML(searchParam); // matches stripHTML(dataset.displayName) below
+  const searchText = useMemo(() => {
+    const searchParam = queryParams.get('s') ?? '';
+    return stripHTML(searchParam); // matches stripHTML(dataset.displayName) below
+  }, [queryParams]);
+
   const debouncedSearchText = useDebounce(searchText, 250);
 
   const setSearchText = useCallback(


### PR DESCRIPTION
Resolves #780 

Also resolves a hitherto unreported bug (endless loop of study list requests)

The only issue with this solution is that if a user starts typing HTML, they find that it is impossible.  Alternatively we can keep the HTML tags in the search box, and add `'displayNameHTML'` to `searchableDatasetColumns`. 