### PR TITLE
Issue 1093

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/hooks/study.ts
+++ b/src/lib/core/hooks/study.ts
@@ -194,12 +194,17 @@ export function useStudyMetadata(datasetId: string, client: SubsettingClient) {
         throw new Error(
           'Could not find study with associated dataset id `' + datasetId + '`.'
         );
-      if (getStudyAccess(studyRecord) === 'prerelease')
+      try {
+        return await client.getStudyMetadata(
+          studyRecord.attributes.eda_study_id
+        );
+      } catch (error) {
+        console.error(error);
         return {
           id: studyRecord.attributes.eda_study_id,
           rootEntity: STUB_ENTITY,
         };
-      return client.getStudyMetadata(studyRecord.attributes.eda_study_id);
+      }
     },
     [datasetId, client]
   );

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -18,7 +18,7 @@ import { Status } from '../core';
 // Hooks
 import { useEntityCounts } from '../core/hooks/entityCounts';
 import { usePrevious } from '../core/hooks/previousValue';
-import { useStudyEntities } from '../core/hooks/study';
+import { isStubEntity, useStudyEntities } from '../core/hooks/study';
 import { useSetDocumentTitle } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { useStudyMetadata, useStudyRecord } from '../core';
 import { useGeoConfig } from '../core/hooks/geoConfig';
@@ -190,7 +190,10 @@ export function AnalysisPanel({
       </div>
     );
   if (analysis == null || approvalStatus === 'loading') return <Loading />;
-  if (approvalStatus === 'not-approved')
+  if (
+    approvalStatus === 'not-approved' ||
+    isStubEntity(studyMetadata.rootEntity)
+  )
     return <Redirect to={Path.normalize(routeBase + '/..')} />;
   return (
     <RestrictedPage approvalStatus={approvalStatus}>

--- a/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -10,13 +10,15 @@ import { AnalysisNameDialog } from './AnalysisNameDialog';
 import AddIcon from '@material-ui/icons/Add';
 
 // Hooks
-import { useStudyRecord } from '../core/hooks/workspace';
+import { useStudyMetadata, useStudyRecord } from '../core/hooks/workspace';
 
 // Definitions & Utilities
 import { cx } from './Utils';
 import { AnalysisState, DEFAULT_ANALYSIS_NAME } from '../core';
 import { getAnalysisId, isSavedAnalysis } from '../core/utils/analysis';
 import { usePermissions } from '@veupathdb/study-data-access/lib/data-restriction/permissionsHooks';
+import { isStubEntity } from '../core/hooks/study';
+import Banner from '@veupathdb/coreui/dist/components/banners/Banner';
 
 interface EDAWorkspaceHeadingProps {
   /** Optional AnalysisState for "New analysis" button functionality */
@@ -28,7 +30,7 @@ export function EDAWorkspaceHeading({
   analysisState,
 }: EDAWorkspaceHeadingProps) {
   const studyRecord = useStudyRecord();
-  // const attemptAction = useAttemptActionCallback();
+  const studyMetadata = useStudyMetadata();
   const analysis = analysisState?.analysis;
   const [dialogIsOpen, setDialogIsOpen] = useState(false);
   const { url } = useRouteMatch();
@@ -54,65 +56,75 @@ export function EDAWorkspaceHeading({
   }, [analysisId]);
 
   return (
-    <div className={cx('-Heading')}>
-      <H3 additionalStyles={{ padding: 0 }}>
-        {safeHtml(studyRecord.displayName)}
-      </H3>
-      {showButtons && (
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            alignItems: 'center',
+    <>
+      <div className={cx('-Heading')}>
+        <H3 additionalStyles={{ padding: 0 }}>
+          {safeHtml(studyRecord.displayName)}
+        </H3>
+        {showButtons && (
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              alignItems: 'center',
+            }}
+          >
+            <div>
+              <FloatingButton
+                themeRole="primary"
+                text="New analysis"
+                tooltip="Create a new analysis"
+                textTransform="capitalize"
+                size="medium"
+                // @ts-ignore
+                icon={AddIcon}
+                onPress={
+                  /** If (1) there is no analysis, (2) we're in an unsaved new
+                   * analysis (here `analysis` is still undefined in this case),
+                   * or (3) we're in a renamed analysis, just go straight to the
+                   * new analysis. Otherwise, show the renaming dialog. */
+                  analysis && analysis.displayName === DEFAULT_ANALYSIS_NAME
+                    ? () => setDialogIsOpen(true)
+                    : redirectToNewAnalysis
+                }
+              />
+            </div>
+            <div>
+              <FloatingButton
+                themeRole="primary"
+                text="My analyses"
+                textTransform="capitalize"
+                tooltip="View all of your analyses for this study"
+                icon={Table}
+                onPress={() =>
+                  history.push(
+                    '/eda?s=' + encodeURIComponent(studyRecord.displayName)
+                  )
+                }
+              />
+            </div>
+          </div>
+        )}
+        {analysisState && isSavedAnalysis(analysis) && (
+          <AnalysisNameDialog
+            isOpen={dialogIsOpen}
+            setIsOpen={setDialogIsOpen}
+            initialAnalysisName={analysis.displayName}
+            setAnalysisName={(newName) =>
+              newName && analysisState.setName(newName)
+            }
+            redirectToNewAnalysis={redirectToNewAnalysis}
+          />
+        )}
+      </div>
+      {isStubEntity(studyMetadata.rootEntity) && (
+        <Banner
+          banner={{
+            type: 'info',
+            message: 'Data for this study is not currently available.',
           }}
-        >
-          <div>
-            <FloatingButton
-              themeRole="primary"
-              text="New analysis"
-              tooltip="Create a new analysis"
-              textTransform="capitalize"
-              size="medium"
-              // @ts-ignore
-              icon={AddIcon}
-              onPress={
-                /** If (1) there is no analysis, (2) we're in an unsaved new
-                 * analysis (here `analysis` is still undefined in this case),
-                 * or (3) we're in a renamed analysis, just go straight to the
-                 * new analysis. Otherwise, show the renaming dialog. */
-                analysis && analysis.displayName === DEFAULT_ANALYSIS_NAME
-                  ? () => setDialogIsOpen(true)
-                  : redirectToNewAnalysis
-              }
-            />
-          </div>
-          <div>
-            <FloatingButton
-              themeRole="primary"
-              text="My analyses"
-              textTransform="capitalize"
-              tooltip="View all of your analyses for this study"
-              icon={Table}
-              onPress={() =>
-                history.push(
-                  '/eda?s=' + encodeURIComponent(studyRecord.displayName)
-                )
-              }
-            />
-          </div>
-        </div>
-      )}
-      {analysisState && isSavedAnalysis(analysis) && (
-        <AnalysisNameDialog
-          isOpen={dialogIsOpen}
-          setIsOpen={setDialogIsOpen}
-          initialAnalysisName={analysis.displayName}
-          setAnalysisName={(newName) =>
-            newName && analysisState.setName(newName)
-          }
-          redirectToNewAnalysis={redirectToNewAnalysis}
         />
       )}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Fixes #1093

This PR introduces changes that allow prerelease studies to be viewed in the analysis workspace. We now always attempt to load study metadata. If the request fails, we use a stub record and use that to determine if we should redirect, and to display a message about not being able to load data.