### PR TITLE
working app thumbnail page

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@veupathdb/study-data-access": "^0.3.0",
     "@veupathdb/tsconfig": "^1.0.1",
     "@veupathdb/wdk-client": "^0.7.1",
-    "@veupathdb/web-common": "^0.4.0",
+    "@veupathdb/web-common": "^0.5.1",
     "bubleify": "^2.0.0",
     "http-proxy-middleware": "^1.0.6",
     "husky": "^4.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -9,7 +9,7 @@ import { ComputationProps } from './Types';
 export interface Props extends ComputationProps {
   computationId: string;
   visualizationTypes: Record<string, VisualizationType>;
-  baseUrl?: string;
+  baseUrl?: string; // right now only defined when *not* using single app mode
 }
 
 export function ComputationInstance(props: Props) {
@@ -63,7 +63,7 @@ export function ComputationInstance(props: Props) {
 
   return (
     <div>
-      <h3>{computation.displayName}</h3>
+      {baseUrl && <h3>{computation.displayName}</h3>}
       <VisualizationsContainer
         geoConfigs={geoConfigs}
         computation={computation}

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -1,4 +1,3 @@
-import { string } from 'fp-ts';
 import React, { useCallback, useMemo } from 'react';
 import { useToggleStarredVariable } from '../../hooks/starredVariables';
 import {

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -1,3 +1,4 @@
+import { string } from 'fp-ts';
 import React, { useCallback, useMemo } from 'react';
 import { useToggleStarredVariable } from '../../hooks/starredVariables';
 import { Visualization } from '../../types/visualization';
@@ -8,6 +9,7 @@ import { ComputationProps } from './Types';
 export interface Props extends ComputationProps {
   computationId: string;
   visualizationTypes: Record<string, VisualizationType>;
+  baseUrl?: string;
 }
 
 export function ComputationInstance(props: Props) {
@@ -19,6 +21,7 @@ export function ComputationInstance(props: Props) {
     filteredCounts,
     geoConfigs,
     visualizationTypes,
+    baseUrl,
   } = props;
 
   const computation = useMemo(() => {
@@ -59,17 +62,21 @@ export function ComputationInstance(props: Props) {
     return null;
 
   return (
-    <VisualizationsContainer
-      geoConfigs={geoConfigs}
-      computation={computation}
-      visualizationsOverview={computationAppOverview.visualizations}
-      visualizationTypes={visualizationTypes}
-      updateVisualizations={updateVisualizations}
-      filters={analysis.descriptor.subset.descriptor}
-      starredVariables={analysis?.descriptor.starredVariables}
-      toggleStarredVariable={toggleStarredVariable}
-      totalCounts={totalCounts}
-      filteredCounts={filteredCounts}
-    />
+    <div>
+      <h3>{computation.displayName}</h3>
+      <VisualizationsContainer
+        geoConfigs={geoConfigs}
+        computation={computation}
+        visualizationsOverview={computationAppOverview.visualizations}
+        visualizationTypes={visualizationTypes}
+        updateVisualizations={updateVisualizations}
+        filters={analysis.descriptor.subset.descriptor}
+        starredVariables={analysis?.descriptor.starredVariables}
+        toggleStarredVariable={toggleStarredVariable}
+        totalCounts={totalCounts}
+        filteredCounts={filteredCounts}
+        baseUrl={baseUrl}
+      />
+    </div>
   );
 }

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -1,10 +1,15 @@
 import { string } from 'fp-ts';
 import React, { useCallback, useMemo } from 'react';
 import { useToggleStarredVariable } from '../../hooks/starredVariables';
-import { Visualization } from '../../types/visualization';
+import {
+  Computation,
+  ComputationAppOverview,
+  Visualization,
+} from '../../types/visualization';
 import { VisualizationsContainer } from '../visualizations/VisualizationsContainer';
 import { VisualizationType } from '../visualizations/VisualizationTypes';
 import { ComputationProps } from './Types';
+import { Link, useRouteMatch } from 'react-router-dom';
 
 export interface Props extends ComputationProps {
   computationId: string;
@@ -21,7 +26,7 @@ export function ComputationInstance(props: Props) {
     filteredCounts,
     geoConfigs,
     visualizationTypes,
-    baseUrl,
+    baseUrl, // Only set when we are *not* using single app mode
   } = props;
 
   const computation = useMemo(() => {
@@ -54,6 +59,8 @@ export function ComputationInstance(props: Props) {
     [setComputations, computationId]
   );
 
+  const { url } = useRouteMatch();
+
   if (
     analysis == null ||
     computation == null ||
@@ -63,7 +70,20 @@ export function ComputationInstance(props: Props) {
 
   return (
     <div>
-      {baseUrl && <h3>{computation.displayName}</h3>}
+      {baseUrl &&
+        (url.replace(/\/+$/, '').split('/').pop() === 'visualizations' ? (
+          <AppTitle
+            computation={computation}
+            computationAppOverview={computationAppOverview}
+            condensed={true}
+          />
+        ) : (
+          <AppTitle
+            computation={computation}
+            computationAppOverview={computationAppOverview}
+            condensed={false}
+          />
+        ))}
       <VisualizationsContainer
         geoConfigs={geoConfigs}
         computation={computation}
@@ -77,6 +97,50 @@ export function ComputationInstance(props: Props) {
         filteredCounts={filteredCounts}
         baseUrl={baseUrl}
       />
+    </div>
+  );
+}
+
+// Title above each app in /visualizations
+interface AppTitleProps {
+  computation: Computation;
+  computationAppOverview: ComputationAppOverview;
+  condensed: boolean;
+}
+
+// We expect two different types of app titles: one in /visualizations that labels each app's row
+// and one just below the navigation when we're working on a viz within an app. The former
+// is the "condensed" version. May make sense to break into two components when
+// further styling is applied?
+function AppTitle(props: AppTitleProps) {
+  const { computation, computationAppOverview, condensed } = { ...props };
+  const style = {
+    borderRadius: 5,
+    paddingTop: 10,
+    paddingRight: 35,
+    paddingBottom: 10,
+    paddingLeft: 20,
+    backgroundColor: 'lightblue',
+    margin: 'auto',
+    marginTop: 10,
+  };
+  return condensed ? (
+    <div>
+      <h3>
+        {computation.displayName} <i className="fa fa-cog"></i>{' '}
+        <i className="fa fa-clone"></i> <i className="fa fa-trash"></i>
+      </h3>
+      <h4>
+        <i>{computationAppOverview.displayName}</i>
+      </h4>
+    </div>
+  ) : (
+    <div style={style}>
+      <h3>
+        {computation.displayName} <i className="fa fa-cog"></i>{' '}
+        <i className="fa fa-clone"></i> <i className="fa fa-trash"></i>
+      </h3>
+      <h4>{computationAppOverview.displayName}</h4>
     </div>
   );
 }

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -9,7 +9,7 @@ import {
 import { VisualizationsContainer } from '../visualizations/VisualizationsContainer';
 import { VisualizationType } from '../visualizations/VisualizationTypes';
 import { ComputationProps } from './Types';
-import { Link, useRouteMatch } from 'react-router-dom';
+import { useRouteMatch } from 'react-router-dom';
 
 export interface Props extends ComputationProps {
   computationId: string;
@@ -26,7 +26,7 @@ export function ComputationInstance(props: Props) {
     filteredCounts,
     geoConfigs,
     visualizationTypes,
-    baseUrl, // Only set when we are *not* using single app mode
+    baseUrl,
   } = props;
 
   const computation = useMemo(() => {
@@ -68,22 +68,19 @@ export function ComputationInstance(props: Props) {
   )
     return null;
 
+  // If we can have multiple app instances, add a title. Otherwise, use
+  // the normal VisualizationsContainer.
   return (
     <div>
-      {baseUrl &&
-        (url.replace(/\/+$/, '').split('/').pop() === 'visualizations' ? (
-          <AppTitle
-            computation={computation}
-            computationAppOverview={computationAppOverview}
-            condensed={true}
-          />
-        ) : (
-          <AppTitle
-            computation={computation}
-            computationAppOverview={computationAppOverview}
-            condensed={false}
-          />
-        ))}
+      {baseUrl && (
+        <AppTitle
+          computation={computation}
+          computationAppOverview={computationAppOverview}
+          condensed={
+            url.replace(/\/+$/, '').split('/').pop() === 'visualizations'
+          }
+        />
+      )}
       <VisualizationsContainer
         geoConfigs={geoConfigs}
         computation={computation}
@@ -113,8 +110,8 @@ interface AppTitleProps {
 // is the "condensed" version. May make sense to break into two components when
 // further styling is applied?
 function AppTitle(props: AppTitleProps) {
-  const { computation, computationAppOverview, condensed } = { ...props };
-  const style = {
+  const { computation, computationAppOverview, condensed } = props;
+  const expandedStyle = {
     borderRadius: 5,
     paddingTop: 10,
     paddingRight: 35,
@@ -135,7 +132,7 @@ function AppTitle(props: AppTitleProps) {
       </h4>
     </div>
   ) : (
-    <div style={style}>
+    <div style={expandedStyle}>
       <h3>
         {computation.displayName} <i className="fa fa-cog"></i>{' '}
         <i className="fa fa-clone"></i> <i className="fa fa-trash"></i>

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -24,7 +24,7 @@ function variableDescriptorToString(
 }
 
 export function AlphaDivConfiguration(props: ComputationConfigProps) {
-  const [name, setName] = useState('New alpha diversity module');
+  const [name, setName] = useState('Unnamed alpha diversity');
   const [alphaDivMethod, setAlphaDivMethod] = useState(ALPHA_DIV_METHODS[0]);
   const { computationAppOverview, addNewComputation } = props;
   const studyMetadata = useStudyMetadata();

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -24,7 +24,7 @@ function variableDescriptorToString(
 }
 
 export function AlphaDivConfiguration(props: ComputationConfigProps) {
-  const [name, setName] = useState('Unnamed alpha diversity');
+  const [name, setName] = useState('Unnamed alpha diversity module');
   const [alphaDivMethod, setAlphaDivMethod] = useState(ALPHA_DIV_METHODS[0]);
   const { computationAppOverview, addNewComputation } = props;
   const studyMetadata = useStudyMetadata();

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -334,7 +334,6 @@ function FullScreenVisualization(props: Props & { id: string }) {
     baseUrl,
   } = props;
   const history = useHistory();
-  const { url } = useRouteMatch();
   const viz = computation.visualizations.find((v) => v.visualizationId === id);
   const vizType = viz && visualizationTypes[viz.descriptor.type];
   const overviews = useMemo(

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -447,7 +447,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
         <Tooltip title="Minimize visualization">
           <Link
             to={{
-              pathname: `../${baseUrl ? '' : computationId}`, // Should go to ../visualizations
+              pathname: `../${baseUrl ? '' : computationId}`, // Should go to ../visualizations unless in single app mode
               state: { scrollToTop: false },
             }}
           >

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -51,6 +51,7 @@ interface Props {
   totalCounts: PromiseHookState<EntityCounts>;
   filteredCounts: PromiseHookState<EntityCounts>;
   geoConfigs: GeoConfig[];
+  baseUrl?: string;
 }
 
 /**
@@ -61,6 +62,7 @@ interface Props {
  * @param props Props
  */
 export function VisualizationsContainer(props: Props) {
+  const { baseUrl } = { ...props };
   const { url } = useRouteMatch();
 
   const currentStudyRecordId = useStudyRecord().id[0].value;
@@ -103,11 +105,11 @@ export function VisualizationsContainer(props: Props) {
         <Route exact path={url}>
           <ConfiguredVisualizations {...props} />
         </Route>
-        <Route exact path={`${url}/new`}>
+        <Route exact path={`${baseUrl || url}/new`}>
           <NewVisualizationPicker {...props} />
         </Route>
         <Route
-          path={`${url}/:id`}
+          path={`${baseUrl || url}/:id`}
           render={(routeProps: RouteComponentProps<{ id: string }>) => (
             <FullScreenVisualization
               id={routeProps.match.params.id}
@@ -121,13 +123,21 @@ export function VisualizationsContainer(props: Props) {
 }
 
 function ConfiguredVisualizations(props: Props) {
-  const { computation, updateVisualizations, visualizationsOverview } = props;
+  const {
+    computation,
+    updateVisualizations,
+    visualizationsOverview,
+    baseUrl,
+  } = props;
   const { url } = useRouteMatch();
 
   return (
     <Grid>
       <Link
-        to={{ pathname: `${url}/new`, state: { scrollToTop: false } }}
+        to={{
+          pathname: `${baseUrl || url}/new`,
+          state: { scrollToTop: false },
+        }}
         className={cx('-NewVisualization')}
       >
         <i className="fa fa-plus"></i>
@@ -185,7 +195,7 @@ function ConfiguredVisualizations(props: Props) {
                 <>
                   <Link
                     to={{
-                      pathname: `${url}/${viz.visualizationId}`,
+                      pathname: `${baseUrl || url}/${viz.visualizationId}`,
                       state: { scrollToTop: false },
                     }}
                   >
@@ -321,8 +331,10 @@ function FullScreenVisualization(props: Props & { id: string }) {
     totalCounts,
     filteredCounts,
     geoConfigs,
+    baseUrl,
   } = props;
   const history = useHistory();
+  const { url } = useRouteMatch();
   const viz = computation.visualizations.find((v) => v.visualizationId === id);
   const vizType = viz && visualizationTypes[viz.descriptor.type];
   const overviews = useMemo(
@@ -436,7 +448,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
         <Tooltip title="Minimize visualization">
           <Link
             to={{
-              pathname: `../${computationId}`,
+              pathname: `../${baseUrl ? '' : computationId}`, // Should go to ../visualizations
               state: { scrollToTop: false },
             }}
           >

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -95,23 +95,31 @@ export function ComputationRoute(props: Props) {
         } else {
           return (
             <Switch>
-              <Route exact path={url}>
-                <StartPage baseUrl={url} apps={apps} {...props} />
+              <Route exact path={`${url}`}>
                 <div>
-                  <h2>Saved apps</h2>
-                  <ul>
-                    {analysisState.analysis?.descriptor.computations.map(
-                      (c) => (
-                        <li>
-                          <Link to={`${url}/${c.computationId}`}>
-                            {c.displayName ?? 'No name'} &mdash;{' '}
-                            {c.descriptor.type}
-                          </Link>
-                        </li>
+                  <Link to={`${url}/new`}> + New app</Link>
+                  <h2>Saved apps and vizs</h2>
+                  {analysisState.analysis?.descriptor.computations.map((c) => {
+                    const app = apps.find(
+                      (app) => app.name === c.descriptor.type
+                    );
+                    const plugin = app && plugins[app.name];
+                    return (
+                      plugin && (
+                        <ComputationInstance
+                          {...props}
+                          computationId={c.computationId}
+                          computationAppOverview={app}
+                          visualizationTypes={plugin.visualizationTypes}
+                          baseUrl={`${url}/${c.computationId}`}
+                        />
                       )
-                    )}
-                  </ul>
+                    );
+                  })}
                 </div>
+              </Route>
+              <Route exact path={`${url}/new`}>
+                <StartPage baseUrl={`${url}`} apps={apps} {...props} />
               </Route>
               {apps.map((app) => {
                 const plugin = plugins[app.name];
@@ -165,6 +173,7 @@ export function ComputationRoute(props: Props) {
                       computationId={routeProps.match.params.id}
                       computationAppOverview={app}
                       visualizationTypes={plugin.visualizationTypes}
+                      baseUrl={`${url}/${computation?.computationId}`}
                     />
                   );
                 }}

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -97,8 +97,15 @@ export function ComputationRoute(props: Props) {
             <Switch>
               <Route exact path={`${url}`}>
                 <div>
-                  <Link to={`${url}/new`}> + New app</Link>
-                  <h2>Saved apps and vizs</h2>
+                  <div>
+                    <Link to={`${url}/new`}>
+                      {' '}
+                      <h2>+ New module</h2>
+                    </Link>
+                  </div>
+                  <br></br>
+                  <h2>Saved modules and vizs</h2>
+                  <hr></hr>
                   {analysisState.analysis?.descriptor.computations.map((c) => {
                     const app = apps.find(
                       (app) => app.name === c.descriptor.type

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,10 +3490,10 @@
     spin.js "^4.0.0"
     uuid "^8.1.0"
 
-"@veupathdb/web-common@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.4.0.tgz#e8cee9b08aaa229b4efe67c2ca3e2a3018808f47"
-  integrity sha512-t7GAgdi+fyIHgH4UIwQJK6k5W6HJMiP0TpxJ3Sy7osn3F/FbHyh4LGmIHqC7pzT3vWNA8mGZ9at++oNcukcuhA==
+"@veupathdb/web-common@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.5.1.tgz#5eb99b7a60d3f199b9fb72ed51a5d59771d64f48"
+  integrity sha512-ylTaIes1Mn6qSbAqUudqQ+xCHNokWMu81AGnLmfAxccus3IgHbKiQaGhhHVc6uA+E9TcEyOJT00wAgBgGU92Hw==
   dependencies:
     custom-event-polyfill "^1.0.7"
     md5 "^2.3.0"


### PR DESCRIPTION
Resolves #950 and also #1019

The goal of this PR is to have a functional app thumbnail page. 

Done:

- [x] Check that nothing i've done so far messes up clinepi
- [x] Consider making different component for the list of configured apps? This component would basically just add the the computation title and such above the `ConfiguredVisualizations` on `/visualizations`. Or maybe make special title component for the configured visualizations view and a different one that renders at the top of any other computation instance route.
- [x] Make it look a _little_ nicer
- [x] Check again that nothing i've done so far messes up clinepi


Left for another issue

- [ ] Functional app copy/delete/modify configuration.
- [ ] All styling

Notes:
- Very curious if the approach i took is reasonable. Felt easy to do but possibly overloading `ComputationInstance` too much? 
- I put in a little bit of support for having two different app titles: one for the `/visualization` page (a small version that can go just above the app's vizs) and one to live above pages within the app (adding a new viz, configuring a viz, etc). In short, eventually these two titles should look pretty different from each other, but they would both have the same information. Should they be two separate components?
- the `web-common` upgrade was to combat an error when the site was building. I can take it out if this is not the right place to upgrade!