### PR TITLE
Organize visualizations into app types and computations

### DIFF
--- a/src/lib/core/components/Grid.tsx
+++ b/src/lib/core/components/Grid.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import './Grid.scss';
 
@@ -7,9 +7,16 @@ interface Props {
 }
 
 export function Grid(props: Props) {
+  const children = useMemo(() => {
+    if (Array.isArray(props.children)) {
+      return props.children.filter((child) => !!child);
+    } else {
+      return props.children;
+    }
+  }, [props.children]);
   return (
     <div className="Grid">
-      {React.Children.map(props.children, (child) => (
+      {React.Children.map(children, (child) => (
         <div>{child}</div>
       ))}
     </div>

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -14,6 +14,7 @@ export interface Props extends ComputationProps {
   computationId: string;
   visualizationTypes: Record<string, VisualizationType>;
   baseUrl?: string; // right now only defined when *not* using single app mode
+  singleAppMode: string | undefined;
 }
 
 export function ComputationInstance(props: Props) {
@@ -26,6 +27,7 @@ export function ComputationInstance(props: Props) {
     geoConfigs,
     visualizationTypes,
     baseUrl,
+    singleAppMode,
   } = props;
 
   const computation = useMemo(() => {
@@ -92,6 +94,7 @@ export function ComputationInstance(props: Props) {
         totalCounts={totalCounts}
         filteredCounts={filteredCounts}
         baseUrl={baseUrl}
+        showHeading={!singleAppMode}
       />
     </div>
   );
@@ -121,22 +124,18 @@ function AppTitle(props: AppTitleProps) {
     marginTop: 10,
   };
   return condensed ? (
-    <div>
-      <h3>
-        {computation.displayName} <i className="fa fa-cog"></i>{' '}
-        <i className="fa fa-clone"></i> <i className="fa fa-trash"></i>
-      </h3>
-      <h4>
-        <i>{computationAppOverview.displayName}</i>
+    <div style={{ marginTop: 10 }}>
+      <h4>{computationAppOverview.displayName}</h4>
+      <h4 style={{ marginLeft: 20 }}>
+        <em>{computation.displayName}</em>
       </h4>
     </div>
   ) : (
     <div style={expandedStyle}>
-      <h3>
-        {computation.displayName} <i className="fa fa-cog"></i>{' '}
-        <i className="fa fa-clone"></i> <i className="fa fa-trash"></i>
-      </h3>
       <h4>{computationAppOverview.displayName}</h4>
+      <h4>
+        <em>{computation.displayName}</em>
+      </h4>
     </div>
   );
 }

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -36,6 +36,21 @@ export function ComputationInstance(props: Props) {
     );
   }, [computationId, analysis]);
 
+  // const groupingObject = useMemo(() => {
+  //   if (!analysis?.descriptor.computations.length) return {};
+  //   const test: any = {};
+  //   for (const computation of analysis?.descriptor.computations) {
+  //     const key  = computation.descriptor.type;
+  //     if (!(key in test)) {
+  //       test[key] = [computation]
+  //     } else {
+  //       test[key] = test[key].concat(computation)
+  //     }
+  //   }
+  //   return test;
+  // }, [analysis]);
+  // console.log(groupingObject);
+
   const toggleStarredVariable = useToggleStarredVariable(props.analysisState);
 
   const updateVisualizations = useCallback(
@@ -82,6 +97,28 @@ export function ComputationInstance(props: Props) {
           }
         />
       )}
+      {/* {groupingObject && 'pass' in groupingObject ?
+        groupingObject.pass.map((comp: Computation) => {
+          return (
+            <VisualizationsContainer
+              geoConfigs={geoConfigs}
+              // computation={computation}
+              computation={comp}
+              // @ts-ignore
+              visualizationsOverview={computationAppOverview.visualizations}
+              visualizationTypes={visualizationTypes}
+              updateVisualizations={updateVisualizations}
+              filters={analysis.descriptor.subset.descriptor}
+              starredVariables={analysis?.descriptor.starredVariables}
+              toggleStarredVariable={toggleStarredVariable}
+              totalCounts={totalCounts}
+              filteredCounts={filteredCounts}
+              baseUrl={baseUrl}
+              showHeading={!singleAppMode}
+            />
+          )
+        }) : null
+      } */}
       <VisualizationsContainer
         geoConfigs={geoConfigs}
         computation={computation}
@@ -125,7 +162,7 @@ function AppTitle(props: AppTitleProps) {
   };
   return condensed ? (
     <div style={{ marginTop: 10 }}>
-      <h4>{computationAppOverview.displayName}</h4>
+      {/* <h4>{computationAppOverview.displayName}</h4> */}
       <h4 style={{ marginLeft: 20 }}>
         <em>{computation.displayName}</em>
       </h4>

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -160,11 +160,35 @@ function AppTitle(props: AppTitleProps) {
     margin: 'auto',
     marginTop: 10,
   };
+
+  let method = 'n/a';
+  let dataset = 'n/a';
+  if (
+    typeof computation.descriptor.configuration === 'object' &&
+    computation.descriptor.configuration
+  ) {
+    const methodKey = Object.keys(
+      computation.descriptor.configuration
+    ).find((c) => c.includes('Method'));
+    // @ts-ignore
+    method = methodKey
+      ? computation.descriptor.configuration[methodKey]
+      : 'n/a';
+    // @ts-ignore
+    dataset = computation.descriptor.configuration.hasOwnProperty(
+      'collectionVariable'
+    )
+      ? computation.descriptor.configuration.collectionVariable.variableId
+      : 'n/a';
+  }
+
   return condensed ? (
     <div style={{ marginTop: 10 }}>
       {/* <h4>{computationAppOverview.displayName}</h4> */}
       <h4 style={{ marginLeft: 20 }}>
-        <em>{computation.displayName}</em>
+        <em>
+          Data: {dataset}, Method: {method}
+        </em>
       </h4>
     </div>
   ) : (

--- a/src/lib/core/components/computations/getAppDisplayProperties.tsx
+++ b/src/lib/core/components/computations/getAppDisplayProperties.tsx
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import { useStudyMetadata } from '../..';
+import { useCollectionVariables } from '../../hooks/study';
+import { Computation } from '../../types/visualization';
+
+const ABUNDANCE_METHODS = ['median', 'q3', 'variance', 'max'];
+const ALPHA_DIV_METHODS = ['shannon', 'simpson', 'evenness'];
+
+export function useAppPropertiesForDisplay(
+  computation: Computation | undefined
+) {
+  const studyMetadata = useStudyMetadata();
+  const collections = useCollectionVariables(studyMetadata.rootEntity);
+  return useMemo(() => {
+    if (computation && !computation.descriptor.configuration) return;
+    const displayProperties = collections
+      .filter(
+        // @ts-ignore
+        (collection) =>
+          collection.id ===
+          computation?.descriptor.configuration.collectionVariable.variableId
+      )
+      .map((varProperties) => ({
+        displayName:
+          varProperties.entityDisplayName + ': ' + varProperties.displayName,
+        // @ts-ignore
+        method: computation?.descriptor.configuration.method,
+      }));
+    return displayProperties[0];
+  }, [computation, collections]);
+}

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -93,7 +93,7 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
               addNewComputation(name, {
                 name: 'RankedAbundanceComputation',
                 collectionVariable: JSON.parse(collectionVariable),
-                rankingMethod,
+                method: rankingMethod,
               })
             }
           >

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -93,7 +93,7 @@ export function AlphaDivConfiguration(props: ComputationConfigProps) {
               addNewComputation(name, {
                 name: 'AlphaDivComputation',
                 collectionVariable: JSON.parse(collectionVariable),
-                alphaDivMethod,
+                method: alphaDivMethod,
               })
             }
           >

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -52,6 +52,7 @@ interface Props {
   filteredCounts: PromiseHookState<EntityCounts>;
   geoConfigs: GeoConfig[];
   baseUrl?: string;
+  showHeading: boolean;
 }
 
 /**
@@ -62,7 +63,7 @@ interface Props {
  * @param props Props
  */
 export function VisualizationsContainer(props: Props) {
-  const { baseUrl } = { ...props };
+  const { baseUrl, showHeading } = { ...props };
   const { url } = useRouteMatch();
 
   const currentStudyRecordId = useStudyRecord().id[0].value;
@@ -128,21 +129,24 @@ function ConfiguredVisualizations(props: Props) {
     updateVisualizations,
     visualizationsOverview,
     baseUrl,
+    showHeading,
   } = props;
   const { url } = useRouteMatch();
 
   return (
     <Grid>
-      <Link
-        to={{
-          pathname: `${baseUrl || url}/new`,
-          state: { scrollToTop: false },
-        }}
-        className={cx('-NewVisualization')}
-      >
-        <i className="fa fa-plus"></i>
-        New visualization
-      </Link>
+      {!showHeading && (
+        <Link
+          to={{
+            pathname: `${baseUrl || url}/new`,
+            state: { scrollToTop: false },
+          }}
+          className={cx('-NewVisualization')}
+        >
+          <i className="fa fa-plus"></i>
+          New visualization
+        </Link>
+      )}
       {computation.visualizations
         .map((viz) => {
           const meta = visualizationsOverview.find(

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -143,6 +143,10 @@ function ConfiguredVisualizations(props: Props) {
           pathname: `${baseUrl || url}/new`,
           state: { scrollToTop: false },
         }}
+        style={{
+          display: 'block',
+          width: 'fit-content',
+        }}
       >
         <FilledButton
           text="New visualization"

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -137,25 +137,25 @@ function ConfiguredVisualizations(props: Props) {
 
   return (
     <>
-      {!showHeading ? (
-        <Link
-          to={{
-            pathname: `${baseUrl || url}/new`,
-            state: { scrollToTop: false },
+      {/* {!showHeading ? ( */}
+      <Link
+        to={{
+          pathname: `${baseUrl || url}/new`,
+          state: { scrollToTop: false },
+        }}
+      >
+        <FilledButton
+          text="New visualization"
+          onPress={() => null}
+          textTransform="none"
+          themeRole="primary"
+          icon={AddIcon}
+          styleOverrides={{
+            container: { marginTop: 15 },
           }}
-        >
-          <FilledButton
-            text="New visualization"
-            onPress={() => null}
-            textTransform="none"
-            themeRole="primary"
-            icon={AddIcon}
-            styleOverrides={{
-              container: { marginTop: 15 },
-            }}
-          />
-        </Link>
-      ) : null}
+        />
+      </Link>
+      {/* ) : null} */}
       <Grid>
         {computation.visualizations
           .map((viz) => {

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -33,6 +33,8 @@ import { EntityCounts } from '../../hooks/entityCounts';
 import { useStudyRecord } from '../../hooks/workspace';
 import { PromiseHookState } from '../../hooks/promise';
 import { GeoConfig } from '../../types/geoConfig';
+import { FilledButton } from '@veupathdb/coreui/dist/components/buttons';
+import AddIcon from '@material-ui/icons/Add';
 
 const cx = makeClassNameHelper('VisualizationsContainer');
 
@@ -134,107 +136,118 @@ function ConfiguredVisualizations(props: Props) {
   const { url } = useRouteMatch();
 
   return (
-    <Grid>
-      {!showHeading && (
+    <>
+      {!showHeading ? (
         <Link
           to={{
             pathname: `${baseUrl || url}/new`,
             state: { scrollToTop: false },
           }}
-          className={cx('-NewVisualization')}
         >
-          <i className="fa fa-plus"></i>
-          New visualization
+          <FilledButton
+            text="New visualization"
+            onPress={() => null}
+            textTransform="none"
+            themeRole="primary"
+            icon={AddIcon}
+            styleOverrides={{
+              container: { marginTop: 15 },
+            }}
+          />
         </Link>
-      )}
-      {computation.visualizations
-        .map((viz) => {
-          const meta = visualizationsOverview.find(
-            (v) => v.name === viz.descriptor.type
-          );
-          return (
-            <div key={viz.visualizationId}>
-              <div className={cx('-ConfiguredVisualization')}>
-                <div className={cx('-ConfiguredVisualizationActions')}>
-                  <div>
-                    <Tooltip title="Delete visualization">
-                      <button
-                        type="button"
-                        className="link"
-                        onClick={() =>
-                          updateVisualizations((visualizations) =>
-                            visualizations.filter(
-                              (v) => v.visualizationId !== viz.visualizationId
+      ) : null}
+      <Grid>
+        {computation.visualizations
+          .map((viz) => {
+            const meta = visualizationsOverview.find(
+              (v) => v.name === viz.descriptor.type
+            );
+            return (
+              <div key={viz.visualizationId}>
+                <div className={cx('-ConfiguredVisualization')}>
+                  <div className={cx('-ConfiguredVisualizationActions')}>
+                    <div>
+                      <Tooltip title="Delete visualization">
+                        <button
+                          type="button"
+                          className="link"
+                          onClick={() =>
+                            updateVisualizations((visualizations) =>
+                              visualizations.filter(
+                                (v) => v.visualizationId !== viz.visualizationId
+                              )
                             )
-                          )
-                        }
-                      >
-                        <i className="fa fa-trash"></i>
-                      </button>
-                    </Tooltip>
+                          }
+                        >
+                          <i className="fa fa-trash"></i>
+                        </button>
+                      </Tooltip>
+                    </div>
+                    <div>
+                      <Tooltip title="Copy visualization">
+                        <button
+                          type="button"
+                          className="link"
+                          onClick={() =>
+                            updateVisualizations((visualizations) =>
+                              visualizations.concat({
+                                ...viz,
+                                displayName: `Copy of ${
+                                  viz.displayName ?? 'visualization'
+                                }`,
+                                visualizationId: uuid(),
+                              })
+                            )
+                          }
+                        >
+                          <i className="fa fa-clone"></i>
+                        </button>
+                      </Tooltip>
+                    </div>
                   </div>
-                  <div>
-                    <Tooltip title="Copy visualization">
-                      <button
-                        type="button"
-                        className="link"
-                        onClick={() =>
-                          updateVisualizations((visualizations) =>
-                            visualizations.concat({
-                              ...viz,
-                              displayName: `Copy of ${
-                                viz.displayName ?? 'visualization'
-                              }`,
-                              visualizationId: uuid(),
-                            })
-                          )
+                  {/* add the Link of thumbnail box here to avoid click conflict with icons */}
+                  <>
+                    <Link
+                      to={{
+                        pathname: `${baseUrl || url}/${viz.visualizationId}`,
+                        state: { scrollToTop: false },
+                      }}
+                    >
+                      {viz.descriptor.thumbnail ? (
+                        <img
+                          alt={viz.displayName}
+                          src={viz.descriptor.thumbnail}
+                        />
+                      ) : (
+                        <div
+                          className={cx('-ConfiguredVisualizationNoPreview')}
+                        >
+                          Preview unavailable
+                        </div>
+                      )}
+                      {/* make gray-out box on top of thumbnail */}
+                      <ConfiguredVisualizationGrayOut
+                        filters={props.filters}
+                        currentPlotFilters={
+                          (viz.descriptor as VisualizationDescriptor)
+                            .currentPlotFilters as Filter[]
                         }
-                      >
-                        <i className="fa fa-clone"></i>
-                      </button>
-                    </Tooltip>
-                  </div>
-                </div>
-                {/* add the Link of thumbnail box here to avoid click conflict with icons */}
-                <>
-                  <Link
-                    to={{
-                      pathname: `${baseUrl || url}/${viz.visualizationId}`,
-                      state: { scrollToTop: false },
-                    }}
-                  >
-                    {viz.descriptor.thumbnail ? (
-                      <img
-                        alt={viz.displayName}
-                        src={viz.descriptor.thumbnail}
                       />
-                    ) : (
-                      <div className={cx('-ConfiguredVisualizationNoPreview')}>
-                        Preview unavailable
-                      </div>
-                    )}
-                    {/* make gray-out box on top of thumbnail */}
-                    <ConfiguredVisualizationGrayOut
-                      filters={props.filters}
-                      currentPlotFilters={
-                        (viz.descriptor as VisualizationDescriptor)
-                          .currentPlotFilters as Filter[]
-                      }
-                    />
-                  </Link>
-                </>
+                    </Link>
+                  </>
+                </div>
+                <div className={cx('-ConfiguredVisualizationTitle')}>
+                  {viz.displayName ?? 'Unnamed visualization'}
+                </div>
+                <div className={cx('-ConfiguredVisualizationSubtitle')}>
+                  {meta?.displayName}
+                </div>
               </div>
-              <div className={cx('-ConfiguredVisualizationTitle')}>
-                {viz.displayName ?? 'Unnamed visualization'}
-              </div>
-              <div className={cx('-ConfiguredVisualizationSubtitle')}>
-                {meta?.displayName}
-              </div>
-            </div>
-          );
-        })
-        .reverse()}
-    </Grid>
+            );
+          })
+          .reverse()}
+      </Grid>
+    </>
   );
 }
 

--- a/src/lib/core/types/visualization.ts
+++ b/src/lib/core/types/visualization.ts
@@ -61,8 +61,7 @@ export const ComputationConfiguration = intersection([
     collectionVariable: VariableDescriptor,
   }),
   partial({
-    alphaDivMethod: string,
-    rankingMethod: string,
+    method: string,
   }),
 ]);
 

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -16,6 +16,7 @@ import { FilledButton } from '@veupathdb/coreui/dist/components/buttons';
 import AddIcon from '@material-ui/icons/Add';
 // alphadiv abundance
 import { ComputationConfiguration } from '../core/types/visualization';
+import { isEqual } from 'lodash';
 
 export interface Props {
   analysisState: AnalysisState;
@@ -199,20 +200,35 @@ export function ComputationRoute(props: Props) {
                   if (analysisState.analysis == null) return;
                   const computations =
                     analysisState.analysis.descriptor.computations;
-                  const computation = createComputation(
-                    app.name,
-                    name,
-                    configuration,
-                    computations
+                  // @ts-ignore
+                  const existingConfig = computations.find((c) =>
+                    isEqual(c.descriptor.configuration, configuration)
                   );
-                  const newAnalysisId = await analysisState.setComputations([
-                    computation,
-                    ...computations,
-                  ]);
-                  const urlBase = newAnalysisId
-                    ? url.replace('new', newAnalysisId)
-                    : url;
-                  history.push(`${urlBase}/${computation.computationId}`);
+                  // console.log(existingConfig);
+                  if (!existingConfig) {
+                    const computation = createComputation(
+                      app.name,
+                      name,
+                      configuration,
+                      computations
+                    );
+                    const newAnalysisId = await analysisState.setComputations([
+                      computation,
+                      ...computations,
+                    ]);
+                    const urlBase = newAnalysisId
+                      ? url.replace('new', newAnalysisId)
+                      : url;
+                    history.push(`${urlBase}/${computation.computationId}`);
+                  } else {
+                    console.log(computations);
+                    console.log(existingConfig);
+                    const newAnalysisId = existingConfig.computationId;
+                    const urlBase = newAnalysisId
+                      ? url.replace('new', newAnalysisId)
+                      : url;
+                    history.push(`${urlBase}/${existingConfig.computationId}`);
+                  }
                 };
 
                 return (

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -12,6 +12,8 @@ import { PromiseHookState, usePromise } from '../core/hooks/promise';
 import { GeoConfig } from '../core/types/geoConfig';
 import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
 import { WdkDependenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
+import { FilledButton } from '@veupathdb/coreui/dist/components/buttons';
+import AddIcon from '@material-ui/icons/Add';
 // alphadiv abundance
 import { ComputationConfiguration } from '../core/types/visualization';
 
@@ -86,6 +88,7 @@ export function ComputationRoute(props: Props) {
                       computationId={singleAppComputationId}
                       computationAppOverview={apps[0]}
                       visualizationTypes={plugin.visualizationTypes}
+                      singleAppMode={singleAppMode}
                     />
                   );
                 }}
@@ -97,15 +100,20 @@ export function ComputationRoute(props: Props) {
             <Switch>
               <Route exact path={`${url}`}>
                 <div>
-                  <div>
+                  <div style={{ width: 'max-content' }}>
                     <Link to={`${url}/new`}>
-                      {' '}
-                      <h2>+ New module</h2>
+                      <FilledButton
+                        text="New visualization"
+                        onPress={() => null}
+                        textTransform="none"
+                        themeRole="primary"
+                        icon={AddIcon}
+                        styleOverrides={{
+                          container: { marginTop: 15 },
+                        }}
+                      />
                     </Link>
                   </div>
-                  <br></br>
-                  <h2>Saved modules and vizs</h2>
-                  <hr></hr>
                   {analysisState.analysis?.descriptor.computations.map((c) => {
                     const app = apps.find(
                       (app) => app.name === c.descriptor.type
@@ -119,6 +127,7 @@ export function ComputationRoute(props: Props) {
                           computationAppOverview={app}
                           visualizationTypes={plugin.visualizationTypes}
                           baseUrl={`${url}/${c.computationId}`}
+                          singleAppMode={singleAppMode}
                         />
                       )
                     );
@@ -192,6 +201,7 @@ export function ComputationRoute(props: Props) {
                       computationAppOverview={app}
                       visualizationTypes={plugin.visualizationTypes}
                       baseUrl={`${url}/${computation?.computationId}`}
+                      singleAppMode={singleAppMode}
                     />
                   );
                 }}

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -54,6 +54,12 @@ export function ComputationRoute(props: Props) {
     }, [dataClient, wdkService, singleAppMode])
   );
 
+  /*  
+    Callback creates an object that will group apps by type, then returns an array 
+    for each type as [appType, computation]. This allows me to map over each appType
+    and its corresponding computations.
+    Lots of room to improve this approach.
+  */
   const appsGroupedByType = useMemo(() => {
     if (!analysisState.analysis?.descriptor.computations.length) return [];
     const groupingObject: any = {};
@@ -67,6 +73,7 @@ export function ComputationRoute(props: Props) {
     }
     return Object.entries(groupingObject);
   }, [analysisState]);
+  console.log(appsGroupedByType);
 
   return (
     <PromiseResult state={promiseState}>
@@ -130,6 +137,10 @@ export function ComputationRoute(props: Props) {
                     </Link>
                   </div>
                   {
+                    /* 
+                      Here we're mapping over the grouped apps such that the computation instances are
+                      also grouped together within the appType
+                    */
                     // @ts-ignore
                     appsGroupedByType.map((appType) => {
                       const app = apps.find((app) => app.name === appType[0]);
@@ -160,26 +171,6 @@ export function ComputationRoute(props: Props) {
                         )
                       );
                     })
-                    // analysisState.analysis?.descriptor.computations.map((c) => {
-                    // const app = apps.find(
-                    //   (app) => app.name === c.descriptor.type
-                    // );
-                    // const plugin = app && plugins[app.name];
-                    // // console.log({app})
-                    // // console.log({plugin})
-                    // return (
-                    //   plugin && (
-                    //     <ComputationInstance
-                    //       {...props}
-                    //       computationId={c.computationId}
-                    //       computationAppOverview={app}
-                    //       visualizationTypes={plugin.visualizationTypes}
-                    //       baseUrl={`${url}/${c.computationId}`}
-                    //       singleAppMode={singleAppMode}
-                    //     />
-                    //   )
-                    // );
-                    // })
                   }
                 </div>
               </Route>
@@ -200,11 +191,14 @@ export function ComputationRoute(props: Props) {
                   if (analysisState.analysis == null) return;
                   const computations =
                     analysisState.analysis.descriptor.computations;
+                  /* 
+                    Here we're checking for a matching configuration before instantiating a new one
+                    If there's a match, we'll store it as existingConfig and use that data in the else block
+                  */
                   // @ts-ignore
                   const existingConfig = computations.find((c) =>
                     isEqual(c.descriptor.configuration, configuration)
                   );
-                  // console.log(existingConfig);
                   if (!existingConfig) {
                     const computation = createComputation(
                       app.name,
@@ -221,8 +215,6 @@ export function ComputationRoute(props: Props) {
                       : url;
                     history.push(`${urlBase}/${computation.computationId}`);
                   } else {
-                    console.log(computations);
-                    console.log(existingConfig);
                     const newAnalysisId = existingConfig.computationId;
                     const urlBase = newAnalysisId
                       ? url.replace('new', newAnalysisId)


### PR DESCRIPTION
Addresses #1095

A couple things of note in this iteration:
1. I've left the "New Visualization" button for each instance to assist with testing/visualizing the changes.
2. I've used `// @ts-ignore` liberally for ease of prototyping. I will add typeguards as I near approval for this stage (and subsequent stages), unless otherwise desired.