### PR TITLE
Fix height of variable tree container in SubsettingDataGridModal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
@@ -327,7 +327,11 @@ export default function SubsettingDataGridModal({
               />
             </div>
           )}
-          <div>
+          <div
+            style={{
+              height: '60vh',
+            }}
+          >
             <MultiSelectVariableTree
               // NOTE: We are purposely removing all child entities here because
               // we only want a user to be able to select variables from a single


### PR DESCRIPTION
Addresses #1057 to constrain the variable tree container's height to within the modal's height.