### PR TITLE
Condition the render of BirdsEyePlot to prevent phantom tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/BirdsEyeView.tsx
+++ b/src/lib/core/components/BirdsEyeView.tsx
@@ -110,7 +110,7 @@ export function BirdsEyeView(props: Props) {
     </div>
   );
 
-  return (
+  return birdsEyeData ? (
     <Tooltip
       content={tooltipContent}
       position={{
@@ -139,5 +139,7 @@ export function BirdsEyeView(props: Props) {
         showSpinner={enableSpinner && !birdsEyeData}
       />
     </Tooltip>
+  ) : (
+    <div style={{ width: '400px', height: '110px' }}></div>
   );
 }


### PR DESCRIPTION
Partly addresses #994 

@bobular @moontrip My solution to what I'm calling the "phantom tooltip" is, like DK suggested, to conditionally render the `BirdsEyePlot` based on `birdsEyeData`. To prevent any undesired jumping, the `falsy` condition renders an empty container with the same `height` and `weight` as the `containerStyles` props passed into the `BirdsEyePlot` component.

Nothing urgent here, but this was bothering me!