### PR TITLE
add three non-computational apps to mbio eda

### DIFF
--- a/src/lib/core/components/computations/plugins/countsandproportions.tsx
+++ b/src/lib/core/components/computations/plugins/countsandproportions.tsx
@@ -1,0 +1,21 @@
+import { barplotVisualization } from '../../visualizations/implementations/BarplotVisualization';
+import {
+  contTableVisualization,
+  twoByTwoVisualization,
+} from '../../visualizations/implementations/MosaicVisualization';
+import { testVisualization } from '../../visualizations/implementations/TestVisualization';
+import { ComputationPlugin } from '../Types';
+import { ZeroConfigWithButton } from '../ZeroConfiguration';
+
+export const plugin: ComputationPlugin = {
+  configurationComponent: ZeroConfigWithButton,
+  visualizationTypes: {
+    testVisualization,
+    twobytwo: twoByTwoVisualization,
+    conttable: contTableVisualization,
+    // lineplot: scatterplotVisualization,
+    // placeholder for densityplot
+    // densityplot: scatterplotVisualization,
+    barplot: barplotVisualization,
+  },
+};

--- a/src/lib/core/components/computations/plugins/distributions.tsx
+++ b/src/lib/core/components/computations/plugins/distributions.tsx
@@ -1,0 +1,15 @@
+import { boxplotVisualization } from '../../visualizations/implementations/BoxplotVisualization';
+import { histogramVisualization } from '../../visualizations/implementations/HistogramVisualization';
+import { testVisualization } from '../../visualizations/implementations/TestVisualization';
+import { ComputationPlugin } from '../Types';
+import { ZeroConfigWithButton } from '../ZeroConfiguration';
+
+export const plugin: ComputationPlugin = {
+  configurationComponent: ZeroConfigWithButton,
+  visualizationTypes: {
+    testVisualization,
+    histogram: histogramVisualization,
+    // densityplot: scatterplotVisualization,
+    boxplot: boxplotVisualization,
+  },
+};

--- a/src/lib/core/components/computations/plugins/index.ts
+++ b/src/lib/core/components/computations/plugins/index.ts
@@ -1,8 +1,14 @@
 import { ComputationPlugin } from '../Types';
 import { plugin as alphadiv } from './alphaDiv';
 import { plugin as pass } from './pass';
+import { plugin as distributions } from './distributions';
+import { plugin as countsandproportions } from './countsandproportions';
+import { plugin as xyrelationships } from './xyrelationships';
 
 export const plugins: Record<string, ComputationPlugin> = {
   alphadiv,
+  countsandproportions,
+  distributions,
   pass,
+  xyrelationships,
 };

--- a/src/lib/core/components/computations/plugins/xyrelationships.tsx
+++ b/src/lib/core/components/computations/plugins/xyrelationships.tsx
@@ -1,0 +1,13 @@
+import { scatterplotVisualization } from '../../visualizations/implementations/ScatterplotVisualization';
+import { testVisualization } from '../../visualizations/implementations/TestVisualization';
+import { ComputationPlugin } from '../Types';
+import { ZeroConfigWithButton } from '../ZeroConfiguration';
+
+export const plugin: ComputationPlugin = {
+  configurationComponent: ZeroConfigWithButton,
+  visualizationTypes: {
+    testVisualization,
+    scatterplot: scatterplotVisualization,
+    // lineplot: scatterplotVisualization,
+  },
+};


### PR DESCRIPTION
Resolves #807 

This PR addresses part 2/2 for issue #807. It adds three non-computational apps to the mbio EDA. These three apps basically divvy up the visualizations in clinepi's current pass-through app. No configuration is required. All variables act normally in these three apps. The three apps are:

- Distributions: contains histogram, box plot, eventually density plot
- Counts and Proportions: Contains barplot and both mosaics
- X-Y Relationships: contains scatter, lineplot (soon!)


