### PR TITLE
Variable coverage table for alphadiv app

### DIFF
--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -75,6 +75,8 @@ type BoxplotData = { series: BoxplotSeries };
 // type of computedVariableMetadata for computation apps such as alphadiv and abundance
 type BoxplotComputedVariableMetadata = {
   computedVariableMetadata?: ComputedVariableMetadata;
+  // for alphadiv VariableCoverageTable
+  yVariableDetails?: VariableDescriptor;
 };
 
 // add type of computedVariableMetadata for computation apps such as alphadiv and abundance
@@ -565,8 +567,20 @@ function BoxplotViz(props: VisualizationProps) {
           {
             role: 'Y-axis',
             required: true,
-            display: variableDisplayWithUnit(yAxisVariable),
-            variable: vizConfig.yAxisVariable,
+            // for alphadiv VariableCoverageTable
+            display:
+              computation.descriptor.configuration != null &&
+              computation.descriptor.type === 'alphadiv'
+                ? data?.value?.computedVariableMetadata?.displayName != null
+                  ? data?.value?.computedVariableMetadata?.displayName[0]
+                  : computation.descriptor.type
+                : variableDisplayWithUnit(yAxisVariable),
+            // for alphadiv VariableCoverageTable
+            variable:
+              computation.descriptor.configuration != null &&
+              computation.descriptor.type === 'alphadiv'
+                ? data?.value?.yVariableDetails
+                : vizConfig.yAxisVariable,
           },
           {
             role: 'Overlay',
@@ -925,6 +939,8 @@ export function boxplotResponseToData(
     completeCasesAxesVars: response.boxplot.config.completeCasesAxesVars,
     // config.computedVariableMetadata should also be returned
     computedVariableMetadata: response.boxplot.config.computedVariableMetadata,
+    // for alphadiv VariableCoverageTable
+    yVariableDetails: response.boxplot.config.yVariableDetails,
   } as BoxplotDataWithCoverage;
 }
 

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -145,6 +145,8 @@ export interface ScatterPlotDataWithCoverage extends CoverageStatistics {
   yMax: number | string | undefined;
   // add computedVariableMetadata for computation apps such as alphadiv and abundance
   computedVariableMetadata?: ComputedVariableMetadata;
+  // for alphadiv VariableCoverageTable
+  yVariableDetails?: VariableDescriptor;
 }
 
 // define ScatterPlotDataResponse
@@ -910,8 +912,20 @@ function ScatterplotViz(props: VisualizationProps) {
           {
             role: 'Y-axis',
             required: true,
-            display: variableDisplayWithUnit(yAxisVariable),
-            variable: vizConfig.yAxisVariable,
+            // for alphadiv VariableCoverageTable
+            display:
+              computation.descriptor.configuration != null &&
+              computation.descriptor.type === 'alphadiv'
+                ? data?.value?.computedVariableMetadata?.displayName != null
+                  ? data?.value?.computedVariableMetadata?.displayName[0]
+                  : computation.descriptor.type
+                : variableDisplayWithUnit(yAxisVariable),
+            // for alphadiv VariableCoverageTable
+            variable:
+              computation.descriptor.configuration != null &&
+              computation.descriptor.type === 'alphadiv'
+                ? data?.value?.yVariableDetails
+                : vizConfig.yAxisVariable,
           },
           {
             role: 'Overlay',
@@ -1492,6 +1506,8 @@ export function scatterplotResponseToData(
     // config.computedVariableMetadata should also be returned
     computedVariableMetadata:
       response.scatterplot.config.computedVariableMetadata,
+    // for alphadiv VariableCoverageTable
+    yVariableDetails: response.scatterplot.config.yVariableDetails,
   } as ScatterPlotDataWithCoverage;
 }
 


### PR DESCRIPTION
This is an implementation of VariableCoverageTable for alphadiv app.

Made as a draft PR because this is not a generic way, even for alphadiv app. The idea of this is to utilize backend's response.(boxplot or scatterplot).config.yVariableDetails, which the yAxisVariable is computed one for alphadiv. The backend only returns xVariableDetails and yVariableDetails, so this approach would not work for the case where overlayVariable is a computed variable (e.g., scatter plot for abundance app). Perhaps better way to handle this is to get the info of computed variables at, e.g., computedVariableMetadata, response.(boxplot or scatterplot).config.computedVariableMetadata

Just leave this as a record for @asizemore 😃 