### PR TITLE
update study-data-access and move to dev and peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@veupathdb/components": "^0.11.27",
     "@veupathdb/coreui": "^0.13.0",
     "@veupathdb/http-utils": "^1.1.0",
-    "@veupathdb/study-data-access": "^0.1.5",
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",
     "io-ts": "^2.2.13",
@@ -28,6 +27,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
+    "@veupathdb/study-data-access": "^0.2.0",
     "@veupathdb/wdk-client": ">=0.5.11"
   },
   "sideEffects": [
@@ -75,6 +75,7 @@
     "@veupathdb/eslint-config": "^1.0.0",
     "@veupathdb/prettier-config": "^1.0.0",
     "@veupathdb/react-scripts": "^1.0.1",
+    "@veupathdb/study-data-access": "^0.2.0",
     "@veupathdb/tsconfig": "^1.0.1",
     "@veupathdb/wdk-client": "^0.5.11",
     "@veupathdb/web-common": "^0.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3659,10 +3659,10 @@
     io-ts "^2.2.16"
     lodash "^4.17.21"
 
-"@veupathdb/study-data-access@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@veupathdb/study-data-access/-/study-data-access-0.1.5.tgz#8f0aae7c4c35f001b8f3bff77feeeba3c86df578"
-  integrity sha512-CPoQ03Hg8O35JaAbhx0g22eAHOaDQ14pvydjMEs1oYFQggw6+cckp6tEpOCHhbAlwIBn0rvSdntGeJho2iLY/w==
+"@veupathdb/study-data-access@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@veupathdb/study-data-access/-/study-data-access-0.2.0.tgz#e6508397caea29578ff3fa07b09970f3dd0afe9a"
+  integrity sha512-roRKPykO/2izuWD/9ihDaMbXPIZFQIo8zCQpT9dyAFJRppvFjkQWLadBOECHqoC7zOj1W3hm7sPoZiz6UbrRzQ==
   dependencies:
     "@veupathdb/http-utils" "^1.0.1"
     fp-ts "^2.11.5"


### PR DESCRIPTION
Related to [PR #8](https://github.com/VEuPathDB/web-study-data-access/pull/8) in web-study-data-access.

Upgrades the `study-data-access` package to the new version, and moves this package to the peer and dev dependencies (removed from regular dependencies).

**Testing**
Tested with dfalke clinepi backend. Tried making a visualization, subsetting, and downloading on a public study (all successful), same for protected study (downloading gave me a nice warning that i should request access, but other tabs successful), and on the private studies i saw only the study details page.

Recall plan is to patch update web-eda with this PR.