### PR TITLE
hide no data control for mbio alphaDiv and abundance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -693,7 +693,12 @@ function BarplotViz(props: VisualizationProps) {
               data.value?.completeCasesAxesVars
           }
           toggleStarredVariable={toggleStarredVariable}
-          onShowMissingnessChange={onShowMissingnessChange}
+          // this can be used to show and hide no data control
+          onShowMissingnessChange={
+            computation.descriptor.type === 'pass'
+              ? onShowMissingnessChange
+              : undefined
+          }
           showMissingness={vizConfig.showMissingness}
           outputEntity={entity}
         />

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -658,7 +658,12 @@ function BoxplotViz(props: VisualizationProps) {
               data.value?.completeCasesAxesVars
           }
           showMissingness={vizConfig.showMissingness}
-          onShowMissingnessChange={onShowMissingnessChange}
+          // this can be used to show and hide no data control
+          onShowMissingnessChange={
+            computation.descriptor.configuration != null
+              ? undefined
+              : onShowMissingnessChange
+          }
           outputEntity={outputEntity}
         />
       </div>

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -605,6 +605,9 @@ function BoxplotViz(props: VisualizationProps) {
     </>
   );
 
+  //DKDK
+  console.log('computation =', computation);
+
   // for handling alphadiv abundance
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -660,9 +663,9 @@ function BoxplotViz(props: VisualizationProps) {
           showMissingness={vizConfig.showMissingness}
           // this can be used to show and hide no data control
           onShowMissingnessChange={
-            computation.descriptor.configuration != null
-              ? undefined
-              : onShowMissingnessChange
+            computation.descriptor.type === 'pass'
+              ? onShowMissingnessChange
+              : undefined
           }
           outputEntity={outputEntity}
         />

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -605,9 +605,6 @@ function BoxplotViz(props: VisualizationProps) {
     </>
   );
 
-  //DKDK
-  console.log('computation =', computation);
-
   // for handling alphadiv abundance
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -572,7 +572,12 @@ function HistogramViz(props: VisualizationProps) {
               data.value?.completeCasesAxesVars
           }
           showMissingness={vizConfig.showMissingness}
-          onShowMissingnessChange={onShowMissingnessChange}
+          // this can be used to show and hide no data control
+          onShowMissingnessChange={
+            computation.descriptor.type === 'pass'
+              ? onShowMissingnessChange
+              : undefined
+          }
           outputEntity={outputEntity}
         />
       </div>

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -990,7 +990,12 @@ function LineplotViz(props: VisualizationProps) {
               data.value?.completeCasesAxesVars
           }
           showMissingness={vizConfig.showMissingness}
-          onShowMissingnessChange={onShowMissingnessChange}
+          // this can be used to show and hide no data control
+          onShowMissingnessChange={
+            computation.descriptor.type === 'pass'
+              ? onShowMissingnessChange
+              : undefined
+          }
           outputEntity={outputEntity}
         />
       </div>

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -526,7 +526,12 @@ function MosaicViz(props: Props) {
               data.value?.completeCasesAxesVars
           }
           showMissingness={vizConfig.showMissingness}
-          onShowMissingnessChange={onShowMissingnessChange}
+          // this can be used to show and hide no data control
+          onShowMissingnessChange={
+            computation.descriptor.type === 'pass'
+              ? onShowMissingnessChange
+              : undefined
+          }
           outputEntity={outputEntity}
         />
       </div>

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1054,9 +1054,9 @@ function ScatterplotViz(props: VisualizationProps) {
           showMissingness={vizConfig.showMissingness}
           // this can be used to show and hide no data control
           onShowMissingnessChange={
-            computation.descriptor.configuration != null
-              ? undefined
-              : onShowMissingnessChange
+            computation.descriptor.type === 'pass'
+              ? onShowMissingnessChange
+              : undefined
           }
           outputEntity={outputEntity}
         />

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1052,7 +1052,12 @@ function ScatterplotViz(props: VisualizationProps) {
               data.value?.completeCasesAxesVars
           }
           showMissingness={vizConfig.showMissingness}
-          onShowMissingnessChange={onShowMissingnessChange}
+          // this can be used to show and hide no data control
+          onShowMissingnessChange={
+            computation.descriptor.configuration != null
+              ? undefined
+              : onShowMissingnessChange
+          }
           outputEntity={outputEntity}
         />
       </div>


### PR DESCRIPTION
This addresses https://github.com/VEuPathDB/web-eda/issues/1089. Initially I tried to make a new prop to conditionally control the option, however, I realized that it also depended on onShowMissingnessChange function. Thus, I have made a condition to show and hide it: only for boxplot and scatterplot Vizs.

It is hidden for mbio alphaDiv and abundance, while it shows for other apps, e.g., pass app, mbio distributions, mbio X-Y relationships, etc.