### PR TITLE
Fix documentation modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/core/components/docs/DocumentationContainer.tsx
+++ b/src/lib/core/components/docs/DocumentationContainer.tsx
@@ -1,4 +1,5 @@
-import { Modal, Close } from '@veupathdb/coreui';
+import { Modal } from '@material-ui/core';
+import { Close } from '@veupathdb/coreui';
 import { Launch } from '@material-ui/icons';
 import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
 import React, { useState, PropsWithChildren, useMemo } from 'react';
@@ -23,62 +24,60 @@ export function DocumentationContainer(props: PropsWithChildren<{}>) {
   const { url } = useRouteMatch();
   const modal = activeDocument ? (
     <Modal
-      visible={activeDocument != null}
-      toggleVisible={() =>
-        activeDocument ? setActiveDocument(undefined) : null
-      }
+      style={{ margin: '2em', zIndex: 2000 }}
+      open={activeDocument != null}
       onClose={() => setActiveDocument(undefined)}
-      styleOverrides={{
-        content: {
-          padding: {
-            top: 0,
-            right: 50,
-            bottom: 25,
-            left: 25,
-          },
-        },
-      }}
     >
       <div
         style={{
-          display: 'flex',
-          flexWrap: 'nowrap',
-          alignItems: 'flex-start',
+          height: '100%',
+          borderRadius: '1em',
+          overflow: 'hidden',
         }}
       >
-        <div style={{ marginRight: 'auto' }}>
-          <Documentation documentName={activeDocument} />
-        </div>
-        <button
+        <div
           style={{
-            fontSize: '2em',
-            border: 'none',
-            background: 'none',
-            padding: 0,
+            background: 'white',
+            height: '100%',
+            overflow: 'auto',
+            padding: '2em',
           }}
-          type="button"
-          onClick={() => setActiveDocument(undefined)}
-          title="Close"
         >
-          <Close />
-        </button>
-      </div>
-      <div
-        style={{
-          position: 'sticky',
-          bottom: 0,
-          padding: '.5em 0',
-          background: 'white',
-        }}
-      >
-        <Link to={`${url}/documentation/${activeDocument}`} target="_blank">
-          <Launch fontSize="inherit" /> Open in new window
-        </Link>
+          <button
+            style={{
+              position: 'absolute',
+              right: '1em',
+              fontSize: '2em',
+              border: 'none',
+              background: 'none',
+              padding: 0,
+            }}
+            type="button"
+            onClick={() => setActiveDocument(undefined)}
+            title="Close"
+          >
+            <Close />
+          </button>
+          <div>
+            <Documentation documentName={activeDocument} />
+          </div>
+        </div>
+        <div
+          style={{
+            position: 'sticky',
+            bottom: 0,
+            padding: '.5em 2em',
+            marginRight: '2em',
+            background: 'white',
+          }}
+        >
+          <Link to={`${url}/documentation/${activeDocument}`} target="_blank">
+            <Launch fontSize="inherit" /> Open in new window
+          </Link>
+        </div>
       </div>
     </Modal>
-  ) : (
-    <></>
-  );
+  ) : null;
   return (
     <DocumentationContext.Provider value={value}>
       {modal}

--- a/src/lib/core/components/variableTrees/VariableList.tsx
+++ b/src/lib/core/components/variableTrees/VariableList.tsx
@@ -46,7 +46,7 @@ import { cx } from '../../../workspace/Utils';
 import { pruneEmptyFields } from '../../utils/wdk-filter-param-adapter';
 
 import { Tooltip as VarTooltip } from '../docs/variable-constraints';
-// import { useActiveDocument } from '../docs/DocumentationContainer';
+import { useActiveDocument } from '../docs/DocumentationContainer';
 
 interface VariableField {
   type?: string;
@@ -157,7 +157,7 @@ export default function VariableList({
   const isMultiPick = mode === 'multiSelection';
 
   const [searchTerm, setSearchTerm] = useState<string>('');
-  // const { setActiveDocument } = useActiveDocument();
+  const { setActiveDocument } = useActiveDocument();
   const getPathToField = useCallback(
     (field?: Field) => {
       if (field == null) return [];
@@ -461,10 +461,10 @@ export default function VariableList({
         <Link
           to="../../../../documentation/variable-constraints"
           target="_blank"
-          // onClick={(event) => {
-          //   event.preventDefault();
-          //   setActiveDocument('variable-constraints');
-          // }}
+          onClick={(event) => {
+            event.preventDefault();
+            setActiveDocument('variable-constraints');
+          }}
         >
           Learn more
         </Link>
@@ -478,14 +478,13 @@ export default function VariableList({
     disabledFields.size > 0 && (
       <div className={cx('-DisabledVariablesToggle')}>
         <HtmlTooltip
-          css={
-            {
-              /*
-               * This is needed to address a compiler error.
-               * Not sure why it's complaining, but here we are...
-               */
-            }
-          }
+          css={{
+            zIndex: 1,
+            /*
+             * This is needed to address a compiler error.
+             * Not sure why it's complaining, but here we are...
+             */
+          }}
           title={tooltipContent}
           interactive
           enterDelay={500}


### PR DESCRIPTION
In this PR, the `Modal` component from material-ui is used for documentation, rather than the `Modal` component from `@veupathdb/coreui`. Since the `VariableTreeDropdown` component also uses a material-ui modal-like component, this addresses interop issues.

fixes #896 
