### PR TITLE
Subsetting: Respond to breaking change in Modal component and clean up code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.6.14",
+  "version": "3.6.15",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/DownloadTab/MySubset.tsx
+++ b/src/lib/workspace/DownloadTab/MySubset.tsx
@@ -17,11 +17,10 @@ import {
   EnhancedEntityData,
   EnhancedEntityDatum,
 } from './hooks/useEnhancedEntityData';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import SubsettingDataGridModal from '../Subsetting/SubsettingDataGridModal';
 import { AnalysisState } from '../../core';
 import { useToggleStarredVariable } from '../../core/hooks/starredVariables';
-import { EntityCounts } from '../../core/hooks/entityCounts';
 import { useAttemptActionCallback } from '@veupathdb/study-data-access/lib/data-restriction/dataRestrictionHooks';
 import { Action } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUiActions';
 
@@ -29,16 +28,12 @@ type MySubsetProps = {
   datasetId: string;
   entities: EnhancedEntityData;
   analysisState: AnalysisState;
-  totalEntityCounts: EntityCounts | undefined;
-  filteredEntityCounts: EntityCounts | undefined;
 };
 
 export default function MySubset({
   datasetId,
   entities,
   analysisState,
-  totalEntityCounts,
-  filteredEntityCounts,
 }: MySubsetProps) {
   const theme = useUITheme();
 
@@ -52,17 +47,6 @@ export default function MySubset({
   const starredVariables = analysisState.analysis?.descriptor.starredVariables;
   const toggleStarredVariable = useToggleStarredVariable(analysisState);
 
-  const [totalEntityCount, filteredEntityCount] = useMemo(() => {
-    if (currentEntity && totalEntityCounts && filteredEntityCounts) {
-      return [
-        totalEntityCounts[currentEntity.id],
-        filteredEntityCounts[currentEntity.id],
-      ];
-    } else {
-      return [undefined, undefined];
-    }
-  }, [currentEntity, totalEntityCounts, filteredEntityCounts]);
-
   return (
     <div key="My Subset" style={{ marginTop: 10, marginBottom: 35 }}>
       {currentEntity ? (
@@ -74,11 +58,7 @@ export default function MySubset({
           }}
           analysisState={analysisState}
           entities={entities}
-          currentEntityID={currentEntity.id}
-          currentEntityRecordCounts={{
-            total: totalEntityCount,
-            filtered: filteredEntityCount,
-          }}
+          currentEntity={currentEntity}
           starredVariables={starredVariables}
           toggleStarredVariable={toggleStarredVariable}
         />

--- a/src/lib/workspace/DownloadTab/index.tsx
+++ b/src/lib/workspace/DownloadTab/index.tsx
@@ -174,8 +174,6 @@ export default function DownloadTab({
           datasetId={datasetId}
           entities={enhancedEntityData}
           analysisState={analysisState}
-          totalEntityCounts={totalCounts}
-          filteredEntityCounts={filteredCounts}
         />
         {mergedReleaseData.map((release, index) =>
           index === 0 ? (


### PR DESCRIPTION
Relates to issue #1045 and to [the refactor of the Modal](https://github.com/VEuPathDB/CoreUI/pull/81) component in CoreUI.

This PR does the following:
1. Removes the `onClose` and `onOpen` props passed into the Modal. Both props are being removed from the Modal component.
2. Replaces passed prop `currentEntityID` with `currentEntity` (of the `<EnhancedEntityDatum>`) from `MySubset` to `SubsettingDataGridModal`. The `currentEntity` of this type includes the filtered and total counts, thereby allowing removal of props/logic related to those counts. Also allows removal of a duplicate `currentEntity` state in `SubsettingDataGridModal`.
3. Removes props `totalEntityCounts` and `filteredEntityCounts` passed from `DownloadTab` to `MySubset`. The `entities` pulled from the `useEnhancedEntityData` in the `DownloadTab` include counts.