### PR TITLE
mbio - boxplot stats table for alphadiv and abundance

### DIFF
--- a/src/lib/core/api/DataClient/types.ts
+++ b/src/lib/core/api/DataClient/types.ts
@@ -521,32 +521,61 @@ const BoxplotResponseData = array(
   ])
 );
 
-export type BoxplotResponse = TypeOf<typeof BoxplotResponse>;
-export const BoxplotResponse = type({
-  boxplot: type({
-    data: BoxplotResponseData,
-    // typing computedVariableMetadata for computation apps such as alphadiv and abundance
-    config: intersection([
+// boxplot stats table
+export type BoxplotStatsTable = TypeOf<typeof BoxplotStatsTable>;
+export const BoxplotStatsTable = array(
+  partial({
+    xVariableDetails: type({
+      variableId: string,
+      entityId: string,
+      value: string,
+    }),
+    facetVariableDetails: array(
       type({
-        completeCasesAllVars: number,
-        completeCasesAxesVars: number,
-        xVariableDetails: type({
-          variableId: string,
-          entityId: string,
+        variableId: string,
+        entityId: string,
+        value: string,
+      })
+    ),
+    parameter: union([number, array(number), nullType]),
+    pvalue: union([number, array(number), nullType]),
+    statistic: union([number, array(number), nullType]),
+    method: union([string, array(string), nullType]),
+    statsError: string,
+  })
+);
+
+export type BoxplotResponse = TypeOf<typeof BoxplotResponse>;
+export const BoxplotResponse = intersection([
+  type({
+    boxplot: type({
+      data: BoxplotResponseData,
+      // typing computedVariableMetadata for computation apps such as alphadiv and abundance
+      config: intersection([
+        type({
+          completeCasesAllVars: number,
+          completeCasesAxesVars: number,
+          xVariableDetails: type({
+            variableId: string,
+            entityId: string,
+          }),
+          yVariableDetails: type({
+            variableId: string,
+            entityId: string,
+          }),
         }),
-        yVariableDetails: type({
-          variableId: string,
-          entityId: string,
+        partial({
+          computedVariableMetadata: ComputedVariableMetadata,
         }),
-      }),
-      partial({
-        computedVariableMetadata: ComputedVariableMetadata,
-      }),
-    ]),
+      ]),
+    }),
+    sampleSizeTable: sampleSizeTableArray,
+    completeCasesTable: completeCasesTableArray,
   }),
-  sampleSizeTable: sampleSizeTableArray,
-  completeCasesTable: completeCasesTableArray,
-});
+  partial({
+    statsTable: BoxplotStatsTable,
+  }),
+]);
 
 export interface MapMarkersRequestParams {
   studyId: string;

--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -298,3 +298,21 @@ $data-table-inner-border: 1px solid #888;
     border-bottom: $data-table-inner-border;
   }
 }
+
+// boxplot stat table for alphadiv and abundance
+.BoxStatsTable {
+  @include data-table;
+  width: 750px;
+  min-width: 750px;
+
+  .percentage {
+    color: #333;
+    font-size: 0.85em;
+  }
+  th {
+    vertical-align: baseline;
+  }
+  th:first-of-type {
+    border-bottom: $data-table-inner-border;
+  }
+}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -71,6 +71,10 @@ import { useDefaultDependentAxisRange } from '../../../hooks/computeDefaultDepen
 import { findEntityAndVariable as findCollectionVariableEntityAndVariable } from '../../../utils/study-metadata';
 // type of computedVariableMetadata for computation apps such as alphadiv and abundance
 import { ComputedVariableMetadata } from '../../../api/DataClient/types';
+// boxplot stats table
+import { TabbedDisplay } from '@veupathdb/coreui';
+import { BoxplotStatsTable } from '../../../api/DataClient/types';
+import { BoxStatsTable } from '../../BoxStatsTable';
 
 type BoxplotData = { series: BoxplotSeries };
 // type of computedVariableMetadata for computation apps such as alphadiv and abundance
@@ -78,10 +82,17 @@ type BoxplotComputedVariableMetadata = {
   computedVariableMetadata?: ComputedVariableMetadata;
 };
 
+// type of statsTable for computation apps such as alphadiv and abundance
+type BoxplotStatsTableType = {
+  statsTable?: BoxplotStatsTable;
+};
+
 // add type of computedVariableMetadata for computation apps such as alphadiv and abundance
 export type BoxplotDataWithCoverage = (BoxplotData | FacetedData<BoxplotData>) &
   CoverageStatistics &
-  BoxplotComputedVariableMetadata;
+  BoxplotComputedVariableMetadata &
+  // type of statsTable for computation apps such as alphadiv and abundance
+  BoxplotStatsTableType;
 
 const plotContainerStyles = {
   height: 450,
@@ -490,41 +501,113 @@ function BoxplotViz(props: VisualizationProps) {
         : variableDisplayWithUnit(yAxisVariable) ?? 'Y-axis'
       : variableDisplayWithUnit(yAxisVariable) ?? 'Y-axis';
 
-  const plotNode = (
-    <BoxplotWithControls
-      // data.value
-      data={data.value}
-      updateThumbnail={updateThumbnail}
-      containerStyles={!isFaceted(data.value) ? plotContainerStyles : undefined}
-      spacingOptions={!isFaceted(data.value) ? plotSpacingOptions : undefined}
-      orientation={'vertical'}
-      displayLegend={false}
-      // alphadiv abundance: set a independentAxisLabel condition for abundance
-      independentAxisLabel={independentAxisLabel}
-      dependentAxisLabel={dependentAxisLabel}
-      // show/hide independent/dependent axis tick label
-      showIndependentAxisTickLabel={true}
-      showDependentAxisTickLabel={true}
-      showMean={true}
-      interactive={!isFaceted(data.value) ? true : false}
-      showSpinner={data.pending || filteredCounts.pending}
-      showRawData={true}
-      legendTitle={variableDisplayWithUnit(overlayVariable)}
-      // for custom legend passing checked state in the  checkbox to PlotlyPlot
-      legendItems={legendItems}
-      checkedLegendItems={checkedLegendItems}
-      onCheckedLegendItemsChange={onCheckedLegendItemsChange}
-      // axis range control
-      vizConfig={vizConfig}
-      updateVizConfig={updateVizConfig}
-      // add dependent axis range for better displaying tick labels in log-scale
-      defaultDependentAxisRange={defaultDependentAxisRange}
-      // no need to pass dependentAxisRange
-      // pass useState of truncation warnings
-      truncatedDependentAxisWarning={truncatedDependentAxisWarning}
-      setTruncatedDependentAxisWarning={setTruncatedDependentAxisWarning}
-    />
-  );
+  const plotNode =
+    computation.descriptor.configuration == null ||
+    (computation.descriptor.configuration != null &&
+      computation.descriptor.type !== 'alphadiv' &&
+      computation.descriptor.type !== 'abundance') ? (
+      <BoxplotWithControls
+        // data.value
+        data={data.value}
+        updateThumbnail={updateThumbnail}
+        containerStyles={
+          !isFaceted(data.value) ? plotContainerStyles : undefined
+        }
+        spacingOptions={!isFaceted(data.value) ? plotSpacingOptions : undefined}
+        orientation={'vertical'}
+        displayLegend={false}
+        // alphadiv abundance: set a independentAxisLabel condition for abundance
+        independentAxisLabel={independentAxisLabel}
+        dependentAxisLabel={dependentAxisLabel}
+        // show/hide independent/dependent axis tick label
+        showIndependentAxisTickLabel={true}
+        showDependentAxisTickLabel={true}
+        showMean={true}
+        interactive={!isFaceted(data.value) ? true : false}
+        showSpinner={data.pending || filteredCounts.pending}
+        showRawData={true}
+        legendTitle={variableDisplayWithUnit(overlayVariable)}
+        // for custom legend passing checked state in the  checkbox to PlotlyPlot
+        legendItems={legendItems}
+        checkedLegendItems={checkedLegendItems}
+        onCheckedLegendItemsChange={onCheckedLegendItemsChange}
+        // axis range control
+        vizConfig={vizConfig}
+        updateVizConfig={updateVizConfig}
+        // add dependent axis range for better displaying tick labels in log-scale
+        defaultDependentAxisRange={defaultDependentAxisRange}
+        // no need to pass dependentAxisRange
+        // pass useState of truncation warnings
+        truncatedDependentAxisWarning={truncatedDependentAxisWarning}
+        setTruncatedDependentAxisWarning={setTruncatedDependentAxisWarning}
+      />
+    ) : (
+      <TabbedDisplay
+        themeRole="primary"
+        tabs={[
+          {
+            displayName: 'Mosaic',
+            content: (
+              <div style={{ marginTop: 15 }}>
+                <BoxplotWithControls
+                  // data.value
+                  data={data.value}
+                  updateThumbnail={updateThumbnail}
+                  containerStyles={
+                    !isFaceted(data.value) ? plotContainerStyles : undefined
+                  }
+                  spacingOptions={
+                    !isFaceted(data.value) ? plotSpacingOptions : undefined
+                  }
+                  orientation={'vertical'}
+                  displayLegend={false}
+                  // alphadiv abundance: set a independentAxisLabel condition for abundance
+                  independentAxisLabel={independentAxisLabel}
+                  dependentAxisLabel={dependentAxisLabel}
+                  // show/hide independent/dependent axis tick label
+                  showIndependentAxisTickLabel={true}
+                  showDependentAxisTickLabel={true}
+                  showMean={true}
+                  interactive={!isFaceted(data.value) ? true : false}
+                  showSpinner={data.pending || filteredCounts.pending}
+                  showRawData={true}
+                  legendTitle={variableDisplayWithUnit(overlayVariable)}
+                  // for custom legend passing checked state in the  checkbox to PlotlyPlot
+                  legendItems={legendItems}
+                  checkedLegendItems={checkedLegendItems}
+                  onCheckedLegendItemsChange={onCheckedLegendItemsChange}
+                  // axis range control
+                  vizConfig={vizConfig}
+                  updateVizConfig={updateVizConfig}
+                  // add dependent axis range for better displaying tick labels in log-scale
+                  defaultDependentAxisRange={defaultDependentAxisRange}
+                  // no need to pass dependentAxisRange
+                  // pass useState of truncation warnings
+                  truncatedDependentAxisWarning={truncatedDependentAxisWarning}
+                  setTruncatedDependentAxisWarning={
+                    setTruncatedDependentAxisWarning
+                  }
+                />
+              </div>
+            ),
+          },
+          {
+            displayName: 'Statistics',
+            content: (
+              <>
+                <BoxStatsTable
+                  data={data}
+                  // descriptor={computation.descriptor}
+                  xAxisVariable={xAxisVariable}
+                  overlayVariable={overlayVariable}
+                  facetVariable={facetVariable}
+                />
+              </>
+            ),
+          },
+        ]}
+      />
+    );
 
   const legendNode = legendItems != null && !data.pending && data != null && (
     <PlotLegend
@@ -954,6 +1037,8 @@ export function boxplotResponseToData(
     completeCasesAxesVars: response.boxplot.config.completeCasesAxesVars,
     // config.computedVariableMetadata should also be returned
     computedVariableMetadata: response.boxplot.config.computedVariableMetadata,
+    // add statsTable in the response for computation apps such as alphadiv and abundance
+    statsTable: response.statsTable,
   } as BoxplotDataWithCoverage;
 }
 


### PR DESCRIPTION
This addresses https://github.com/VEuPathDB/web-eda/issues/610. Several tests need to be made for finding out what I might have missed.

Tab style like Mosaic is implemented. Screenshots will be shown in the following comments.  
Currently, N/A is assigned to be shown if table values are null or empty array.