### PR TITLE
Visualisations: Handle null oddsratio in recently fixed Mosaic 2x2 response

### DIFF
--- a/src/lib/core/api/DataClient/types.ts
+++ b/src/lib/core/api/DataClient/types.ts
@@ -411,7 +411,7 @@ export const TwoByTwoResponse = intersection([
   partial({
     statsTable: array(
       partial({
-        oddsratio: number, // TO DO: should these stats values really all be optional?
+        oddsratio: numberOrNull, // TO DO: should these stats values really all be optional?
         pvalue: union([number, string]),
         orInterval: string,
         rrInterval: string,


### PR DESCRIPTION
@d-callan fixed a bug under the radar that I spotted. I can't find a PR but she said it was tagged v1.6.8 in rserve. 

To reproduce the bug:

**India ICEMR Fever Surveillance**
filter on Antimalarial treatment date = [ 2016-04, 2016-06, 2016-07 ]
viz 2x2: x="Ill now" y="Any symptoms"

Danielle's back-end fix prevents a 500, but returns a null for `statsTable.oddsratio` - this PR fixes the latter client-side.