### PR TITLE
fixing bug on scatterplot range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/core/utils/default-dependent-axis-range.ts
+++ b/src/lib/core/utils/default-dependent-axis-range.ts
@@ -39,7 +39,7 @@ export function defaultDependentAxisRange(
                 : variable.rangeMin,
             max:
               yMinMaxRange != null
-                ? Math.min(variable.rangeMax, yMinMaxRange.max as number)
+                ? Math.max(variable.rangeMax, yMinMaxRange.max as number)
                 : variable.rangeMax,
           };
     } else if (variable.type === 'date') {


### PR DESCRIPTION
This resolves [#311 at web-components](https://github.com/VEuPathDB/web-components/issues/311)

I have examined this issue carefully, perhaps too deep unnecessarily, but found that there was an error to use Math.min/max. Simply put, Math.min was wrongfully used to calculate Math.max. 

Here is a screenshot after fix: used the same example shown in the ticket and now it shows correct dependent range (see Olyset Plus plot that looks like a fish 😄)

![LLINEUP scatterplot range bug](https://user-images.githubusercontent.com/12802305/156208778-022fa4ed-202e-4df5-a519-188ccb99d799.png)

