### PR TITLE
Tweak verbiage and spacing in download tab's data access msg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.5.21",
+  "version": "3.5.22",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/DownloadTab/index.tsx
+++ b/src/lib/workspace/DownloadTab/index.tsx
@@ -76,7 +76,7 @@ export default function DownloadTab({
       permission.permissions.perDataset[studyRecord.id[0].value]
         ?.actionAuthorization['resultsAll'];
     const requestElement = (
-      <button className="link" onClick={handleClick}>
+      <button className="link" style={{ padding: 0 }} onClick={handleClick}>
         Click here to request access.
       </button>
     );
@@ -216,9 +216,9 @@ function getDataAccessDeclaration(
   const LOGIN_REQUEST_STUB =
     'You must register or log in and request access to download data;';
   const CONTROLLED_ACCESS_STUB =
-    ' data can be downloaded immediately following request submission.';
+    ' data can be downloaded immediately following request submission. ';
   const PROTECTED_ACCESS_STUB =
-    ' data can be downloaded after the study team reviews and grants you access.';
+    ' data can be downloaded after the study team reviews your request and grants you access. ';
   const ACCESS_GRANTED_STUB =
     'You have been granted access to download the data.';
   // const ACCESS_PENDING_STUB = 'Your data access request is pending.';


### PR DESCRIPTION
This is in response to [this comment](https://github.com/VEuPathDB/web-eda/issues/1143#issuecomment-1149124812) in issue #1143. 

![image](https://user-images.githubusercontent.com/69446567/172487593-9ce3fdb1-3ccb-49c8-a422-cd8bb6d9ce8f.png)