### PR TITLE
force computedVar display ranges to be numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultDependentAxisRange.ts
@@ -221,7 +221,7 @@ function boxplotDefaultDependentAxisMinMax(
             ),
             min(data.value.series.flatMap((o) => o.lowerfence as number[])),
             // check displayRange with computedVariableMetadata
-            computedVariableMetadata?.displayRangeMin,
+            Number(computedVariableMetadata?.displayRangeMin),
           ]) as number,
           max: max([
             max(
@@ -229,7 +229,7 @@ function boxplotDefaultDependentAxisMinMax(
             ),
             max(data.value.series.flatMap((o) => o.upperfence as number[])),
             // check displayRange with computedVariableMetadata
-            computedVariableMetadata?.displayRangeMax,
+            Number(computedVariableMetadata?.displayRangeMax),
           ]) as number,
         }
       : undefined;


### PR DESCRIPTION
Resolves #1107 


Goal: force the computed variable display ranges to be always numbers in the boxplot. 

At first i thought we should change the api to send along numbers instead of strings, but i realize we want to keep sending as strings so that we can handle dates in the future. So instead, the fix is to just force the values to be numbers here!

