### PR TITLE
respecting filters for lineplot viz proportion

### DIFF
--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -885,7 +885,7 @@ function LineplotViz(props: VisualizationProps) {
 
   /**
    * changed allowedValues to respect filters
-   * ideally, valuePicker component needs be changed to behave like Legend, e.g., disabling checkbox (grayed out) per filter
+   * ideally, valuePicker component will need to be changed to behave like Legend, e.g., disabling checkbox (grayed out) per filter
    * but it is not that simple task, especially with upcoming release, so skipped it for now
    */
   const proportionInputs = (

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -298,19 +298,29 @@ function LineplotViz(props: VisualizationProps) {
   );
 
   // update numeratorValues and denominatorValues depending on filters and filteredProportionArray
-  useEffect(
-    () =>
-      updateVizConfig({
-        denominatorValues:
-          yAxisVariable != null
-            ? filteredProportionArray != null &&
-              filteredProportionArray.length > 0
-              ? filteredProportionArray
-              : yAxisVariable?.vocabulary
-            : undefined,
-      }),
-    [filters, filteredProportionArray]
-  );
+  useEffect(() => {
+    updateVizConfig({
+      // handle edge case of numeratorValues when filters are changed without changing yAxisVariable
+      // e.g., switching from Viz to Browser and Subset, changing filters, and coming back to Viz
+      numeratorValues:
+        filteredProportionArray == null || filteredProportionArray.length === 0
+          ? vizConfig.numeratorValues
+          : vizConfig.numeratorValues != null
+          ? vizConfig.numeratorValues.every((value: string) =>
+              filteredProportionArray?.includes(value)
+            )
+            ? vizConfig.numeratorValues
+            : undefined
+          : undefined,
+      denominatorValues:
+        yAxisVariable != null
+          ? filteredProportionArray != null &&
+            filteredProportionArray.length > 0
+            ? filteredProportionArray
+            : yAxisVariable?.vocabulary
+          : undefined,
+    });
+  }, [filters, filteredProportionArray]);
 
   const handleInputVariableChange = useCallback(
     (selectedVariables: VariablesByInputName) => {
@@ -371,6 +381,7 @@ function LineplotViz(props: VisualizationProps) {
       vizConfig.binWidth,
       vizConfig.binWidthTimeUnit,
       findEntityAndVariable,
+      filteredProportionArray,
     ]
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3036,10 +3036,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.0.0.tgz#90ca79640ffbb195a87d4d65cd4b2f92342f8b76"
   integrity sha512-qfKu1z9gaaHdMgRGaZBiayuIh92ishsf14lR+Rj61CJF131XWq3+5e2VyLyOdKsYJ1EreAxgyC/0upIBEzwQJw==
 
-"@veupathdb/components@^0.16.5":
-  version "0.16.5"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.16.5.tgz#c4d75295622713770d11e8738b3efd7f8e19c70e"
-  integrity sha512-TbkwpSst8GiDU1g8yGwgVDGl9Mwb5FimVsuQJU9m3LSxRauJwhh5+gCgHh/ryiydINLfmLsCP7SuWvc+v6pO5w==
+"@veupathdb/components@^0.16.6":
+  version "0.16.6"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.16.6.tgz#b60f08c7479f40a2e283697849ea1604f375cb02"
+  integrity sha512-FZoOFO74KkT0nHkr42KgFMlQ4bjMTGXGBWBGUtjMRswsY5i8cfasVGtsY6mVfY3EV0RXbI956QRTi/aR6tjsCg==
   dependencies:
     "@visx/gradient" "^1.0.0"
     "@visx/group" "^1.0.0"


### PR DESCRIPTION
This draft PR is a trial to address https://github.com/VEuPathDB/web-eda/pull/1204#issuecomment-1155393275 at frontend side. Certainly, there is a backend work to address the issue (https://github.com/VEuPathDB/plot.data/pull/177), but perhaps this PR would also be helpful, if working fine. So, it would be great if you can test this PR when you are available.

The basic idea of this work is to respect filters for numerator and denominator values of Lineplot Viz's proportion option concerning categorical variables. To this end, check variableId of filters (array) and selected yAxisVariable, and then make an array which will be used as checkbox list at both numerator and denominator.

As I made a comment in the code, ideally, valuePicker component will need to be changed to behave like Legend, e.g., disabling checkbox (grayed out) per filters, but it is not that simple task, especially with upcoming release, so skipped it for now.

I will show some screenshots below. 