### PR TITLE
Prevent data.series undefined error

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -723,7 +723,7 @@ export function boxplotResponseToData(
       (data) => data.label.length === 0 && data.median.length === 0
     );
     return facetIsEmpty
-      ? undefined
+      ? { series: [] }
       : {
           series: group.map((data) => ({
             lowerfence: data.lowerfence,


### PR DESCRIPTION
Resolves #902 

This was a fairly simple fix, but will need some careful testing to make sure that 'no data' facets are still handled properly. I think they are.