### PR TITLE
Lineplot yscale

### DIFF
--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -859,7 +859,7 @@ function LineplotWithControls({
         </LabelledGroup>
         <LabelledGroup label="Y-axis">
           <Switch
-            label="Show error bars"
+            label="Show error bars (95% C.I.)"
             state={showErrorBars}
             onStateChange={onShowErrorBarsChange}
             disabled={neverShowErrorBars}

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -1195,7 +1195,19 @@ function processInputData(
   });
 
   const xValues = dataSetProcess.flatMap<string | number>((series) => series.x);
-  const yValues = dataSetProcess.flatMap<string | number>((series) => series.y);
+  // get all values of y (including error bars if present) in a kind of clunky way...
+  const yValues = dataSetProcess
+    .flatMap<string | number>((series) => series.y)
+    .concat(
+      dataSetProcess
+        .flatMap((series) => series.yErrorBarLower ?? [])
+        .filter((val): val is number | string => val != null)
+    )
+    .concat(
+      dataSetProcess
+        .flatMap((series) => series.yErrorBarUpper ?? [])
+        .filter((val): val is number | string => val != null)
+    );
 
   return {
     dataSetProcess: {

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -41,8 +41,6 @@ import {
   isEqual,
   min,
   max,
-  lte,
-  gte,
   groupBy,
   size,
   head,
@@ -50,7 +48,6 @@ import {
   mapValues,
   map,
   keys,
-  uniqBy,
 } from 'lodash';
 // directly use RadioButtonGroup instead of LinePlotControls
 import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
@@ -86,10 +83,7 @@ import {
   hasIncompleteCases,
 } from '../../../utils/visualization';
 import { gray } from '../colors';
-import {
-  ColorPaletteDefault,
-  ColorPaletteDark,
-} from '@veupathdb/components/lib/types/plots/addOns';
+import { ColorPaletteDefault } from '@veupathdb/components/lib/types/plots/addOns';
 // import variable's metadata-based independent axis range utils
 import { defaultIndependentAxisRange } from '../../../utils/default-independent-axis-range';
 import { axisRangeMargin } from '../../../utils/axis-range-margin';
@@ -103,9 +97,6 @@ import PlotLegend, {
 } from '@veupathdb/components/lib/components/plotControls/PlotLegend';
 import { isFaceted, isTimeDelta } from '@veupathdb/components/lib/types/guards';
 import FacetedLinePlot from '@veupathdb/components/lib/plots/facetedPlots/FacetedLinePlot';
-// for converting rgb() to rgba()
-import * as ColorMath from 'color-math';
-//DKDK a custom hook to preserve the status of checked legend items
 import { useCheckedLegendItemsStatus } from '../../../hooks/checkedLegendItemsStatus';
 import { BinSpec, BinWidthSlider } from '../../../types/general';
 import { useVizConfig } from '../../../hooks/visualizations';

--- a/src/lib/core/utils/default-dependent-axis-range.ts
+++ b/src/lib/core/utils/default-dependent-axis-range.ts
@@ -9,7 +9,10 @@ export function defaultDependentAxisRange(
     | undefined
 ): NumberOrDateRange | undefined {
   // make universal range variable
-  if (variable != null && plotName === 'scatterplot') {
+  if (
+    variable != null &&
+    (plotName === 'scatterplot' || plotName === 'lineplot')
+  ) {
     // this should check integer as well
     if (variable.type === 'number' || variable.type === 'integer') {
       return variable.displayRangeMin != null &&


### PR DESCRIPTION
Branched off `lineplot-ordinalx-963` #964  (so some of the diff is for that PR, sorry)
Fixes #965 


@d-callan - because all the code was basically there already (thanks @moontrip) I just enabled the same y-axis handling as we already have in scatterplot.  That means the range will be the annotated range, but if the data goes outside this (for example with error bars) then it is extended.  There's not explicit "zero y axis" behaviour as far as I can tell.