### PR TITLE
Default to include mergeKey column in download modal results table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
@@ -148,12 +148,20 @@ export default function SubsettingDataGridModal({
   const fetchPaginatedData = useCallback(
     ({ pageSize, pageIndex }) => {
       setDataLoading(true);
+      if (!currentEntity) return;
+      const mergeKeys = () => {
+        return currentEntity.variables
+          .filter((variable) => 'isMergeKey' in variable && variable.isMergeKey)
+          .map((mergeKey) => mergeKey.id);
+      };
 
       subsettingClient
         .getTabularData(studyMetadata.id, currentEntityID, {
           filters: analysisState.analysis?.descriptor.subset.descriptor ?? [],
-          outputVariableIds: selectedVariableDescriptors.map(
-            (descriptor) => descriptor.variableId
+          outputVariableIds: mergeKeys().concat(
+            selectedVariableDescriptors.map(
+              (descriptor) => descriptor.variableId
+            )
           ),
           reportConfig: {
             headerFormat: 'standard',
@@ -179,6 +187,7 @@ export default function SubsettingDataGridModal({
       studyMetadata.id,
       subsettingClient,
       analysisState.analysis?.descriptor.subset.descriptor,
+      currentEntity,
     ]
   );
 


### PR DESCRIPTION
Addresses #931 

Added logic to the `fetchPaginatedData` callback that concatenates the `mergeKey` ids of the `currentEntity` with the `selectedVariableDescriptors` state.