### PR TITLE
Render VariableCoverageTable only when completeCases is truthy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.6.18",
+  "version": "3.6.19",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/VariableCoverageTable.tsx
+++ b/src/lib/core/components/VariableCoverageTable.tsx
@@ -59,7 +59,7 @@ export function VariableCoverageTable({
       ? 'VariableCoverageTable'
       : `${containerClassName} VariableCoverageTable`;
 
-  return variableSpecs.some((spec) => spec.variable) ? (
+  return completeCases ? (
     <div className={className}>
       <table>
         <tbody>


### PR DESCRIPTION
Resolves #1072

Rendering when `completeCases` is defined ensures that the `VariableCoverageTable` and the `BirdsEyeView` are both now hidden until all required data is provided.

X and Y vars selected:
![image](https://user-images.githubusercontent.com/69446567/177367170-db0b81b7-1746-443a-ba5b-806ede884612.png)

Proportion set:
![image](https://user-images.githubusercontent.com/69446567/177367275-5a18a38b-d2a9-40cd-a712-78f80efcff04.png)
 