### PR TITLE
conditional yLabel as Proportion, switching string to date variable bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -592,7 +592,13 @@ function LineplotViz(props: VisualizationProps) {
                 : defaultIndependentRange.max,
           } as NumberOrDateRange)
         : defaultIndependentRange;
-    return axisRangeMargin(extendedIndependentRange, xAxisVariable?.type);
+    // need to check date type for the case switching from string to date variable
+    // it is because date value is also string which causes issue at axisRangeMargin
+    return xAxisVariable?.type === 'date' &&
+      (isNaN(Date.parse(extendedIndependentRange?.min as string)) ||
+        isNaN(Date.parse(extendedIndependentRange?.max as string)))
+      ? undefined
+      : axisRangeMargin(extendedIndependentRange, xAxisVariable?.type);
   }, [xAxisVariable, data.value]);
 
   // find deependent axis range and its margin
@@ -703,10 +709,14 @@ function LineplotViz(props: VisualizationProps) {
       spacingOptions={
         !isFaceted(data.value?.dataSetProcess) ? plotSpacingOptions : undefined
       }
-      // title={'Line plot'}
       displayLegend={false}
       independentAxisLabel={variableDisplayWithUnit(xAxisVariable) ?? 'X-axis'}
-      dependentAxisLabel={variableDisplayWithUnit(yAxisVariable) ?? 'Y-axis'}
+      // set dependent axis label as Proportion conditionally
+      dependentAxisLabel={
+        vizConfig.valueSpecConfig === 'Proportion'
+          ? 'Proportion'
+          : variableDisplayWithUnit(yAxisVariable) ?? 'Y-axis'
+      }
       // set valueSpec as Raw when yAxisVariable = date
       onBinWidthChange={onBinWidthChange}
       vizType={visualization.descriptor.type}

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -710,7 +710,13 @@ function LineplotViz(props: VisualizationProps) {
       dependentAxisLabel={
         vizConfig.valueSpecConfig === 'Proportion'
           ? 'Proportion'
-          : variableDisplayWithUnit(yAxisVariable) ?? 'Y-axis'
+          : variableDisplayWithUnit(yAxisVariable)
+          ? vizConfig.valueSpecConfig === 'Mean'
+            ? 'Mean: ' + variableDisplayWithUnit(yAxisVariable)
+            : vizConfig.valueSpecConfig === 'Median'
+            ? 'Median: ' + variableDisplayWithUnit(yAxisVariable)
+            : 'Y-axis'
+          : 'Y-axis'
       }
       // set valueSpec as Raw when yAxisVariable = date
       onBinWidthChange={onBinWidthChange}


### PR DESCRIPTION
This addresses two issues: a) [Update Y-axis labels for line plots #1050](https://github.com/VEuPathDB/web-eda/issues/1050) and [Viz: Error message in line plots when switching x-axis variable #1061](https://github.com/VEuPathDB/web-eda/issues/1061).

- For a): the Y-axis label is conditionally set to be Proportion in the line plot viz when Proportion mode is used. A example screenshot is shown in the following (SCORE S. mansoni Cluster Randomized Trial)

- For b): this is similar situation to [switching from number to date variable on scatterplot and lineplot y-axis causes an exception #1003](https://github.com/VEuPathDB/web-eda/issues/1003). For the line plot viz, categorical and/or ordinal have string type and its value is string. For a date variable, its type is date but its value is also string: more exactly, date string. So when switching string type to date type, old values of sting from string type is used as a date string, which causes the error when computing axis range margin. To resolve this, a condition is set to check whether it is date type as well as date string value using Date.parse(). 

- screenshot of Y-axis label as Proportion
![lineplot-yaxis-label](https://user-images.githubusercontent.com/12802305/163310818-9db73f8f-47aa-44e5-94a2-a4667d248f98.png)

