### PR TITLE
Don't render the AnalysisPanel until the approvalStatus is loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -183,7 +183,7 @@ export function AnalysisPanel({
         <p>Could not load the analysis.</p>
       </div>
     );
-  if (analysis == null) return <Loading />;
+  if (analysis == null || approvalStatus === 'loading') return <Loading />;
   if (approvalStatus === 'not-approved')
     return <Redirect to={Path.normalize(routeBase + '/..')} />;
   return (

--- a/src/lib/workspace/StudyList.tsx
+++ b/src/lib/workspace/StudyList.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { Link, Loading } from '@veupathdb/wdk-client/lib/Components';
 import {
   safeHtml,
@@ -18,7 +20,10 @@ interface StudyListProps {
  */
 export function StudyList(props: StudyListProps) {
   const { baseUrl } = props;
-  const datasets = useWdkStudyRecords(['study_access']);
+
+  const studyRecordAttributes = useMemo(() => ['study_access'], []);
+
+  const datasets = useWdkStudyRecords(studyRecordAttributes);
 
   const permissions = usePermissions();
 

--- a/src/lib/workspace/Utils.ts
+++ b/src/lib/workspace/Utils.ts
@@ -28,9 +28,7 @@ export function findFirstVariable(
   );
 
   if (entitySubtree == null) {
-    throw new Error(
-      'Tried to find the first variable of an nonexistent entity'
-    );
+    throw new Error('Tried to find the first variable of a nonexistent entity');
   }
 
   return (


### PR DESCRIPTION
Fixes #898, as well as some peripheral issues:

1. A typo in a relevant error message
2. An infinite fetching loop in the `StudyList`

Ideas for future work:
1. DRY up the derivation of the `approvalStatus` by introducing a variant of `usePermissions` which receives an action type and returns an appropriate `ApprovalStatus` for that action
2. Generalize the `RestrictedPage` to handle the case where we don't want to render the `children` when the `ApprovalStatus` is `loading` or `not-approved`