### PR TITLE
Show apps as disabled when client plugins are not implemented

### DIFF
--- a/src/lib/core/components/computations/StartPage.tsx
+++ b/src/lib/core/components/computations/StartPage.tsx
@@ -1,14 +1,16 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 import { ComputationAppOverview } from '../../types/visualization';
+import { ComputationPlugin } from './Types';
+import { orderBy } from 'lodash';
 
 interface Props {
   baseUrl: string;
   apps: ComputationAppOverview[];
+  plugins: Record<string, ComputationPlugin>;
 }
 
 export function StartPage(props: Props) {
-  const { apps, baseUrl } = props;
+  const { apps, baseUrl, plugins } = props;
   return (
     <div>
       <h3>To get started, select an app.</h3>
@@ -18,22 +20,35 @@ export function StartPage(props: Props) {
         variables.
       </p>
       <div style={{ display: 'flex', flexDirection: 'column', width: '50%' }}>
-        {apps.map((app) => (
-          <Link
-            to={`${baseUrl}/new/${app.name}`}
-            style={{
-              padding: '1em',
-              border: '1px solid',
-              borderRadius: '.5em',
-              margin: '1em 0',
-            }}
-          >
-            <div style={{ fontWeight: 'bold', fontSize: '1.2em' }}>
-              {app.displayName}
+        {/* orderBy renders available apps ahead of those in development */}
+        {orderBy(apps, [(app) => (plugins[app.name] ? 1 : 0)], ['desc']).map(
+          (app) => (
+            <div
+              style={{
+                padding: '1em',
+                border: '1px solid',
+                borderRadius: '.5em',
+                margin: '1em 0',
+                cursor: plugins[app.name] ? 'pointer' : 'not-allowed',
+                background: plugins[app.name] ? 'transparent' : '#eee',
+                opacity: plugins[app.name] ? '1' : '0.5',
+              }}
+            >
+              <Link
+                to={`${baseUrl}/new/${app.name}`}
+                style={{
+                  pointerEvents: plugins[app.name] ? 'auto' : 'none',
+                }}
+              >
+                <div style={{ fontWeight: 'bold', fontSize: '1.2em' }}>
+                  {app.displayName}
+                  {plugins[app.name] ? '' : <i> (Coming soon!)</i>}
+                </div>
+                <div>{app.description}</div>
+              </Link>
             </div>
-            <div>{app.description}</div>
-          </Link>
-        ))}
+          )
+        )}
       </div>
     </div>
   );

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -126,7 +126,12 @@ export function ComputationRoute(props: Props) {
                 </div>
               </Route>
               <Route exact path={`${url}/new`}>
-                <StartPage baseUrl={`${url}`} apps={apps} {...props} />
+                <StartPage
+                  baseUrl={`${url}`}
+                  apps={apps}
+                  plugins={plugins}
+                  {...props}
+                />
               </Route>
               {apps.map((app) => {
                 const plugin = plugins[app.name];


### PR DESCRIPTION
Addresses #1059 

 If `!singleAppMode`, the disabling logic is handled in the `StartPage` component by using the CSS property `pointer-events: none` for apps missing client plugins. As in `ClinEpi`, disabled implementations are rendered after enabled implementations.

![image](https://user-images.githubusercontent.com/69446567/167056325-9a11d0c7-2c30-43e6-9d94-057fc11c948a.png)
