### PR TITLE
filter apps by projectId

### DIFF
--- a/src/lib/core/types/visualization.ts
+++ b/src/lib/core/types/visualization.ts
@@ -111,6 +111,7 @@ export const ComputationAppOverview = intersection([
   Thing,
   partial({
     visualizations: array(VisualizationOverview),
+    projects: array(string),
   }),
 ]);
 

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -9,6 +9,7 @@ import { createComputation } from '../core/components/computations/Utils';
 import { PromiseResult } from '../core/components/Promise';
 import { EntityCounts } from '../core/hooks/entityCounts';
 import { PromiseHookState, usePromise } from '../core/hooks/promise';
+import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 import { GeoConfig } from '../core/types/geoConfig';
 
 export interface Props {
@@ -26,8 +27,20 @@ export function ComputationRoute(props: Props) {
   const { url } = useRouteMatch();
   const history = useHistory();
   const dataClient = useDataClient();
+  const projectId = useWdkService((wdkService) => wdkService.getConfig(), [])
+    ?.projectId;
   const promiseState = usePromise(
-    useCallback(() => dataClient.getApps(), [dataClient])
+    useCallback(async () => {
+      let { apps } = await dataClient.getApps();
+
+      if (projectId) {
+        apps = apps.filter((app) => app.projects?.includes(projectId));
+      }
+
+      if (apps == null) throw new Error('Could not find any computation app.');
+
+      return { apps };
+    }, [dataClient, projectId])
   );
 
   return (


### PR DESCRIPTION
Resolves #955 

In the data service, each app is assigned a list of projects for which it is valid. The code changes in this PR use that project array and filter the apps to show only those that are valid for the current project.