### PR TITLE
Ranked abundance app uses display names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -68,10 +68,7 @@ import Notification from '@veupathdb/components/lib/components/widgets//Notifica
 import Button from '@veupathdb/components/lib/components/widgets/Button';
 import { useDefaultDependentAxisRange } from '../../../hooks/computeDefaultDependentAxisRange';
 // alphadiv abundance this should be used for collection variable
-import {
-  findEntityAndVariable as findCollectionVariableEntityAndVariable,
-  findEntityAndVariable,
-} from '../../../utils/study-metadata';
+import { findEntityAndVariable as findCollectionVariableEntityAndVariable } from '../../../utils/study-metadata';
 // type of computedVariableMetadata for computation apps such as alphadiv and abundance
 import { ComputedVariableMetadata } from '../../../api/DataClient/types';
 

--- a/src/lib/core/utils/visualization.ts
+++ b/src/lib/core/utils/visualization.ts
@@ -12,6 +12,7 @@ import { CompleteCasesTable } from '../api/DataClient';
 import { Bounds } from '@veupathdb/components/lib/map/Types';
 import { Filter } from '../types/filter';
 import { VariableDescriptor } from '../types/variable';
+import { findEntityAndVariable } from './study-metadata';
 
 // was: BarplotData | HistogramData | { series: BoxplotData };
 type SeriesWithStatistics<T> = T & CoverageStatistics;
@@ -114,6 +115,34 @@ export function fixLabelsForNumberVariables(
     ? labels.map((n) => String(Number(n)))
     : labels;
 }
+
+export function fixVarIdLabels(
+  labels: string[] = [],
+  variableList: VariableDescriptor[],
+  entities: StudyEntity[]
+): string[] {
+  const displayNames: string[] = labels.map((label) => {
+    // Label is variable id. Get entity and var id from collection list.
+    const variableDescriptors = variableList.filter(
+      (varItem) => varItem.variableId === label
+    );
+    const variableDescriptor = variableDescriptors && variableDescriptors[0];
+    const retrievedVariable = findEntityAndVariable(
+      entities,
+      variableDescriptor
+    );
+    return retrievedVariable?.variable.displayName || label;
+  });
+  return displayNames;
+}
+
+// ? data.label.map((label) => {
+//   const labelVariables = response.boxplot.config.computedVariableMetadata?.collectionVariable?.collectionVariableDetails?.filter((varDetails) => varDetails.variableId === label);
+//   const labelVariable = labelVariables && labelVariables[0];
+//   const retrievedVariable = entities && findEntityAndVariable(entities, labelVariable);
+//   return retrievedVariable?.variable.displayName || label;
+// })
+// : fixLabelsForNumberVariables(data.label, variable),
 
 /**
  * non-array version of fixLabelsForNumberVariables

--- a/src/lib/core/utils/visualization.ts
+++ b/src/lib/core/utils/visualization.ts
@@ -147,19 +147,7 @@ export function fixVarIdLabels(
   entities: StudyEntity[]
 ): string[] {
   console.log(labels);
-  const displayNames: string[] = labels.map((label) => {
-    // Label is a variable id. Get entity and var id from variable list.
-    const variableDescriptors = variableList.filter(
-      (varItem) => varItem.variableId === label
-    );
-    const variableDescriptor = variableDescriptors && variableDescriptors[0];
-    const retrievedVariable = findEntityAndVariable(
-      entities,
-      variableDescriptor
-    );
-    return retrievedVariable?.variable.displayName || label;
-  });
-  return displayNames;
+  return labels.map((label) => fixVarIdLabel(label, variableList, entities);
 }
 
 /**

--- a/src/lib/core/utils/visualization.ts
+++ b/src/lib/core/utils/visualization.ts
@@ -13,6 +13,7 @@ import { Bounds } from '@veupathdb/components/lib/map/Types';
 import { Filter } from '../types/filter';
 import { VariableDescriptor } from '../types/variable';
 import { findEntityAndVariable } from './study-metadata';
+import { updateColumnsDialogSelection } from '@veupathdb/wdk-client/lib/Actions/SummaryView/ResultTableSummaryViewActions';
 
 // was: BarplotData | HistogramData | { series: BoxplotData };
 type SeriesWithStatistics<T> = T & CoverageStatistics;
@@ -111,38 +112,12 @@ export function fixLabelsForNumberVariables(
   labels: string[] = [],
   variable?: Variable
 ): string[] {
+  console.log('fixing number labels');
+  console.log(labels);
   return variable != null && variable.type === 'number'
     ? labels.map((n) => String(Number(n)))
     : labels;
 }
-
-export function fixVarIdLabels(
-  labels: string[] = [],
-  variableList: VariableDescriptor[],
-  entities: StudyEntity[]
-): string[] {
-  const displayNames: string[] = labels.map((label) => {
-    // Label is variable id. Get entity and var id from collection list.
-    const variableDescriptors = variableList.filter(
-      (varItem) => varItem.variableId === label
-    );
-    const variableDescriptor = variableDescriptors && variableDescriptors[0];
-    const retrievedVariable = findEntityAndVariable(
-      entities,
-      variableDescriptor
-    );
-    return retrievedVariable?.variable.displayName || label;
-  });
-  return displayNames;
-}
-
-// ? data.label.map((label) => {
-//   const labelVariables = response.boxplot.config.computedVariableMetadata?.collectionVariable?.collectionVariableDetails?.filter((varDetails) => varDetails.variableId === label);
-//   const labelVariable = labelVariables && labelVariables[0];
-//   const retrievedVariable = entities && findEntityAndVariable(entities, labelVariable);
-//   return retrievedVariable?.variable.displayName || label;
-// })
-// : fixLabelsForNumberVariables(data.label, variable),
 
 /**
  * non-array version of fixLabelsForNumberVariables
@@ -157,6 +132,55 @@ export function fixLabelForNumberVariables(
   return variable != null && variable.type === 'number'
     ? String(isNaN(Number(label)) ? label : Number(label))
     : label;
+}
+
+/**
+ *
+ * In the abundance app, var ids show up like normal variable values. This function
+ * takes these ids (labels) and returns that variable's display name, if it exists.
+ *
+ * If no variable is found with that id, the original label is returned.
+ */
+export function fixVarIdLabels(
+  labels: string[] = [],
+  variableList: VariableDescriptor[],
+  entities: StudyEntity[]
+): string[] {
+  console.log(labels);
+  const displayNames: string[] = labels.map((label) => {
+    // Label is a variable id. Get entity and var id from variable list.
+    const variableDescriptors = variableList.filter(
+      (varItem) => varItem.variableId === label
+    );
+    const variableDescriptor = variableDescriptors && variableDescriptors[0];
+    const retrievedVariable = findEntityAndVariable(
+      entities,
+      variableDescriptor
+    );
+    return retrievedVariable?.variable.displayName || label;
+  });
+  return displayNames;
+}
+
+/**
+ *
+ * non-array version of fixVarIdLabels
+ *
+ * If no variable is found with that id, the original label is returned.
+ */
+export function fixVarIdLabel(
+  label: string,
+  variableList: VariableDescriptor[],
+  entities: StudyEntity[]
+): string {
+  // Label is a variable id. Get entity and var id from variable list.
+  const variableDescriptors = variableList.filter(
+    (varItem) => varItem.variableId === label
+  );
+  const variableDescriptor = variableDescriptors && variableDescriptors[0];
+  const retrievedVariable = findEntityAndVariable(entities, variableDescriptor);
+  const displayName: string = retrievedVariable?.variable.displayName || label;
+  return displayName;
 }
 
 export const nonUniqueWarning =

--- a/src/lib/core/utils/visualization.ts
+++ b/src/lib/core/utils/visualization.ts
@@ -112,8 +112,6 @@ export function fixLabelsForNumberVariables(
   labels: string[] = [],
   variable?: Variable
 ): string[] {
-  console.log('fixing number labels');
-  console.log(labels);
   return variable != null && variable.type === 'number'
     ? labels.map((n) => String(Number(n)))
     : labels;
@@ -146,8 +144,7 @@ export function fixVarIdLabels(
   variableList: VariableDescriptor[],
   entities: StudyEntity[]
 ): string[] {
-  console.log(labels);
-  return labels.map((label) => fixVarIdLabel(label, variableList, entities);
+  return labels.map((label) => fixVarIdLabel(label, variableList, entities));
 }
 
 /**


### PR DESCRIPTION
Resolves #1084 

The ranked abundance app response has box labels (or scatter overlay labels) that are variable ids instead of display names. Additionally the computation metadata lists these variable ids in a specific order which is not yet respected by the box or scatter.

This PR replaces the var ids with display names, and then also ensures they are displayed in the correct order.

To Dos
- [x] Box
- [x] Scatter