### PR TITLE
testing warning icons for axis range truncation

### DIFF
--- a/src/lib/core/components/visualizations/OutputEntityTitle.tsx
+++ b/src/lib/core/components/visualizations/OutputEntityTitle.tsx
@@ -2,15 +2,34 @@ import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUt
 
 import { StudyEntity } from '../../types/study';
 import { makeEntityDisplayName } from '../../utils/study-metadata';
+//DKDK add icon and tooltip
+// import WarningIcon from '@material-ui/icons/Warning';
+import Tooltip from '@veupathdb/wdk-client/lib/Components/Overlays/Tooltip';
+// use Banner from CoreUI for showing message for no smoothing
+import SVGWarning from '@veupathdb/coreui/dist/components/icons/Warning';
 
 interface Props {
   entity?: StudyEntity;
   outputSize?: number;
+  //DKDK add axis truncation config
+  axisTruncationConfig?: boolean[];
 }
 
 const cx = makeClassNameHelper('OutputEntityTitle');
 
-export function OutputEntityTitle({ entity, outputSize }: Props) {
+//DKDK add axis truncation config
+// export function OutputEntityTitle({ entity, outputSize }: Props) {
+export function OutputEntityTitle({
+  entity,
+  outputSize,
+  axisTruncationConfig,
+}: Props) {
+  //DKDK
+  const isAxisTruncation = axisTruncationConfig?.some(
+    (value: boolean) => value
+  );
+  const truncationHelp = 'truncated!!!';
+
   return (
     <p className={cx()}>
       {outputSize != null && <>{outputSize.toLocaleString()} </>}
@@ -22,6 +41,86 @@ export function OutputEntityTitle({ entity, outputSize }: Props) {
             )
           : 'No entity selected'}
       </span>
+      {/* DKDK add warning icon for axis truncation */}
+      &nbsp;&nbsp;
+      {isAxisTruncation && (
+        <>
+          <SVGWarning
+            style={{ verticalAlign: 'middle' }}
+            fill={'yellow'}
+            // fontSize="medium"
+          />
+          &nbsp;
+          <SVGWarning
+            style={{ verticalAlign: 'middle' }}
+            fill={'green'}
+            // fontSize="medium"
+          />
+          &nbsp;
+          <SVGWarning
+            style={{ verticalAlign: 'middle' }}
+            fill={'blue'}
+            // fontSize="medium"
+          />
+          &nbsp;
+          <Tooltip content={truncationHelp} showDelay={0}>
+            {/* <WarningIcon
+              style={{ color: 'black', verticalAlign: 'middle' }}
+              fontSize="medium"
+            /> */}
+            <SVGWarning
+              style={{ verticalAlign: 'middle' }}
+              fill={'red'}
+              // fontSize="medium"
+            />
+            {/* <i
+              style={{ marginLeft: '0px', color: 'blue' }}
+              className="fa fa-exclamation-triangle"
+              aria-hidden="true"
+              title="asdfasdfasdf"
+            /> */}
+            {/* <i
+              style={{ marginLeft: '0px', color: 'blue' }}
+              // className="fa fa-exclamation-triangle"
+              className="fa fa-exclamation-circle"
+              aria-hidden="true"
+              title="asdfasdfasdf"
+            /> */}
+          </Tooltip>
+          &nbsp;
+          <i
+            style={{ marginLeft: '0px', color: 'yellow' }}
+            // className="fa fa-exclamation-triangle"
+            className="fa fa-exclamation-circle"
+            aria-hidden="true"
+            title="asdfasdfasdf"
+          />
+          &nbsp;
+          <i
+            style={{ marginLeft: '0px', color: 'green' }}
+            // className="fa fa-exclamation-triangle"
+            className="fa fa-exclamation-circle"
+            aria-hidden="true"
+            title="asdfasdfasdf"
+          />
+          &nbsp;
+          <i
+            style={{ marginLeft: '0px', color: 'blue' }}
+            // className="fa fa-exclamation-triangle"
+            className="fa fa-exclamation-circle"
+            aria-hidden="true"
+            title="asdfasdfasdf"
+          />
+          &nbsp;
+          <i
+            style={{ marginLeft: '0px', color: 'red' }}
+            // className="fa fa-exclamation-triangle"
+            className="fa fa-exclamation-circle"
+            aria-hidden="true"
+            title="asdfasdfasdf"
+          />
+        </>
+      )}
     </p>
   );
 }

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -700,7 +700,20 @@ function BarplotViz(props: VisualizationProps) {
       </div>
 
       <PluginError error={data.error} outputSize={outputSize} />
-      <OutputEntityTitle entity={entity} outputSize={outputSize} />
+      {/* DKDK truncation warning sign */}
+      {/* <OutputEntityTitle entity={entity} outputSize={outputSize} /> */}
+      <OutputEntityTitle
+        entity={entity}
+        outputSize={outputSize}
+        // pass axisTruncationConfig as boolean array
+        axisTruncationConfig={[
+          truncationConfigIndependentAxisMin,
+          truncationConfigIndependentAxisMax,
+          truncationConfigDependentAxisMin,
+          truncationConfigDependentAxisMax,
+        ]}
+      />
+
       <PlotLayout
         isFaceted={isFaceted(data.value)}
         plotNode={plotNode}


### PR DESCRIPTION
This is a draft PR to test warning icon above any zoomed plot, discussed #1103: not cleaned up as testing several icons. 

Yellow icon is not clearly visible under white background so tried a couple of different colors and round icon as follows: also shows a tooltip implementation  when mouseover to the icon.

![barplot-truncated-warning](https://user-images.githubusercontent.com/12802305/166981975-6c3b6c35-05e7-4177-b66c-a844a1ad1bd2.png)