### PR TITLE
Fix pie number bugs and legend checking behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.6.11",
+  "version": "3.6.12",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -509,12 +509,7 @@ function MapViz(props: VisualizationProps) {
    * TO DO: generalise this for use in other visualizations
    */
   useEffect(() => {
-    if (
-      vizConfig.checkedLegendItems == null ||
-      vocabulary == null ||
-      vocabulary.length <= 8
-    )
-      return;
+    if (vizConfig.checkedLegendItems == null || vocabulary == null) return;
 
     if (
       vizConfig.checkedLegendItems.some(
@@ -600,11 +595,12 @@ function MapViz(props: VisualizationProps) {
 
         const count =
           overlayData != null
-            ? vizConfig.markerType === 'pie'
+            ? vizConfig.markerType == null || vizConfig.markerType === 'pie'
               ? // pies always show sum of legend checked items (donutData is already filtered on checkboxes)
                 donutData.reduce((sum, item) => (sum = sum + item.value), 0)
               : // the bar/histogram charts always show the constant entity count
-                overlayData[geoAggregateValue]?.entityCount ?? ''
+                // however, if there is no data at all we can safely infer a zero
+                overlayData[geoAggregateValue]?.entityCount ?? 0
             : entityCount;
 
         const formattedCount =


### PR DESCRIPTION
Fixes #1214 

I was stung by late-in-the-day default value provision: `selectedOption={vizConfig.markerType || 'pie'}` - must avoid this in future.

@asizemore I removed the `vocabulary.length <= 8` optimisation because that `vocabulary` variable (well, `const` lol) is not always the original metadata vocabulary. It's often coming from the data back end response. Perhaps it should be called `activeValues` or something? When there are more than 8 values for a cat. variable, you can zoom in to a part of the map where there are fewer than 8 values, but we should still apply the logic here.  

