### PR TITLE
Add scatterplot to alpha diversity app

### DIFF
--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -4,12 +4,14 @@ import { useStudyEntities } from '../../../hooks/study';
 import { VariableDescriptor } from '../../../types/variable';
 import { findEntityAndVariable } from '../../../utils/study-metadata';
 import { boxplotVisualization } from '../../visualizations/implementations/BoxplotVisualization';
+import { scatterplotVisualization } from '../../visualizations/implementations/ScatterplotVisualization';
 import { ComputationConfigProps, ComputationPlugin } from '../Types';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: AlphaDivConfiguration,
   visualizationTypes: {
     boxplot: boxplotVisualization,
+    scatterplot: scatterplotVisualization,
   },
 };
 
@@ -18,7 +20,7 @@ const ALPHA_DIV_METHODS = ['shannon', 'simpson', 'evenness'];
 
 // Include known collection variables in this array.
 const ALPHA_DIV_COLLECTION_VARIABLES = [
-  { entityId: 'EUPATH_0000738', variableId: 'OGMS_0000083' },
+  { entityId: 'EUPATH_0000808', variableId: 'EUPATH_0009253' },
 ];
 
 function variableDescriptorToString(

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -768,7 +768,13 @@ function ScatterplotViz(props: VisualizationProps) {
       independentValueType={
         NumberVariable.is(xAxisVariable) ? 'number' : 'date'
       }
-      dependentValueType={NumberVariable.is(yAxisVariable) ? 'number' : 'date'}
+      // yAxisVariable will be null when a computed var takes its place. Computed vars are always numbers
+      dependentValueType={
+        NumberVariable.is(yAxisVariable) ||
+        (computation.descriptor.configuration && yAxisVariable == null)
+          ? 'number'
+          : 'date'
+      }
       legendTitle={variableDisplayWithUnit(overlayVariable)}
       // pass checked state of legend checkbox to PlotlyPlot
       checkedLegendItems={checkedLegendItems}
@@ -1276,6 +1282,8 @@ function processInputData<T extends number | string>(
           'The number of X data is not equal to the number of Y data'
         );
       }
+
+      // Computations are always numbers
 
       /*
         For raw data, there are two cases:


### PR DESCRIPTION
This PR adds a scatterplot visualization to the alpha diversity app. When finished, this resolves #304 

The approach was the same as that for boxplot, with one small addition. When the yAxisVariable is undefined, the logic called it a date. Since our computed variable is on the y axis, we are always in this case. So there were a few additions to handle this scenario.

At this point i've learned that this will get messier when we add the next app :) The reason is that the computation is going to specify _two_ variables instead of one. Perhaps we could have the app tell the front end which variables it will override?