### PR TITLE
resolve r2 = null and change truncation message for axis range control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "dependencies": {
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",

--- a/src/lib/core/api/DataClient/types.ts
+++ b/src/lib/core/api/DataClient/types.ts
@@ -212,7 +212,8 @@ export const ScatterplotResponseData = array(
     // add bestFitLineWithRaw
     bestFitLineX: array(string),
     bestFitLineY: array(number),
-    r2: number,
+    // allow null for r2
+    r2: NumberOrNull,
     // need to make sure if below is correct (untested)
     overlayVariableDetails: type({
       entityId: string,

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -448,7 +448,7 @@ function BarplotViz(props: VisualizationProps) {
   useEffect(() => {
     if (truncationConfigDependentAxisMin || truncationConfigDependentAxisMax) {
       setTruncatedDependentAxisWarning(
-        'Data may have been truncated by range selection, as indicated by the light gray shading'
+        'Data may have been truncated by range selection, as indicated by the yellow shading'
       );
     }
   }, [truncationConfigDependentAxisMin, truncationConfigDependentAxisMax]);

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -675,7 +675,7 @@ function BoxplotWithControls({
   useEffect(() => {
     if (truncationConfigDependentAxisMin || truncationConfigDependentAxisMax) {
       setTruncatedDependentAxisWarning(
-        'Data may have been truncated by range selection, as indicated by the light gray shading'
+        'Data may have been truncated by range selection, as indicated by the yellow shading'
       );
     }
   }, [truncationConfigDependentAxisMin, truncationConfigDependentAxisMax]);

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -817,7 +817,7 @@ function HistogramPlotWithControls({
       truncationConfigIndependentAxisMax
     ) {
       setTruncatedIndependentAxisWarning(
-        'Data may have been truncated by range selection, as indicated by the light gray shading'
+        'Data may have been truncated by range selection, as indicated by the yellow shading'
       );
     }
   }, [truncationConfigIndependentAxisMin, truncationConfigIndependentAxisMax]);
@@ -825,7 +825,7 @@ function HistogramPlotWithControls({
   useEffect(() => {
     if (truncationConfigDependentAxisMin || truncationConfigDependentAxisMax) {
       setTruncatedDependentAxisWarning(
-        'Data may have been truncated by range selection, as indicated by the light gray shading'
+        'Data may have been truncated by range selection, as indicated by the yellow shading'
       );
     }
   }, [truncationConfigDependentAxisMin, truncationConfigDependentAxisMax]);

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1098,7 +1098,7 @@ function ScatterplotWithControls({
       truncationConfigIndependentAxisMax
     ) {
       setTruncatedIndependentAxisWarning(
-        'Data may have been truncated by range selection, as indicated by the light gray shading'
+        'Data may have been truncated by range selection, as indicated by the yellow shading'
       );
     }
   }, [truncationConfigIndependentAxisMin, truncationConfigIndependentAxisMax]);
@@ -1111,7 +1111,7 @@ function ScatterplotWithControls({
       truncationConfigDependentAxisMax
     ) {
       setTruncatedDependentAxisWarning(
-        'Data may have been truncated by range selection, as indicated by the light gray shading'
+        'Data may have been truncated by range selection, as indicated by the yellow shading'
       );
     }
   }, [truncationConfigDependentAxisMin, truncationConfigDependentAxisMax]);


### PR DESCRIPTION
This resolves https://github.com/VEuPathDB/EdaNewIssues/issues/199 and https://github.com/VEuPathDB/EdaNewIssues/issues/198

A screenshot is attached to show a correct behavior as compared to the ones at each ticket above.

![r2=null](https://user-images.githubusercontent.com/12802305/159281238-6b79f758-6061-4dc7-bd53-a4b71ff3d904.png)

