### PR TITLE
Attempt to resolve Chrome map/thumbnail performance issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.6.6",
+  "version": "3.6.7",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",
@@ -19,7 +19,7 @@
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
-    "@veupathdb/components": "^0.16.4",
+    "@veupathdb/components": "^0.16.5",
     "@veupathdb/coreui": "^0.16.1",
     "@veupathdb/http-utils": "^1.1.0",
     "@veupathdb/study-data-access": "^0.3.2",
@@ -78,7 +78,7 @@
     "@types/react-table": "^7.7.9",
     "@types/uuid": "^8.3.0",
     "@veupathdb/browserslist-config": "^1.0.0",
-    "@veupathdb/components": "^0.16.4",
+    "@veupathdb/components": "^0.16.5",
     "@veupathdb/coreui": "^0.16.1",
     "@veupathdb/eslint-config": "^1.0.0",
     "@veupathdb/http-utils": "^1.1.0",

--- a/src/lib/core/hooks/thumbnails.ts
+++ b/src/lib/core/hooks/thumbnails.ts
@@ -46,7 +46,7 @@ export function useUpdateThumbnailEffect(
     return Task.fromPromise(
       () =>
         new Promise((resolve) => {
-          setTimeout(resolve, 0);
+          setTimeout(resolve, 5000);
         })
     )
       .chain(() =>
@@ -60,6 +60,32 @@ export function useUpdateThumbnailEffect(
     // of "deps" which are not array literals
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
+
+  //  // When the client component dismounts, also make a screenshot
+  //  useLayoutEffect(() => {
+  //    return function cleanup() {
+  //      const plotInstance = plotRef.current;
+  //
+  //      if (plotInstance == null) {
+  //	console.log("With useEffect(), plotInstance is not available in cleanup...");
+  //	return;
+  //      }
+  //
+  //      const { updateThumbnail, thumbnailDimensions } = thumbnailArgsRef.current;
+  //
+  //      Task.fromPromise(
+  //	() =>
+  //          new Promise((resolve) => {
+  //            setTimeout(resolve, 0);
+  //          })
+  //      )
+  //	.chain(() =>
+  //          Task.fromPromise(() =>
+  //	    makePlotThumbnailUrl(plotInstance, thumbnailDimensions)
+  //			  )
+  //	      ).run(updateThumbnail);
+  //    }
+  //  }, []);
 
   // Return a ref callback which can be passed to plot components
   return useCallback((instance: FacetedPlotRef | PlotRef | null) => {

--- a/src/lib/core/hooks/thumbnails.ts
+++ b/src/lib/core/hooks/thumbnails.ts
@@ -42,7 +42,9 @@ export function useUpdateThumbnailEffect(
 
     const { updateThumbnail, thumbnailDimensions } = thumbnailArgsRef.current;
 
-    // Update the thumbnail
+    // Update the thumbnail.
+    // Returns a cancel function for the useLayoutEffect's cleanup.
+    // This in effect (pun intended) provides debouncing functionality
     return Task.fromPromise(
       () =>
         new Promise((resolve) => {

--- a/src/lib/core/hooks/thumbnails.ts
+++ b/src/lib/core/hooks/thumbnails.ts
@@ -46,7 +46,7 @@ export function useUpdateThumbnailEffect(
     return Task.fromPromise(
       () =>
         new Promise((resolve) => {
-          setTimeout(resolve, 5000);
+          setTimeout(resolve, 2000);
         })
     )
       .chain(() =>
@@ -60,32 +60,6 @@ export function useUpdateThumbnailEffect(
     // of "deps" which are not array literals
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
-
-  //  // When the client component dismounts, also make a screenshot
-  //  useLayoutEffect(() => {
-  //    return function cleanup() {
-  //      const plotInstance = plotRef.current;
-  //
-  //      if (plotInstance == null) {
-  //	console.log("With useEffect(), plotInstance is not available in cleanup...");
-  //	return;
-  //      }
-  //
-  //      const { updateThumbnail, thumbnailDimensions } = thumbnailArgsRef.current;
-  //
-  //      Task.fromPromise(
-  //	() =>
-  //          new Promise((resolve) => {
-  //            setTimeout(resolve, 0);
-  //          })
-  //      )
-  //	.chain(() =>
-  //          Task.fromPromise(() =>
-  //	    makePlotThumbnailUrl(plotInstance, thumbnailDimensions)
-  //			  )
-  //	      ).run(updateThumbnail);
-  //    }
-  //  }, []);
 
   // Return a ref callback which can be passed to plot components
   return useCallback((instance: FacetedPlotRef | PlotRef | null) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3036,10 +3036,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.16.4":
-  version "0.16.4"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.16.4.tgz#b9c1e49790939851104d742210452fb6dbb37e18"
-  integrity sha512-75omxvigR11ZQ0lu3zGkIwaORjMJ9hO/4EzdbsOkjyTjN7gVMcpWS33emHzcJYG1YZ9v9byyHbXVaLL1O6wfoA==
+"@veupathdb/components@^0.16.5":
+  version "0.16.5"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.16.5.tgz#c4d75295622713770d11e8738b3efd7f8e19c70e"
+  integrity sha512-TbkwpSst8GiDU1g8yGwgVDGl9Mwb5FimVsuQJU9m3LSxRauJwhh5+gCgHh/ryiydINLfmLsCP7SuWvc+v6pO5w==
   dependencies:
     "@visx/gradient" "^1.0.0"
     "@visx/group" "^1.0.0"


### PR DESCRIPTION
Resolves https://github.com/VEuPathDB/web-components/issues/360  (different repo - maybe move it here)
Depends on https://github.com/VEuPathDB/web-components/pull/365

This PR effectively debounces the calls to the plot thumbnailer (because the Task.run() returns a cancel function, that is returned as the useLayoutEffect cleanup function).  Using a 5000ms debounce, this seems to sort out the performance problems in Chrome (spinner and map locking up).  

We had thought about adding an extra call to the thumbnail grabber when the visualization is closed, otherwise the thumbnails could be very out of date or missing altogether.  I tried this using the second (commented out) `useLayoutEffect` in hooks/thumbnails.ts - but the asynchronous call to the screenshotter fails, presumably because the map has already gone away by this point. I think somehow we'd have to do it synchronously... ??

Reducing the "debounce" from 5000 to 2000 still seems to solve the Chrome freezing problem (even on my quite slow laptop) - and minimises the risk of having a very out-of-date screenshot. I think this would be an adequate b58 deliverable.

I'll leave this in draft (with 5000ms) for discussion

