### PR TITLE
Change style of computation's configuration display header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.5.19",
+  "version": "3.5.20",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -1,10 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useToggleStarredVariable } from '../../hooks/starredVariables';
-import {
-  Computation,
-  ComputationAppOverview,
-  Visualization,
-} from '../../types/visualization';
+import { Computation, Visualization } from '../../types/visualization';
 import { VisualizationsContainer } from '../visualizations/VisualizationsContainer';
 import { VisualizationType } from '../visualizations/VisualizationTypes';
 import { ComputationProps } from './Types';
@@ -22,7 +18,6 @@ export function ComputationInstance(props: Props) {
     computationAppOverview,
     computationId,
     analysisState,
-    // analysisState: { analysis, setComputations },
     totalCounts,
     filteredCounts,
     geoConfigs,
@@ -116,13 +111,25 @@ interface AppTitleProps {
 // further styling is applied?
 function AppTitle(props: AppTitleProps) {
   const { computation, condensed } = props;
+  const splitDisplayName = computation.displayName
+    ? computation.displayName.split('&;&')
+    : '';
 
   return condensed ? (
-    <div style={{ marginTop: 10 }}>
+    <div style={{ lineHeight: 1.5 }}>
       {computation.descriptor.configuration ? (
-        <h4 style={{ marginLeft: 20 }}>
-          <em>{computation.displayName}</em>
-        </h4>
+        <>
+          <h4 style={{ padding: '15px 0 0 0', marginLeft: 20 }}>
+            Data: <span style={{ fontWeight: 300 }}>{splitDisplayName[0]}</span>
+          </h4>
+          <h4 style={{ padding: 0, marginLeft: 20 }}>
+            Method:{' '}
+            <span style={{ fontWeight: 300 }}>
+              {splitDisplayName[1][0].toUpperCase() +
+                splitDisplayName[1].slice(1)}
+            </span>
+          </h4>
+        </>
       ) : null}
     </div>
   ) : null;

--- a/src/lib/core/components/computations/StartPage.tsx
+++ b/src/lib/core/components/computations/StartPage.tsx
@@ -97,6 +97,9 @@ export function StartPage(props: Props) {
                     >
                       <Tooltip title={<>{vizType.description}</>}>
                         <button
+                          style={{
+                            cursor: disabled ? 'not-allowed' : 'cursor',
+                          }}
                           disabled={disabled}
                           onClick={async () => {
                             if (analysisState.analysis == null) return;

--- a/src/lib/core/components/computations/getAppsDefaultConfigs.tsx
+++ b/src/lib/core/components/computations/getAppsDefaultConfigs.tsx
@@ -26,7 +26,7 @@ export const useDefaultPluginConfiguration = (
     if (!defaultObject) return null;
     return {
       name: app.name,
-      displayName: `Data: ${collections[0].entityDisplayName}: ${collections[0].displayName}; Method: ${defaultObject.method}`,
+      displayName: `${collections[0].entityDisplayName} > ${collections[0].displayName}&;&${defaultObject.method}`,
       configuration: {
         name: defaultObject.name,
         collectionVariable: {

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -132,7 +132,7 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
       const newComputation = createComputation(
         computation.descriptor.type,
         // @ts-ignore
-        `Data: ${variableObject?.entityDisplayName}: ${variableObject?.displayName}; Method: ${newConfigObject.rankingMethod}`,
+        `${variableObject?.entityDisplayName} > ${variableObject?.displayName}&;&${newConfigObject.rankingMethod}`,
         // @ts-ignore
         newConfigObject,
         computations,

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -219,7 +219,8 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
                   entityId: collectionVar.entityId,
                 })}
               >
-                {collectionVar.entityDisplayName}: {collectionVar.displayName}
+                {collectionVar.entityDisplayName} {' > '}{' '}
+                {collectionVar.displayName}
               </option>
             );
           })}

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -135,7 +135,7 @@ export function AlphaDivConfiguration(props: ComputationConfigProps) {
       const newComputation = createComputation(
         computation.descriptor.type,
         // @ts-ignore
-        `Data: ${variableObject?.entityDisplayName}: ${variableObject?.displayName}; Method: ${newConfigObject.alphaDivMethod}`,
+        `${variableObject?.entityDisplayName} > ${variableObject?.displayName}&;&${newConfigObject.alphaDivMethod}`,
         // @ts-ignore
         newConfigObject,
         computations,

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -222,7 +222,8 @@ export function AlphaDivConfiguration(props: ComputationConfigProps) {
                   entityId: collectionVar.entityId,
                 })}
               >
-                {collectionVar.entityDisplayName}: {collectionVar.displayName}
+                {collectionVar.entityDisplayName} {' > '}{' '}
+                {collectionVar.displayName}
               </option>
             );
           })}

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -130,7 +130,7 @@ export function ComputationRoute(props: Props) {
                         themeRole="primary"
                         icon={AddIcon}
                         styleOverrides={{
-                          container: { marginTop: 15 },
+                          container: { margin: '15px 0' },
                         }}
                       />
                     </Link>
@@ -143,7 +143,9 @@ export function ComputationRoute(props: Props) {
                     // @ts-ignore
                     appsGroupedByType.map((appType) => {
                       const app = apps.find((app) => app.name === appType[0]);
-                      const appName = <h4>{app?.displayName}</h4>;
+                      const appName = (
+                        <h4 style={{ paddingBottom: 0 }}>{app?.displayName}</h4>
+                      );
                       const plugin = app && plugins[app.name];
                       return (
                         plugin && (


### PR DESCRIPTION
Addresses #1178 

My implementation splits the configuration's display string at an arbitrarily chosen/inserted `&;&` string, effectively creating "data" and "method" substrings. I opted for this simple approach because my [current refactoring of the implementation details](https://github.com/VEuPathDB/web-eda/pull/1180) may affect this data.

![image](https://user-images.githubusercontent.com/69446567/172450090-89a62c9e-87a2-4028-bf91-4c69763a1045.png)
