### PR TITLE
Clean up console logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/src/lib/core/components/filter/HistogramFilter.tsx
@@ -450,9 +450,6 @@ function HistogramPlotWithControls({
 
   const handleDependentAxisRangeChange = useCallback(
     (newRange?: NumberRange) => {
-      console.log(
-        `handleDependentAxisRangeChange newRange: ${newRange?.min} to ${newRange?.max}`
-      );
       updateUIState({
         dependentAxisRange: newRange,
       });

--- a/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
+++ b/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
@@ -63,9 +63,7 @@ export default function MultiSelectVariableTree({
     return selectedVariableFields;
   }, [selectedVariableDescriptors, fieldsByTerm]);
 
-  const onActiveFieldChange = useCallback((term?: string) => {
-    // console.log('Hello from Multi-Select onActiveFieldChange', term);
-  }, []);
+  const onActiveFieldChange = useCallback((term?: string) => {}, []);
 
   const onSelectedVariableTermsChange = useCallback(
     (terms: Array<string>) => {

--- a/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
+++ b/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
@@ -51,12 +51,6 @@ export default function MultiSelectVariableTree({
    * Translate selectedVariableTerms to corresponding Field objects.
    */
   const selectedVariableFields = useMemo(() => {
-    // console.log(
-    //   'MultiSelect -> selectedVariableFields',
-    //   selectedVariableDescriptors,
-    //   fieldsByTerm
-    // );
-
     const selectedVariableTerms = selectedVariableDescriptors.map(
       (descriptor) => `${descriptor.entityId}/${descriptor.variableId}`
     );
@@ -66,12 +60,11 @@ export default function MultiSelectVariableTree({
       fieldsByTerm[term] && selectedVariableFields.push(fieldsByTerm[term]);
     });
 
-    // console.log('WILL RETURN', selectedVariableFields);
     return selectedVariableFields;
   }, [selectedVariableDescriptors, fieldsByTerm]);
 
   const onActiveFieldChange = useCallback((term?: string) => {
-    console.log('Hello from Multi-Select onActiveFieldChange', term);
+    // console.log('Hello from Multi-Select onActiveFieldChange', term);
   }, []);
 
   const onSelectedVariableTermsChange = useCallback(


### PR DESCRIPTION
Related to Issue #585 

I initially tried to remove this handler from `MultiSelectVariableTree`:
```js 
const onActiveFieldChange = useCallback((term?: string) => {
  console.log('Hello from Multi-Select onActiveFieldChange', term);
}, []);
```
That led me to discover that `VariableList` receives the `onActiveFieldChange` handler from two sources, thus simply removing it and its references proved problematic. But without the `console.log` it's essentially doing nothing now which feels very odd:
```js
  const onActiveFieldChange = useCallback((term?: string) => {}, []);
```