### PR TITLE
addressing a couple of lineplot viz stuffs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -437,10 +437,6 @@ function LineplotViz(props: VisualizationProps) {
       if (categoricalMode && !valuesAreSpecified) return undefined;
 
       if (categoricalMode && valuesAreSpecified) {
-        if (isEqual(vizConfig.numeratorValues, vizConfig.denominatorValues))
-          throw new Error(
-            'Numerator and denominator value(s) cannot be the same. Numerator values must be a subset of the denominator values.'
-          );
         if (
           vizConfig.numeratorValues != null &&
           !vizConfig.numeratorValues.every((value) =>
@@ -457,18 +453,6 @@ function LineplotViz(props: VisualizationProps) {
         ? xAxisVariable.type
         : '';
       const dependentValueType = yAxisVariable?.type ? yAxisVariable.type : '';
-
-      if (
-        !categoricalMode &&
-        !(
-          dependentValueType === 'number' ||
-          dependentValueType === 'integer' ||
-          dependentValueType === 'date'
-        )
-      )
-        throw new Error(
-          "TEMPORARY ERROR... this variable isn't suitable (perhaps no distinct values) and constraints will handle this soon..."
-        );
 
       // add visualization.type here. valueSpec too?
       const params = getRequestParams(
@@ -1996,7 +1980,6 @@ function isSuitableCategoricalVariable(variable?: Variable): boolean {
     variable != null &&
     variable.dataShape !== 'continuous' &&
     variable.vocabulary != null &&
-    variable.distinctValuesCount != null &&
-    variable.distinctValuesCount > 1
+    variable.distinctValuesCount != null
   );
 }


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1079, which the required tasks are summarized at https://github.com/VEuPathDB/web-eda/issues/1079#issuecomment-1152401516.

Here are example screenshots with PRISM data

- ### before applying this PR: the first screenshot is without removing the error message (taken from the ticket) and the second one is by simply removing the error message in the code, which causes 500 error instead 

a) 
![163398028-b31185d1-6051-4f28-b662-adcd082686fc](https://user-images.githubusercontent.com/12802305/173437423-86c5ccb6-92ae-4b9e-8293-8c876e7b1468.png)

b)
![lineplot-error-msg1](https://user-images.githubusercontent.com/12802305/173436242-8afed2e1-c0c9-40f7-a575-995e943b8d7f.png)

- ### after applying this PR: now proportion can be used without error message & numerator = denominator & showing 1
![lineplot-temporary error1](https://user-images.githubusercontent.com/12802305/173436445-12f21f76-83ce-4a3e-8c85-0b58e953febd.png)

- ### after applying this PR: other variable for test the case of numerator = denominator & showing 1
![lineplot-numerator-denominator1](https://user-images.githubusercontent.com/12802305/173436521-9a6972d2-9bf5-4c37-a5ef-3e8b947e7703.png)
