### PR TITLE
Provide safer fallbacks for vocabulary-less facet variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.6.10",
+  "version": "1.7.0",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -704,6 +704,8 @@ function reorderData(
 ): BarplotDataWithStatistics | BarplotData {
   // If faceted, reorder the facets and within the facets
   if (isFaceted(data)) {
+    if (facetVocabulary.length === 0) return data; // FIX-ME stop-gap for vocabulary-less numeric variables
+
     // for each value in the facet vocabulary's correct order
     // find the index in the series where series.name equals that value
     const facetValues = data.facets.map((facet) => facet.label);

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -822,6 +822,8 @@ function reorderData(
   facetVocabulary: string[] = []
 ): BoxplotDataWithCoverage | BoxplotData {
   if (isFaceted(data)) {
+    if (facetVocabulary.length === 0) return data; // FIX-ME stop-gap for vocabulary-less numeric variables
+
     // for each value in the facet vocabulary's correct order
     // find the index in the series where series.name equals that value
     const facetValues = data.facets.map((facet) => facet.label);

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -944,6 +944,8 @@ function reorderData(
   facetVocabulary: string[] = []
 ): HistogramDataWithCoverageStatistics | HistogramData {
   if (isFaceted(data)) {
+    if (facetVocabulary.length === 0) return data; // FIX-ME stop-gap for vocabulary-less numeric variables
+
     // for each value in the facet vocabulary's correct order
     // find the index in the series where series.name equals that value
     const facetValues = data.facets.map((facet) => facet.label);

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -870,6 +870,8 @@ function reorderData(
   | ContTableDataWithCoverage
   | ContTableData {
   if (isFaceted(data)) {
+    if (facetVocabulary.length === 0) return data; // FIX-ME stop-gap for vocabulary-less numeric variables
+
     // for each value in the facet vocabulary's correct order
     // find the index in the series where series.name equals that value
     const facetValues = data.facets.map((facet) => facet.label);

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1027,6 +1027,10 @@ export function scatterplotResponseToData(
       : '__NO_FACET__'
   );
 
+  // if the vocabulary is missing (e.g. for numeric variables), we can just use the keys from the
+  // groupBy and hope they are in the right order (they seem to be produced in numeric order, even though the values are strings)
+  const fallbackFacetVocabulary = keys(facetGroupedResponseData);
+
   const processedData = mapValues(facetGroupedResponseData, (group) => {
     const { dataSetProcess, yMin, yMax } = processInputData(
       reorderResponseScatterplotData(
@@ -1063,7 +1067,7 @@ export function scatterplotResponseToData(
       : // faceted
         {
           facets: vocabularyWithMissingData(
-            facetVocabulary,
+            facetVocabulary.length ? facetVocabulary : fallbackFacetVocabulary,
             showMissingFacet
           ).map((facetValue) => ({
             label: facetValue,


### PR DESCRIPTION
Temporarily resolves VEuPathDB/plot.data#134 (I couldn't move that issue into this repo!)

(Until vocabulary metadata is provided for these variables)
