### PR TITLE
set four decimal points for independent axis range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/hooks/computeDefaultIndependentAxisRange.ts
+++ b/src/lib/core/hooks/computeDefaultIndependentAxisRange.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import { DateVariable, NumberVariable, Variable } from '../types/study';
 import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
+// utililty function to get specific decimal points as a number, not string
+import { numberDecimalPoint } from '../utils/number-decimal-point';
 
 export function defaultIndependentAxisRangeFunction(
   variable: Variable | undefined,
@@ -13,16 +15,22 @@ export function defaultIndependentAxisRangeFunction(
       return defaults.displayRangeMin != null &&
         defaults.displayRangeMax != null
         ? {
-            min: Math.min(defaults.displayRangeMin, defaults.rangeMin),
-            max: Math.max(defaults.displayRangeMax, defaults.rangeMax),
+            min: numberDecimalPoint(
+              Math.min(defaults.displayRangeMin, defaults.rangeMin),
+              4
+            ),
+            max: numberDecimalPoint(
+              Math.max(defaults.displayRangeMax, defaults.rangeMax),
+              4
+            ),
           }
         : {
             // separate histogram following the criterion at histogram filter
             min:
               plotName === 'histogram'
-                ? Math.min(0, defaults.rangeMin)
-                : defaults.rangeMin,
-            max: defaults.rangeMax,
+                ? numberDecimalPoint(Math.min(0, defaults.rangeMin), 4)
+                : numberDecimalPoint(defaults.rangeMin, 4),
+            max: numberDecimalPoint(defaults.rangeMax, 4),
           };
     } else if (DateVariable.is(variable)) {
       const defaults = variable.distributionDefaults;

--- a/src/lib/core/utils/number-decimal-point.ts
+++ b/src/lib/core/utils/number-decimal-point.ts
@@ -3,5 +3,5 @@ export function numberDecimalPoint(
   value: number,
   decimalPoint: number
 ): number {
-  return Number(value.toFixed(decimalPoint));
+  return Number.isInteger(value) ? value : Number(value.toFixed(decimalPoint));
 }


### PR DESCRIPTION
This addresses https://github.com/VEuPathDB/web-eda/issues/1015#issuecomment-1116389339

The same study and variables shown in the comment's screenshot is reproduced with this PR as follows. Now the decimal point is limited up to 4 digits: see X-axis range's min value. I also changed existing function to check whether the number value is integer or not because there is no need to have additional decimal point for the integer case.

![scatter-LLINEUP-X-range-decimal-points](https://user-images.githubusercontent.com/12802305/166811778-0e699de5-67cb-4b03-a30f-0302b689af02.png)

