### PR TITLE
Add italics for Downloads modal (and other fixes)

### DIFF
--- a/src/lib/workspace/DownloadTab/MySubset.tsx
+++ b/src/lib/workspace/DownloadTab/MySubset.tsx
@@ -90,7 +90,7 @@ export default function MySubset({
         styleOverrides={{ margin: '0px 0px 10px 0px' }}
         textSize="small"
       >
-        Configure and download one or more tabular views
+        Configure and download one or more tabular files of the filtered dataset
       </Paragraph>
       {Object.values(entities).map((data, index) => (
         <FloatingButton

--- a/src/lib/workspace/DownloadTab/PastRelease.tsx
+++ b/src/lib/workspace/DownloadTab/PastRelease.tsx
@@ -102,7 +102,7 @@ export default function PastRelease({
         title={`Full Dataset (Release ${release.releaseNumber})`}
         subTitle={{
           Date: release.date ?? '',
-          Changelog: release.description ?? '',
+          'Change Log': release.description ?? '',
         }}
       >
         <div style={{ padding: 15, paddingLeft: 35 }}>

--- a/src/lib/workspace/DownloadTab/hooks/useGetReleaseFiles.ts
+++ b/src/lib/workspace/DownloadTab/hooks/useGetReleaseFiles.ts
@@ -49,8 +49,11 @@ export function useGetReleaseFiles(
          * which can identify here as naving no real name (just an
          * extension).
          */
-        .filter((fileData) => fileData.fileDescription.length);
-
+        .filter((fileData) => fileData.fileDescription.length)
+        /**
+         * Sort alphabetically on fileDescription
+         */
+        .sort((a, b) => a.fileDescription.localeCompare(b.fileDescription));
       // Augment the URL each valid file.
       for (const fileData of filesData) {
         const fileUrl = await downloadClient.downloadStudyFileURL(

--- a/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
@@ -380,7 +380,11 @@ export default function SubsettingDataGridModal({
       }}
     >
       <H5
-        additionalStyles={{ marginTop: 10, marginBottom: 25 }}
+        additionalStyles={{
+          marginTop: 10,
+          marginBottom: 25,
+          fontStyle: 'italic',
+        }}
         color={gray[700]}
       >
         {analysisState.analysis?.displayName}


### PR DESCRIPTION
Resolves #758 

The font issue is being resolved elsewhere.

- [x] italicisation of analysis name
- [x] Changelog to Change Log
- [x] wording relating to tabular files
- [x] sort download files lexographically
