### PR TITLE
Allow variables to be (un)checked by clicking on the name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
+++ b/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
@@ -82,23 +82,7 @@ export default function MultiSelectVariableTree({
     [onSelectedVariablesChange]
   );
 
-  const onActiveFieldChange = useCallback(
-    (term?: string) => {
-      if (term == null) return;
-      // If `term` is already selected, then remove it; else add it.
-      // Note that we're using the destructive `.splice()` method here when
-      // removing to make the code a little more efficient and succinct. We can
-      // get away with this becuase we're creating a new array, via `.map()`.
-      const selectedVariableFieldTerms = selectedVariableFields.map(
-        (field) => field.term
-      );
-      const indexOfTerm = selectedVariableFieldTerms.indexOf(term);
-      if (indexOfTerm === -1) selectedVariableFieldTerms.push(term);
-      else selectedVariableFieldTerms.splice(indexOfTerm, 1);
-      onSelectedVariableTermsChange(selectedVariableFieldTerms);
-    },
-    [onSelectedVariableTermsChange, selectedVariableFields]
-  );
+  const onActiveFieldChange = useCallback(() => undefined, []);
 
   return (
     <VariableList

--- a/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
+++ b/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
@@ -70,10 +70,6 @@ export default function MultiSelectVariableTree({
     return selectedVariableFields;
   }, [selectedVariableDescriptors, fieldsByTerm]);
 
-  const onActiveFieldChange = useCallback((term?: string) => {
-    console.log('Hello from Multi-Select onActiveFieldChange', term);
-  }, []);
-
   const onSelectedVariableTermsChange = useCallback(
     (terms: Array<string>) => {
       onSelectedVariablesChange(
@@ -84,6 +80,24 @@ export default function MultiSelectVariableTree({
       );
     },
     [onSelectedVariablesChange]
+  );
+
+  const onActiveFieldChange = useCallback(
+    (term?: string) => {
+      if (term == null) return;
+      // If term is already selected, then remove it; else add it.
+      // Note that we're using the destructive `splice` method here when removing
+      // to make the code a little more efficient and succinct. We can get away
+      // with this becuase we're creating a new array, via `.map()`.
+      const selectedVariableFieldTerms = selectedVariableFields.map(
+        (field) => field.term
+      );
+      const indexOfTerm = selectedVariableFieldTerms.indexOf(term);
+      if (indexOfTerm === -1) selectedVariableFieldTerms.push(term);
+      else selectedVariableFieldTerms.splice(indexOfTerm, 1);
+      onSelectedVariableTermsChange(selectedVariableFieldTerms);
+    },
+    [onSelectedVariableTermsChange, selectedVariableFields]
   );
 
   return (

--- a/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
+++ b/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
@@ -85,10 +85,10 @@ export default function MultiSelectVariableTree({
   const onActiveFieldChange = useCallback(
     (term?: string) => {
       if (term == null) return;
-      // If term is already selected, then remove it; else add it.
-      // Note that we're using the destructive `splice` method here when removing
-      // to make the code a little more efficient and succinct. We can get away
-      // with this becuase we're creating a new array, via `.map()`.
+      // If `term` is already selected, then remove it; else add it.
+      // Note that we're using the destructive `.splice()` method here when
+      // removing to make the code a little more efficient and succinct. We can
+      // get away with this becuase we're creating a new array, via `.map()`.
       const selectedVariableFieldTerms = selectedVariableFields.map(
         (field) => field.term
       );

--- a/src/lib/core/components/variableTrees/VariableList.tsx
+++ b/src/lib/core/components/variableTrees/VariableList.tsx
@@ -68,6 +68,7 @@ interface FieldNodeProps {
   field: VariableField;
   searchTerm: string;
   isActive: boolean;
+  isMultiPick: boolean;
   isDisabled?: boolean;
   isMultiFilterDescendant: boolean;
   showMultiFilterDescendants: boolean;
@@ -153,6 +154,7 @@ export default function VariableList({
     showOnlyCompatibleVariables,
     setShowOnlyCompatibleVariablesHandler,
   } = useContext(ShowHideVariableContext);
+  const isMultiPick = mode === 'multiSelection';
 
   const [searchTerm, setSearchTerm] = useState<string>('');
   const { setActiveDocument } = useActiveDocument();
@@ -179,7 +181,7 @@ export default function VariableList({
   // of the active field. We also want to retain the expanded state of internal nodes, so
   // we will only remove entity nodes from the list of expanded nodes.
   useEffect(() => {
-    if (activeField == null || mode === 'multiSelection') return;
+    if (activeField == null || isMultiPick) return;
     setExpandedNodes((expandedNodes) => {
       const activeNodeLineage = getPathToField(activeField);
       if (activeNodeLineage.every((node) => expandedNodes.includes(node))) {
@@ -198,13 +200,25 @@ export default function VariableList({
       );
       return newExpandedNodes;
     });
-  }, [activeField, activeFieldEntity, getPathToField, mode]);
+  }, [activeField, activeFieldEntity, getPathToField, isMultiPick]);
 
   const handleFieldSelect = useCallback(
     (field: Field) => {
-      onActiveFieldChange(field.term);
+      if (isMultiPick && onSelectedFieldsChange) {
+        // If `term` is already selected, then remove it; else add it.
+        // Note that we're using the destructive `.splice()` method here when
+        // removing to make the code a little more efficient and succinct. We can
+        // get away with this becuase we're creating a new array, via `.map()`.
+        const selectedFieldTerms = selectedFields.map((field) => field.term);
+        const indexOfField = selectedFieldTerms.indexOf(field.term);
+        if (indexOfField === -1) selectedFieldTerms.push(field.term);
+        else selectedFieldTerms.splice(indexOfField, 1);
+        onSelectedFieldsChange(selectedFieldTerms);
+      } else {
+        onActiveFieldChange(field.term);
+      }
     },
-    [onActiveFieldChange]
+    [isMultiPick, onSelectedFieldsChange, selectedFields, onActiveFieldChange]
   );
 
   const getNodeId = useCallback((node: FieldTreeNode) => {
@@ -306,6 +320,7 @@ export default function VariableList({
       return (
         <FieldNode
           field={node.field}
+          isMultiPick={isMultiPick}
           isMultiFilterDescendant={isMultiFilterDescendant}
           showMultiFilterDescendants={showMultiFilterDescendants}
           searchTerm={searchTerm}
@@ -325,6 +340,7 @@ export default function VariableList({
     },
     [
       multiFilterDescendants,
+      isMultiPick,
       showMultiFilterDescendants,
       searchTerm,
       activeField?.term,
@@ -518,7 +534,7 @@ export default function VariableList({
                   className="wdk-CheckboxTreeItem wdk-CheckboxTreeItem__leaf"
                 >
                   <div className="wdk-CheckboxTreeNodeContent">
-                    {mode === 'multiSelection' && (
+                    {isMultiPick && (
                       <input
                         type="checkbox"
                         checked={selectedFields.some(
@@ -537,6 +553,7 @@ export default function VariableList({
                       />
                     )}
                     <FieldNode
+                      isMultiPick={isMultiPick}
                       isMultiFilterDescendant={false}
                       showMultiFilterDescendants={showMultiFilterDescendants}
                       field={field}
@@ -570,7 +587,7 @@ export default function VariableList({
       {renderFeaturedFields()}
 
       <CheckboxTree
-        {...(mode === 'multiSelection' && {
+        {...(isMultiPick && {
           selectedList: selectedFields.map((field) => field.term),
           isSelectable: true,
           isMultiPick: true,
@@ -617,6 +634,7 @@ const FieldNode = ({
   searchTerm,
   isActive,
   isDisabled,
+  isMultiPick,
   customDisabledVariableMessage,
   handleFieldSelect,
   activeFieldEntity,
@@ -649,7 +667,9 @@ const FieldNode = ({
   ) ? (
     <Tooltip
       title={
-        isDisabled
+        isMultiPick
+          ? ''
+          : isDisabled
           ? customDisabledVariableMessage ??
             'This variable cannot be used with this plot and other variable selections.'
           : 'Select this variable.'


### PR DESCRIPTION
This is a quick fix to allow variables to be (un)checked by clicking on the name, when in multiselect mode.

Note that the tooltip still says "Select this variable", even if the variable is checked. Addressing this will be a little more involved.

fixes #891 