### PR TITLE
Documentation: do not generate chunks for source maps and TypeScript …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/core/components/docs/Documentation.tsx
+++ b/src/lib/core/components/docs/Documentation.tsx
@@ -7,7 +7,11 @@ interface Props {
 
 export function Documentation(props: Props) {
   const Component = React.lazy(() =>
-    import('./' + props.documentName).catch((error) => {
+    import(
+      /* webpackInclude: /\.(js|jsx|ts|tsx)$/ */
+      /* webpackExclude: /\.d\.ts$/ */
+      './' + props.documentName
+    ).catch((error) => {
       console.error(error);
       return import('@veupathdb/wdk-client/lib/Components/PageStatus/Error');
     })


### PR DESCRIPTION
…declaration files

Related to `multiple console warnings (possibly due to odd self-referencing of web-eda?)` from https://github.com/VEuPathDB/web-eda/issues/614. 

Currently, Webpack handles the dynamic import `import('./' + props.documentName)` by generating a chunk for each file in `./` (i.e., each file in the `/docs` directory). This is problematic for consumers who bundle the "compiled" assets which live in `@veupathdb/eda/lib/core/components/docs`, as this directory contains some source maps and TypeScript declaration files. For example, the web-eda local dev server generates some warnings like this:

```
./node_modules/@veupathdb/eda/lib/core/components/docs/Documentation.d.ts 1:0
Module parse failed: The keyword 'interface' is reserved (1:0)
File was processed with these loaders:
 * ./node_modules/ify-loader/index.js
 * ./node_modules/source-map-loader/dist/cjs.js
You may need an additional loader to handle the result of these loaders.
> interface Props {
|     documentName: string;
| }
```

This PR limits this chunk generation to JS(X)/TS(X) files, and in particular, excludes source maps and TypeScript declaration files.