### PR TITLE
Re-enable map and fix double triggering of map markers

### DIFF
--- a/src/lib/core/components/computations/PassThroughComputation.tsx
+++ b/src/lib/core/components/computations/PassThroughComputation.tsx
@@ -44,7 +44,7 @@ const visualizationTypes: Record<string, VisualizationType> = {
   // densityplot: scatterplotVisualization,
   barplot: barplotVisualization,
   boxplot: boxplotVisualization,
-  // 'map-markers': mapVisualization,
+  'map-markers': mapVisualization,
 };
 
 export function PassThroughComputation(props: Props) {

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -259,7 +259,11 @@ function MapViz(props: VisualizationProps) {
       studyId,
       filters,
       dataClient,
-      vizConfig,
+      // we don't want to allow vizConfig.mapCenterAndZoom to trigger an update,
+      // because boundsZoomLevel does the same thing, but they can trigger two separate updates
+      // (baseLayer doesn't matter either) - so we cherry pick properties of vizConfig
+      vizConfig.geoEntityId,
+      vizConfig.outputEntityId,
       boundsZoomLevel,
       computation.descriptor.type,
       geoConfig,


### PR DESCRIPTION
Works toward #875 

I found that the problem was the `vizConfig` dependency of the "get data" callback.  `vizConfig.mapCenterAndZoom` does not need to be a dependency. Changes in the state variable `boundsZoomLevel` are the only important changes w.r.t. getting data.  Cherry picking the vizConfig dependencies solved the double back-end call problem.

I will look at the other bug in #875 now.