### PR TITLE
Fix logic in delete visualization buttons for when singleAppMode is falsy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -10,7 +10,7 @@ export interface Props extends ComputationProps {
   computationId: string;
   visualizationTypes: Record<string, VisualizationType>;
   baseUrl?: string; // right now only defined when *not* using single app mode
-  singleAppMode: string | undefined;
+  isSingleAppMode: boolean;
 }
 
 export function ComputationInstance(props: Props) {
@@ -23,7 +23,7 @@ export function ComputationInstance(props: Props) {
     geoConfigs,
     visualizationTypes,
     baseUrl,
-    singleAppMode,
+    isSingleAppMode,
   } = props;
 
   const { analysis, setComputations } = analysisState;
@@ -93,7 +93,7 @@ export function ComputationInstance(props: Props) {
         totalCounts={totalCounts}
         filteredCounts={filteredCounts}
         baseUrl={baseUrl}
-        showHeading={!singleAppMode}
+        isSingleAppMode={isSingleAppMode}
       />
     </div>
   );

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -143,7 +143,7 @@ function ConfiguredVisualizations(props: Props) {
 
   return (
     <>
-      {!isSingleAppMode ? (
+      {isSingleAppMode ? (
         <Link
           to={{
             pathname: `${baseUrl || url}/new`,
@@ -187,19 +187,18 @@ function ConfiguredVisualizations(props: Props) {
                                 (v) => v.visualizationId !== viz.visualizationId
                               )
                             );
-                            const computations =
-                              analysisState.analysis?.descriptor.computations;
+                            /* 
+                              Here we're deleting the computation in the event we delete
+                              the computation's last remaining visualization.
+                            */
                             if (
-                              computation.visualizations.length === 1 &&
-                              computations
+                              !isSingleAppMode &&
+                              computation.visualizations.length === 1
                             ) {
-                              analysisState.setComputations([
-                                ...computations.filter(
-                                  (c) =>
-                                    c.computationId !==
-                                    computation.computationId
-                                ),
-                              ]);
+                              deleteComputationWithNoVisualizations(
+                                analysisState,
+                                computation.computationId
+                              );
                             }
                           }}
                         >
@@ -457,19 +456,23 @@ function FullScreenVisualization(props: Props & { id: string }) {
                 updateVisualizations((visualizations) =>
                   visualizations.filter((v) => v.visualizationId !== id)
                 );
-                const computations =
-                  analysisState.analysis?.descriptor.computations;
-                if (computation.visualizations.length === 1 && computations) {
-                  analysisState.setComputations([
-                    ...computations.filter(
-                      (c) => c.computationId !== computationId
-                    ),
-                  ]);
+                /* 
+                  Here we're deleting the computation in the event we delete
+                  the computation's last remaining visualization.
+                */
+                if (
+                  !isSingleAppMode &&
+                  computation.visualizations.length === 1
+                ) {
+                  deleteComputationWithNoVisualizations(
+                    analysisState,
+                    computationId
+                  );
                 }
                 history.replace(
                   Path.resolve(
                     history.location.pathname,
-                    isSingleAppMode ? '../..' : '..'
+                    isSingleAppMode ? '..' : '../..'
                   )
                 );
               }}
@@ -598,4 +601,16 @@ function ConfiguredVisualizationGrayOut({
   ) : (
     <></>
   );
+}
+
+function deleteComputationWithNoVisualizations(
+  analysisState: AnalysisState,
+  computationId: string
+) {
+  const computations = analysisState.analysis?.descriptor.computations;
+  if (computations) {
+    analysisState.setComputations([
+      ...computations.filter((c) => c.computationId !== computationId),
+    ]);
+  }
 }

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -59,7 +59,7 @@ interface Props {
   filteredCounts: PromiseHookState<EntityCounts>;
   geoConfigs: GeoConfig[];
   baseUrl?: string;
-  showHeading: boolean;
+  isSingleAppMode: boolean;
 }
 
 /**
@@ -132,17 +132,18 @@ export function VisualizationsContainer(props: Props) {
 
 function ConfiguredVisualizations(props: Props) {
   const {
+    analysisState,
     computation,
     updateVisualizations,
     visualizationsOverview,
     baseUrl,
-    showHeading,
+    isSingleAppMode,
   } = props;
   const { url } = useRouteMatch();
 
   return (
     <>
-      {!showHeading ? (
+      {!isSingleAppMode ? (
         <Link
           to={{
             pathname: `${baseUrl || url}/new`,
@@ -180,13 +181,27 @@ function ConfiguredVisualizations(props: Props) {
                         <button
                           type="button"
                           className="link"
-                          onClick={() =>
+                          onClick={() => {
                             updateVisualizations((visualizations) =>
                               visualizations.filter(
                                 (v) => v.visualizationId !== viz.visualizationId
                               )
-                            )
-                          }
+                            );
+                            const computations =
+                              analysisState.analysis?.descriptor.computations;
+                            if (
+                              computation.visualizations.length === 1 &&
+                              computations
+                            ) {
+                              analysisState.setComputations([
+                                ...computations.filter(
+                                  (c) =>
+                                    c.computationId !==
+                                    computation.computationId
+                                ),
+                              ]);
+                            }
+                          }}
                         >
                           <i className="fa fa-trash"></i>
                         </button>
@@ -360,6 +375,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
     filteredCounts,
     geoConfigs,
     baseUrl,
+    isSingleAppMode,
   } = props;
   const history = useHistory();
   const viz = computation.visualizations.find((v) => v.visualizationId === id);
@@ -441,7 +457,21 @@ function FullScreenVisualization(props: Props & { id: string }) {
                 updateVisualizations((visualizations) =>
                   visualizations.filter((v) => v.visualizationId !== id)
                 );
-                history.replace(Path.resolve(history.location.pathname, '..'));
+                const computations =
+                  analysisState.analysis?.descriptor.computations;
+                if (computation.visualizations.length === 1 && computations) {
+                  analysisState.setComputations([
+                    ...computations.filter(
+                      (c) => c.computationId !== computationId
+                    ),
+                  ]);
+                }
+                history.replace(
+                  Path.resolve(
+                    history.location.pathname,
+                    isSingleAppMode ? '../..' : '..'
+                  )
+                );
               }}
             >
               <i className="fa fa-trash"></i>

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -109,7 +109,7 @@ export function ComputationRoute(props: Props) {
                       computationId={singleAppComputationId}
                       computationAppOverview={apps[0]}
                       visualizationTypes={plugin.visualizationTypes}
-                      singleAppMode={singleAppMode}
+                      isSingleAppMode={!singleAppMode}
                     />
                   );
                 }}
@@ -163,7 +163,7 @@ export function ComputationRoute(props: Props) {
                                       plugin.visualizationTypes
                                     }
                                     baseUrl={`${url}/${c.computationId}`}
-                                    singleAppMode={singleAppMode}
+                                    isSingleAppMode={!singleAppMode}
                                   />
                                 );
                               })
@@ -261,7 +261,7 @@ export function ComputationRoute(props: Props) {
                       computationAppOverview={app}
                       visualizationTypes={plugin.visualizationTypes}
                       baseUrl={`${url}/${computation?.computationId}`}
-                      singleAppMode={singleAppMode}
+                      isSingleAppMode={!singleAppMode}
                     />
                   );
                 }}

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -109,7 +109,7 @@ export function ComputationRoute(props: Props) {
                       computationId={singleAppComputationId}
                       computationAppOverview={apps[0]}
                       visualizationTypes={plugin.visualizationTypes}
-                      isSingleAppMode={!singleAppMode}
+                      isSingleAppMode={!!singleAppMode}
                     />
                   );
                 }}
@@ -163,7 +163,7 @@ export function ComputationRoute(props: Props) {
                                       plugin.visualizationTypes
                                     }
                                     baseUrl={`${url}/${c.computationId}`}
-                                    isSingleAppMode={!singleAppMode}
+                                    isSingleAppMode={!!singleAppMode}
                                   />
                                 );
                               })
@@ -261,7 +261,7 @@ export function ComputationRoute(props: Props) {
                       computationAppOverview={app}
                       visualizationTypes={plugin.visualizationTypes}
                       baseUrl={`${url}/${computation?.computationId}`}
-                      isSingleAppMode={!singleAppMode}
+                      isSingleAppMode={!!singleAppMode}
                     />
                   );
                 }}


### PR DESCRIPTION
Addresses #1187 and #1188 

Specifically:
- Added some logic that will delete a computation if the last remaining visualization is deleted
- Improved readability by coercing `singleAppMode` into a boolean called `isSingleAppMode`. This coercion takes place in the `ComputationRoute` when passing it into `ComputationInstance` (which then passes it to `VisualizationsContainer`).
```js
  // lines 258 - 265 in ComputationRoute.tsx
  <ComputationInstance
      {...props}
      computationId={routeProps.match.params.id}
      computationAppOverview={app}
      visualizationTypes={plugin.visualizationTypes}
      baseUrl={`${url}/${computation?.computationId}`}
      isSingleAppMode={!!singleAppMode}
  />
```
- Added a ternary based on the `isSingleAppMode` property that will route a deletion in the `FullScreenVisualization` component to the appropriate `url`