### PR TITLE
add optional subtitle to OutputEntityTitle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.5.22",
+  "version": "3.5.23",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/OutputEntityTitle.tsx
+++ b/src/lib/core/components/visualizations/OutputEntityTitle.tsx
@@ -1,4 +1,5 @@
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+import { gray } from '@veupathdb/coreui/dist/definitions/colors';
 
 import { StudyEntity } from '../../types/study';
 import { makeEntityDisplayName } from '../../utils/study-metadata';
@@ -6,11 +7,13 @@ import { makeEntityDisplayName } from '../../utils/study-metadata';
 interface Props {
   entity?: StudyEntity;
   outputSize?: number;
+  subtitle?: string;
 }
 
 const cx = makeClassNameHelper('OutputEntityTitle');
+const cxSubtitle = makeClassNameHelper('OutputEntitySubtitle');
 
-export function OutputEntityTitle({ entity, outputSize }: Props) {
+export function OutputEntityTitle({ entity, outputSize, subtitle }: Props) {
   return (
     <p className={cx()}>
       {outputSize != null && <>{outputSize.toLocaleString()} </>}
@@ -22,6 +25,12 @@ export function OutputEntityTitle({ entity, outputSize }: Props) {
             )
           : 'No entity selected'}
       </span>
+      {subtitle && (
+        <div className={cxSubtitle()} style={{ color: gray[700] }}>
+          <br />
+          {subtitle}
+        </div>
+      )}
     </p>
   );
 }

--- a/src/lib/core/components/visualizations/Visualizations.scss
+++ b/src/lib/core/components/visualizations/Visualizations.scss
@@ -282,6 +282,12 @@ $data-table-inner-border: 1px solid #888;
   }
 }
 
+.OutputEntitySubtitle {
+  font-style: italic;
+  font-size: 0.9em;
+  margin-top: -10px;
+}
+
 // R-square table for Scatter plot's Best fit option
 .ScatterRsquareTable {
   @include data-table;

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -605,6 +605,12 @@ function BoxplotViz(props: VisualizationProps) {
     </>
   );
 
+  // plot subtitle
+  const plotSubtitle =
+    computation.descriptor.type === 'abundance'
+      ? `Ranked abundance: Variables with median = 0 removed. Showing up to the top ten variables.`
+      : undefined;
+
   // for handling alphadiv abundance
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -664,7 +670,11 @@ function BoxplotViz(props: VisualizationProps) {
       </div>
 
       <PluginError error={data.error} outputSize={outputSize} />
-      <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
+      <OutputEntityTitle
+        entity={outputEntity}
+        outputSize={outputSize}
+        subtitle={plotSubtitle}
+      />
       <PlotLayout
         isFaceted={isFaceted(data.value)}
         legendNode={legendNode}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -607,8 +607,11 @@ function BoxplotViz(props: VisualizationProps) {
 
   // plot subtitle
   const plotSubtitle =
-    computation.descriptor.type === 'abundance'
-      ? `Ranked abundance: Variables with median = 0 removed. Showing up to the top ten variables.`
+    computation.descriptor.type === 'abundance' && outputSize != null
+      ? `Ranked abundance: Variables with ${
+          (computation.descriptor.configuration as ComputationConfiguration)
+            ?.rankingMethod
+        } = 0 removed. Showing up to the top ten variables.`
       : undefined;
 
   // for handling alphadiv abundance

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -999,6 +999,12 @@ function ScatterplotViz(props: VisualizationProps) {
     </>
   );
 
+  // plot subtitle
+  const plotSubtitle =
+    computation.descriptor.type === 'abundance'
+      ? `Ranked abundance: Variables with median = 0 removed. Showing up to the top eight variables.`
+      : undefined;
+
   // alphadiv abundance: y-axis and overlayVariable
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -1093,7 +1099,11 @@ function ScatterplotViz(props: VisualizationProps) {
           />
         )}
 
-      <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
+      <OutputEntityTitle
+        entity={outputEntity}
+        outputSize={outputSize}
+        subtitle={plotSubtitle}
+      />
       <PlotLayout
         isFaceted={isFaceted(data.value?.dataSetProcess)}
         legendNode={legendNode}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -58,7 +58,11 @@ import {
   FacetedData,
 } from '@veupathdb/components/lib/types/plots';
 // import Computation ts
-import { CoverageStatistics, Computation } from '../../../types/visualization';
+import {
+  CoverageStatistics,
+  Computation,
+  ComputationConfiguration,
+} from '../../../types/visualization';
 // import axis label unit util
 import { variableDisplayWithUnit } from '../../../utils/variable-display';
 import { NumberVariable, Variable, StudyEntity } from '../../../types/study';
@@ -1001,8 +1005,11 @@ function ScatterplotViz(props: VisualizationProps) {
 
   // plot subtitle
   const plotSubtitle =
-    computation.descriptor.type === 'abundance'
-      ? `Ranked abundance: Variables with median = 0 removed. Showing up to the top eight variables.`
+    computation.descriptor.type === 'abundance' && outputSize != null
+      ? `Ranked abundance: Variables with ${
+          (computation.descriptor.configuration as ComputationConfiguration)
+            ?.rankingMethod
+        } = 0 removed. Showing up to the top eight variables.`
       : undefined;
 
   // alphadiv abundance: y-axis and overlayVariable


### PR DESCRIPTION
Resolves #1173 

In ranked abundance and future beta diversity, the app contains (or returns) information about the computation that is helpful for interpreting the plot. In the ranked abundance case, the computation removes all vars with rankingMethod = 0. That means sometimes a user sees a boxplot with 5 boxes, sometimes with 10, and sometimes with 1. 

For the ranked abundance app, the added subtitle won't change based on how the computation went. Though this differs from the live site, it's much less convoluted in terms of logic around what subtitle to display. [Here](https://github.com/VEuPathDB/MicrobiomeWebsite/blob/0d4e0b97bdc07677d338673a27dbe2382314861d/View/lib/R/shiny/apps/abundance_app/server.R#L210-L234) is logic currently used on the live site abundance app.

For the beta diversity app (future), the computation itself will return information worth displaying to the user. For example, it might say if the computation converged or how good of a job it did at finding the right projection. That info will be returned with the response, and when the time comes just assigned to the subtitle.