### PR TITLE
Remove nulls-hack, since we use a custom legend, and so data displays correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -1819,8 +1819,8 @@ function processInputData(
           : (el.seriesY as string[]);
 
       dataSetProcess.push({
-        x: seriesX.length ? seriesX : (([null] as unknown) as number[]), // [null] hack required to make sure
-        y: seriesY.length ? seriesY : (([null] as unknown) as number[]), // Plotly has a legend entry for empty traces
+        x: seriesX,
+        y: seriesY,
         ...(binSpec?.value ? { binLabel: el.seriesX } : {}),
         ...(el.errorBars != null
           ? {


### PR DESCRIPTION
Fixes #1069

The previous hack to fill x and y series data with `null` values appears to break plots with only one non-empty data series. This PR removes that hack, since we now use a custom legend.

cc @moontrip @bobular

ETA Note that I'm not completely satisfied with this solution, as it seems to rely on Plotly.js's behavior to treat such elements as "empty". I think a better solution would be to remove the entry from the data array, but this requires some reworking of how [legendItems is constructed](https://github.com/VEuPathDB/web-eda/blob/9cbf9b2656206e32fbfe64557732e9fab45d599d/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx#L633-L676). I will probably make an issue for this as a follow-up, since I don't want to mess with the current logic right now :slightly_smiling_face:.