### PR TITLE
Use new date trimming option for downloads

### DIFF
--- a/src/lib/core/api/SubsettingClient/types.ts
+++ b/src/lib/core/api/SubsettingClient/types.ts
@@ -66,6 +66,7 @@ export interface TabularDataRequestParams {
   outputVariableIds: Array<string>;
   reportConfig?: {
     headerFormat?: 'standard' | 'display';
+    trimTimeFromDateVars?: boolean;
     paging?: {
       numRows: number;
       offset: number;

--- a/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
@@ -175,6 +175,8 @@ export default function SubsettingDataGridModal({
             (descriptor) => descriptor.variableId
           ),
           reportConfig: {
+            headerFormat: 'standard',
+            trimTimeFromDateVars: true,
             paging: { numRows: pageSize, offset: pageSize * pageIndex },
           },
         })

--- a/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
@@ -175,7 +175,6 @@ export default function SubsettingDataGridModal({
             (descriptor) => descriptor.variableId
           ),
           reportConfig: {
-            headerFormat: 'standard',
             paging: { numRows: pageSize, offset: pageSize * pageIndex },
           },
         })
@@ -209,6 +208,7 @@ export default function SubsettingDataGridModal({
       ),
       reportConfig: {
         headerFormat: 'display',
+        trimTimeFromDateVars: true,
       },
     });
   }, [


### PR DESCRIPTION
The backend for this is only in dev for right now but hoping to push to QA tomorrow, Monday 2/28.

Works toward https://github.com/VEuPathDB/EdaSubsettingService/issues/56