### PR TITLE
let abundance boxplot appear on page load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.5.17",
+  "version": "3.5.18",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -261,23 +261,23 @@ function BoxplotViz(props: VisualizationProps) {
   );
 
   // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams
-  let outputEntity = useFindOutputEntity(
-    dataElementDependencyOrder,
-    vizConfig,
-    'xAxisVariable',
-    entities
-  );
-
-  // Abundance boxplots already know their entity, x, and y vars. Set the output entity here so that
-  // the boxplot can appear on load.
-  if (computation.descriptor.type === 'abundance') {
-    outputEntity = entities.find(
-      (e) =>
-        e.id ===
-        (computation.descriptor.configuration as ComputationConfiguration)
-          ?.collectionVariable.entityId
-    );
-  }
+  // Abundance boxplots already know their entity, x, and y vars. If we're in the abundance app, set
+  // the output entity here so that the boxplot can appear on load.
+  const outputEntity =
+    useFindOutputEntity(
+      dataElementDependencyOrder,
+      vizConfig,
+      'xAxisVariable',
+      entities
+    ) ??
+    (computation.descriptor.type === 'abundance'
+      ? entities.find(
+          (e) =>
+            e.id ===
+            (computation.descriptor.configuration as ComputationConfiguration)
+              ?.collectionVariable.entityId
+        )
+      : undefined);
 
   // add to support both alphadiv and abundance
   const data = usePromise(

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -27,7 +27,11 @@ import {
   FacetedData,
   BoxplotDataObject,
 } from '@veupathdb/components/lib/types/plots';
-import { Computation, CoverageStatistics } from '../../../types/visualization';
+import {
+  Computation,
+  ComputationConfiguration,
+  CoverageStatistics,
+} from '../../../types/visualization';
 import { BirdsEyeView } from '../../BirdsEyeView';
 import { PlotLayout } from '../../layouts/PlotLayout';
 import PluginError from '../PluginError';
@@ -257,12 +261,23 @@ function BoxplotViz(props: VisualizationProps) {
   );
 
   // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams
-  const outputEntity = useFindOutputEntity(
+  let outputEntity = useFindOutputEntity(
     dataElementDependencyOrder,
     vizConfig,
     'xAxisVariable',
     entities
   );
+
+  // Abundance boxplots already know their entity, x, and y vars. Set the output entity here so that
+  // the boxplot can appear on load.
+  if (computation.descriptor.type === 'abundance') {
+    outputEntity = entities.find(
+      (e) =>
+        e.id ===
+        (computation.descriptor.configuration as ComputationConfiguration)
+          ?.collectionVariable.entityId
+    );
+  }
 
   // add to support both alphadiv and abundance
   const data = usePromise(


### PR DESCRIPTION
Resolves #993 

An un-stratified ranked abundance viz is a very large part of what the mbio eda has to offer, and i'd love to show that part off at the demo on thursday. This PR implements a small hack to make it happen, with the intention that this will be able to be removed and all will look nicer after the refactoring :) 

Tested on the mbio backend. All three boxplots on the site work as they should. Note if i do ranked abundance boxplot, i get a plot, then add an overlay var, there's a brief time where it says "no plottable data". Looks like `outputSize` is getting set to 0, causing the error. Upon further investigation, i think when there is no stratification value set, we're getting that `data.value?.completeCasesAllVars = 0` because the boxplot response is not right. I will address this in plot.data.

Notes: Would definitely appreciate any advice on implementation! I felt squirmish about messing with `useFindOutputEntity` for this hack, but also didn't want to add a bunch of logic all over the place that would be hard to remove.