### PR TITLE
App viz interaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.6.19",
+  "version": "3.7.0",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/EDAWorkspaceContainer.tsx
+++ b/src/lib/core/components/EDAWorkspaceContainer.tsx
@@ -12,15 +12,15 @@ import {
 } from '../context/WorkspaceContext';
 import {
   HookValue as WdkStudyRecord,
-  useStudyEntities,
   useStudyMetadata,
   useWdkStudyRecord,
 } from '../hooks/study';
 
-import { FieldWithMetadata, StudyMetadata } from '..';
+import { FieldWithMetadata, StudyMetadata, useStudyEntities } from '..';
 
 import { useFieldTree, useFlattenedFields } from './variableTrees/hooks';
 import { DownloadClient } from '../api/DownloadClient';
+import { entityTreeToArray } from '../utils/study-metadata';
 
 export interface Props {
   studyId: string;
@@ -67,7 +67,9 @@ function EDAWorkspaceContainerWithLoadedData({
   wdkStudyRecord,
   studyMetadata,
 }: LoadedDataProps) {
-  const entities = useStudyEntities(studyMetadata.rootEntity);
+  const entities = useMemo(() => entityTreeToArray(studyMetadata.rootEntity), [
+    studyMetadata.rootEntity,
+  ]);
   const variableTreeFields = useFlattenedFields(entities, 'variableTree');
   const variableTree = useFieldTree(variableTreeFields);
 

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -3,13 +3,13 @@ import { useRouteMatch } from 'react-router-dom';
 import { useToggleStarredVariable } from '../../hooks/starredVariables';
 import { Computation, Visualization } from '../../types/visualization';
 import { VisualizationsContainer } from '../visualizations/VisualizationsContainer';
-import { VisualizationType } from '../visualizations/VisualizationTypes';
 import { ComputationProps } from './Types';
 import { plugins } from './plugins';
+import { VisualizationPlugin } from '../visualizations/VisualizationPlugin';
 
 export interface Props extends ComputationProps {
   computationId: string;
-  visualizationTypes: Partial<Record<string, VisualizationType>>;
+  visualizationTypes: Partial<Record<string, VisualizationPlugin>>;
   baseUrl?: string; // right now only defined when *not* using single app mode
   isSingleAppMode: boolean;
 }

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -9,7 +9,7 @@ import { VisualizationPlugin } from '../visualizations/VisualizationPlugin';
 
 export interface Props extends ComputationProps {
   computationId: string;
-  visualizationTypes: Partial<Record<string, VisualizationPlugin>>;
+  visualizationPlugins: Partial<Record<string, VisualizationPlugin>>;
   baseUrl?: string; // right now only defined when *not* using single app mode
   isSingleAppMode: boolean;
 }
@@ -22,7 +22,7 @@ export function ComputationInstance(props: Props) {
     totalCounts,
     filteredCounts,
     geoConfigs,
-    visualizationTypes,
+    visualizationPlugins,
     baseUrl,
     isSingleAppMode,
   } = props;
@@ -86,7 +86,7 @@ export function ComputationInstance(props: Props) {
         geoConfigs={geoConfigs}
         computation={computation}
         visualizationsOverview={computationAppOverview.visualizations}
-        visualizationTypes={visualizationTypes}
+        visualizationPlugins={visualizationPlugins}
         updateVisualizations={updateVisualizations}
         filters={analysis.descriptor.subset.descriptor}
         starredVariables={analysis?.descriptor.starredVariables}

--- a/src/lib/core/components/computations/StartPage.tsx
+++ b/src/lib/core/components/computations/StartPage.tsx
@@ -80,7 +80,6 @@ export function StartPage(props: Props) {
                       plugin && plugin.visualizationPlugins[viz.name];
                     const disabled =
                       !plugin || !plugin.visualizationPlugins[viz.name];
-                    const VizSelector = vizPlugin?.selectorComponent;
                     return (
                       <div
                         className={cx('-PickerEntry', disabled && 'disabled')}
@@ -178,8 +177,12 @@ export function StartPage(props: Props) {
                               }
                             }}
                           >
-                            {VizSelector ? (
-                              <VizSelector {...app} />
+                            {vizPlugin ? (
+                              <img
+                                src={vizPlugin.selectorIcon}
+                                alt={viz.displayName}
+                                style={{ height: '100%', width: '100%' }}
+                              />
                             ) : (
                               <PlaceholderIcon name={viz.name} />
                             )}

--- a/src/lib/core/components/computations/StartPage.tsx
+++ b/src/lib/core/components/computations/StartPage.tsx
@@ -74,12 +74,12 @@ export function StartPage(props: Props) {
                     rowGap: '2em',
                   }}
                 >
-                  {app.visualizations?.map((vizType, index) => {
+                  {app.visualizations?.map((viz, index) => {
                     const plugin = plugins[app.name];
                     const vizPlugin =
-                      plugin && plugin.visualizationTypes[vizType.name];
+                      plugin && plugin.visualizationPlugins[viz.name];
                     const disabled =
-                      !plugin || !plugin.visualizationTypes[vizType.name];
+                      !plugin || !plugin.visualizationPlugins[viz.name];
                     const VizSelector = vizPlugin?.selectorComponent;
                     return (
                       <div
@@ -89,7 +89,7 @@ export function StartPage(props: Props) {
                           margin: '0 3em',
                         }}
                       >
-                        <Tooltip title={<>{vizType.description}</>}>
+                        <Tooltip title={<>{viz.description}</>}>
                           <button
                             style={{
                               cursor: disabled ? 'not-allowed' : 'cursor',
@@ -132,7 +132,7 @@ export function StartPage(props: Props) {
                                 visualizationId,
                                 displayName: 'Unnamed visualization',
                                 descriptor: {
-                                  type: vizType.name!,
+                                  type: viz.name!,
                                   configuration: vizPlugin.createDefaultConfig(),
                                 },
                               };
@@ -181,13 +181,13 @@ export function StartPage(props: Props) {
                             {VizSelector ? (
                               <VizSelector {...app} />
                             ) : (
-                              <PlaceholderIcon name={vizType.name} />
+                              <PlaceholderIcon name={viz.name} />
                             )}
                           </button>
                         </Tooltip>
                         <div className={cx('-PickerEntryName')}>
                           <div>
-                            {vizType.displayName
+                            {viz.displayName
                               ?.split(/(, )/g)
                               .map((str) => (str === ', ' ? <br /> : str))}
                           </div>

--- a/src/lib/core/components/computations/Types.ts
+++ b/src/lib/core/components/computations/Types.ts
@@ -44,7 +44,7 @@ export interface ComputationPlugin {
   configurationDescriptionComponent?: React.ComponentType<{
     computation: Computation;
   }>;
-  visualizationTypes: Partial<Record<string, VisualizationPlugin<any>>>;
+  visualizationPlugins: Partial<Record<string, VisualizationPlugin<any>>>;
   createDefaultComputationSpec?: (
     rootEntity: StudyEntity
   ) => { configuration: unknown };

--- a/src/lib/core/components/computations/Types.ts
+++ b/src/lib/core/components/computations/Types.ts
@@ -4,8 +4,8 @@ import { EntityCounts } from '../../hooks/entityCounts';
 import { PromiseHookState } from '../../hooks/promise';
 import { GeoConfig } from '../../types/geoConfig';
 import { Computation, ComputationAppOverview } from '../../types/visualization';
-import { VisualizationType } from '../visualizations/VisualizationTypes';
 import { StudyEntity } from '../..';
+import { VisualizationPlugin } from '../visualizations/VisualizationPlugin';
 
 export interface ComputationProps {
   analysisState: AnalysisState;
@@ -44,7 +44,7 @@ export interface ComputationPlugin {
   configurationDescriptionComponent?: React.ComponentType<{
     computation: Computation;
   }>;
-  visualizationTypes: Partial<Record<string, VisualizationType>>;
+  visualizationTypes: Partial<Record<string, VisualizationPlugin<any>>>;
   createDefaultComputationSpec?: (
     rootEntity: StudyEntity
   ) => { configuration: unknown };

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -67,6 +67,7 @@ export const plugin: ComputationPlugin = {
         }
       },
       hideShowMissingnessToggle: true,
+      hideTrendlines: true,
     }),
   },
 };

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -25,7 +25,30 @@ export const plugin: ComputationPlugin = {
   configurationComponent: AbundanceConfiguration,
   configurationDescriptionComponent: AbundanceConfigDescriptionComponent,
   visualizationTypes: {
-    boxplot: boxplotVisualization,
+    boxplot: boxplotVisualization.withOptions({
+      getXAxisVariable(config) {
+        if (AbundanceConfig.is(config)) {
+          return config.collectionVariable;
+        }
+      },
+      getYAxisVariable(config) {
+        if (AbundanceConfig.is(config)) {
+          return {
+            entityId: config.collectionVariable.entityId,
+            variableId: 'abundance',
+          };
+        }
+      },
+      getPlotSubtitle(config) {
+        if (AbundanceConfig.is(config)) {
+          return `Ranked abundance: Variables with ${config.rankingMethod} = 0 removed. Showing up to the top ten variables.`;
+        }
+      },
+      getYAxisLabel() {
+        return 'Relative abundance';
+      },
+      disableShowMissingness: true,
+    }),
     scatterplot: scatterplotVisualization,
   },
   createDefaultComputationSpec: createDefaultComputationSpec,

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -67,7 +67,6 @@ export const plugin: ComputationPlugin = {
         }
       },
       hideShowMissingnessToggle: true,
-      hideTrendlines: true,
     }),
   },
 };

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -25,7 +25,7 @@ export const plugin: ComputationPlugin = {
   configurationComponent: AbundanceConfiguration,
   configurationDescriptionComponent: AbundanceConfigDescriptionComponent,
   createDefaultComputationSpec: createDefaultComputationSpec,
-  visualizationTypes: {
+  visualizationPlugins: {
     boxplot: boxplotVisualization.withOptions({
       getXAxisVariable(config) {
         if (AbundanceConfig.is(config)) {

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { useStudyMetadata } from '../../..';
-import { useCollectionVariables } from '../../../hooks/study';
+import { useCollectionVariables } from '../../../hooks/workspace';
 import { VariableDescriptor } from '../../../types/variable';
 import { StudyEntity } from '../../../types/study';
 import { boxplotVisualization } from '../../visualizations/implementations/BoxplotVisualization';
@@ -24,6 +24,7 @@ export const AbundanceConfig = t.type({
 export const plugin: ComputationPlugin = {
   configurationComponent: AbundanceConfiguration,
   configurationDescriptionComponent: AbundanceConfigDescriptionComponent,
+  createDefaultComputationSpec: createDefaultComputationSpec,
   visualizationTypes: {
     boxplot: boxplotVisualization.withOptions({
       getXAxisVariable(config) {
@@ -49,9 +50,31 @@ export const plugin: ComputationPlugin = {
       },
       disableShowMissingness: true,
     }),
-    scatterplot: scatterplotVisualization,
+    scatterplot: scatterplotVisualization.withOptions({
+      getYAxisVariable(config) {
+        if (AbundanceConfig.is(config)) {
+          return {
+            entityId: config.collectionVariable.entityId,
+            variableId: 'abundance',
+          };
+        }
+      },
+      getOverlayVariable(config) {
+        if (AbundanceConfig.is(config)) {
+          return config.collectionVariable;
+        }
+      },
+      getPlotSubtitle(config) {
+        if (AbundanceConfig.is(config)) {
+          return `Ranked abundance: Variables with ${config.rankingMethod} = 0 removed. Showing up to the top ten variables.`;
+        }
+      },
+      getYAxisLabel() {
+        return 'Relative abundance';
+      },
+      hideShowMissingnessToggle: true,
+    }),
   },
-  createDefaultComputationSpec: createDefaultComputationSpec,
 };
 
 function AbundanceConfigDescriptionComponent({

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -32,11 +32,11 @@ export const plugin: ComputationPlugin = {
           return config.collectionVariable;
         }
       },
-      getYAxisVariable(config) {
+      getComputedYAxisDetails(config) {
         if (AbundanceConfig.is(config)) {
           return {
             entityId: config.collectionVariable.entityId,
-            variableId: 'abundance',
+            placeholderDisplayName: 'Relative abundance',
           };
         }
       },
@@ -45,17 +45,14 @@ export const plugin: ComputationPlugin = {
           return `Ranked abundance: Variables with ${config.rankingMethod} = 0 removed. Showing up to the top ten variables.`;
         }
       },
-      getYAxisLabel() {
-        return 'Relative abundance';
-      },
-      disableShowMissingness: true,
+      hideShowMissingnessToggle: true,
     }),
     scatterplot: scatterplotVisualization.withOptions({
-      getYAxisVariable(config) {
+      getComputedYAxisDetails(config) {
         if (AbundanceConfig.is(config)) {
           return {
             entityId: config.collectionVariable.entityId,
-            variableId: 'abundance',
+            placeholderDisplayName: 'Relative abundance',
           };
         }
       },
@@ -68,9 +65,6 @@ export const plugin: ComputationPlugin = {
         if (AbundanceConfig.is(config)) {
           return `Ranked abundance: Variables with ${config.rankingMethod} = 0 removed. Showing up to the top ten variables.`;
         }
-      },
-      getYAxisLabel() {
-        return 'Relative abundance';
       },
       hideShowMissingnessToggle: true,
     }),

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -46,6 +46,7 @@ export const plugin: ComputationPlugin = {
         }
       },
       hideShowMissingnessToggle: true,
+      hideTrendlines: true,
     }),
   },
 };

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -25,7 +25,21 @@ export const plugin: ComputationPlugin = {
   configurationComponent: AlphaDivConfiguration,
   configurationDescriptionComponent: AlphaDivConfigDescriptionComponent,
   visualizationTypes: {
-    boxplot: boxplotVisualization,
+    boxplot: boxplotVisualization.withOptions({
+      getYAxisVariable(config) {
+        if (AlphaDivConfig.is(config)) {
+          return {
+            entityId: config.collectionVariable.entityId,
+            variableId: 'alphadiv',
+          };
+        }
+      },
+      getYAxisLabel(config) {
+        if (AlphaDivConfig.is(config)) {
+          return 'Alphadiv';
+        }
+      },
+    }),
     scatterplot: scatterplotVisualization,
   },
   createDefaultComputationSpec: createDefaultComputationSpec,

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
-import { useStudyMetadata } from '../../..';
+import { useCollectionVariables, useStudyMetadata } from '../../..';
 import { StudyEntity } from '../../../types/study';
-import { useCollectionVariables } from '../../../hooks/study';
 import { VariableDescriptor } from '../../../types/variable';
 import { boxplotVisualization } from '../../visualizations/implementations/BoxplotVisualization';
 import { scatterplotVisualization } from '../../visualizations/implementations/ScatterplotVisualization';
@@ -24,6 +23,7 @@ export const AlphaDivConfig = t.type({
 export const plugin: ComputationPlugin = {
   configurationComponent: AlphaDivConfiguration,
   configurationDescriptionComponent: AlphaDivConfigDescriptionComponent,
+  createDefaultComputationSpec: createDefaultComputationSpec,
   visualizationTypes: {
     boxplot: boxplotVisualization.withOptions({
       getYAxisVariable(config) {
@@ -39,10 +39,25 @@ export const plugin: ComputationPlugin = {
           return 'Alphadiv';
         }
       },
+      disableShowMissingness: true,
     }),
-    scatterplot: scatterplotVisualization,
+    scatterplot: scatterplotVisualization.withOptions({
+      getYAxisVariable(config) {
+        if (AlphaDivConfig.is(config)) {
+          return {
+            entityId: config.collectionVariable.entityId,
+            variableId: 'alphadiv',
+          };
+        }
+      },
+      getYAxisLabel(config) {
+        if (AlphaDivConfig.is(config)) {
+          return 'Alphadiv';
+        }
+      },
+      hideShowMissingnessToggle: true,
+    }),
   },
-  createDefaultComputationSpec: createDefaultComputationSpec,
 };
 
 function AlphaDivConfigDescriptionComponent({

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -24,7 +24,7 @@ export const plugin: ComputationPlugin = {
   configurationComponent: AlphaDivConfiguration,
   configurationDescriptionComponent: AlphaDivConfigDescriptionComponent,
   createDefaultComputationSpec: createDefaultComputationSpec,
-  visualizationTypes: {
+  visualizationPlugins: {
     boxplot: boxplotVisualization.withOptions({
       getComputedYAxisDetails(config) {
         if (AlphaDivConfig.is(config)) {

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -26,33 +26,23 @@ export const plugin: ComputationPlugin = {
   createDefaultComputationSpec: createDefaultComputationSpec,
   visualizationTypes: {
     boxplot: boxplotVisualization.withOptions({
-      getYAxisVariable(config) {
+      getComputedYAxisDetails(config) {
         if (AlphaDivConfig.is(config)) {
           return {
             entityId: config.collectionVariable.entityId,
-            variableId: 'alphadiv',
+            placeholderDisplayName: 'Alphadiv',
           };
         }
       },
-      getYAxisLabel(config) {
-        if (AlphaDivConfig.is(config)) {
-          return 'Alphadiv';
-        }
-      },
-      disableShowMissingness: true,
+      hideShowMissingnessToggle: true,
     }),
     scatterplot: scatterplotVisualization.withOptions({
-      getYAxisVariable(config) {
+      getComputedYAxisDetails(config) {
         if (AlphaDivConfig.is(config)) {
           return {
             entityId: config.collectionVariable.entityId,
-            variableId: 'alphadiv',
+            placeholderDisplayName: 'Alphadiv',
           };
-        }
-      },
-      getYAxisLabel(config) {
-        if (AlphaDivConfig.is(config)) {
-          return 'Alphadiv';
         }
       },
       hideShowMissingnessToggle: true,

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -46,7 +46,6 @@ export const plugin: ComputationPlugin = {
         }
       },
       hideShowMissingnessToggle: true,
-      hideTrendlines: true,
     }),
   },
 };

--- a/src/lib/core/components/computations/plugins/countsAndProportions.tsx
+++ b/src/lib/core/components/computations/plugins/countsAndProportions.tsx
@@ -9,7 +9,7 @@ import { ZeroConfigWithButton } from '../ZeroConfiguration';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
-  visualizationTypes: {
+  visualizationPlugins: {
     testVisualization,
     twobytwo: twoByTwoVisualization,
     conttable: contTableVisualization,

--- a/src/lib/core/components/computations/plugins/distributions.tsx
+++ b/src/lib/core/components/computations/plugins/distributions.tsx
@@ -6,7 +6,7 @@ import { ZeroConfigWithButton } from '../ZeroConfiguration';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
-  visualizationTypes: {
+  visualizationPlugins: {
     testVisualization,
     histogram: histogramVisualization,
     // densityplot: scatterplotVisualization,

--- a/src/lib/core/components/computations/plugins/pass.tsx
+++ b/src/lib/core/components/computations/plugins/pass.tsx
@@ -14,7 +14,7 @@ import { ZeroConfigWithButton } from '../ZeroConfiguration';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
-  visualizationTypes: {
+  visualizationPlugins: {
     testVisualization,
     histogram: histogramVisualization,
     twobytwo: twoByTwoVisualization,

--- a/src/lib/core/components/computations/plugins/xyRelationships.tsx
+++ b/src/lib/core/components/computations/plugins/xyRelationships.tsx
@@ -6,7 +6,7 @@ import { ZeroConfigWithButton } from '../ZeroConfiguration';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
-  visualizationTypes: {
+  visualizationPlugins: {
     testVisualization,
     scatterplot: scatterplotVisualization,
     lineplot: lineplotVisualization,

--- a/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
+++ b/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
@@ -6,7 +6,7 @@ import { StudyEntity, VariableScope } from '../../types/study';
 import { VariableDescriptor } from '../../types/variable';
 import VariableList, { VariableFieldTreeNode } from './VariableList';
 import './VariableTree.scss';
-import { useStudyEntities } from '../../hooks/study';
+import { useStudyEntities } from '../../hooks/workspace';
 import {
   useFieldTree,
   useFlattenedFields,
@@ -16,10 +16,10 @@ import {
 import { CustomCheckboxes } from '@veupathdb/wdk-client/lib/Components/CheckboxTree/CheckboxTreeNode';
 
 export interface MultiSelectVariableTreeProps {
-  /** The entity from which to derive the tree structure. */
-  rootEntity: StudyEntity;
   /** The "scope" of variables which should be offered. */
   scope: VariableScope;
+  /** Predicate function used to filter entities */
+  filterEntity: (entity: StudyEntity) => boolean;
   /** Which variables have been selected? */
   selectedVariableDescriptors: Array<VariableDescriptor>;
   featuredFields: Array<Field>;
@@ -36,8 +36,8 @@ export interface MultiSelectVariableTreeProps {
  * variables concurrently.
  */
 export default function MultiSelectVariableTree({
-  rootEntity,
   scope,
+  filterEntity,
   selectedVariableDescriptors,
   starredVariableDescriptors,
   toggleStarredVariable,
@@ -46,7 +46,7 @@ export default function MultiSelectVariableTree({
   customCheckboxes,
   startExpanded,
 }: MultiSelectVariableTreeProps) {
-  const entities = useStudyEntities(rootEntity);
+  const entities = useStudyEntities().filter(filterEntity);
   const valuesMap = useValuesMap(entities);
   const flattenedFields = useFlattenedFields(entities, scope);
   const fieldsByTerm = useFlattenFieldsByTerm(flattenedFields);

--- a/src/lib/core/components/variableTrees/VariableTree.tsx
+++ b/src/lib/core/components/variableTrees/VariableTree.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from 'react';
 
-import { StudyEntity, VariableScope } from '../../types/study';
+import { VariableScope } from '../../types/study';
 import { VariableDescriptor } from '../../types/variable';
 import VariableList from './VariableList';
 import './VariableTree.scss';
-import { useStudyEntities } from '../../hooks/study';
+import { useStudyEntities } from '../../hooks/workspace';
 import {
   useValuesMap,
   useFlattenedFields,
@@ -14,7 +14,6 @@ import {
 } from './hooks';
 
 export interface VariableTreeProps {
-  rootEntity: StudyEntity;
   starredVariables?: VariableDescriptor[];
   toggleStarredVariable: (targetVariableId: VariableDescriptor) => void;
   entityId?: string;
@@ -31,7 +30,6 @@ export interface VariableTreeProps {
 
 export default function VariableTree({
   customDisabledVariableMessage,
-  rootEntity,
   disabledVariables,
   starredVariables,
   toggleStarredVariable,
@@ -41,7 +39,7 @@ export default function VariableTree({
   showMultiFilterDescendants = false,
   scope,
 }: VariableTreeProps) {
-  const entities = useStudyEntities(rootEntity);
+  const entities = useStudyEntities();
   const valuesMap = useValuesMap(entities);
   const flattenedFields = useFlattenedFields(entities, scope);
   const fieldsByTerm = useFlattenFieldsByTerm(flattenedFields);

--- a/src/lib/core/components/variableTrees/VariableTreeDropdown.tsx
+++ b/src/lib/core/components/variableTrees/VariableTreeDropdown.tsx
@@ -4,12 +4,12 @@ import PopoverButton from '@veupathdb/components/lib/components/widgets/PopoverB
 
 import { cx } from '../../../workspace/Utils';
 import './VariableTree.scss';
-import { useStudyEntities } from '../../hooks/study';
+import { useStudyEntities } from '../../hooks/workspace';
 import VariableTree, { VariableTreeProps } from './VariableTree';
 
 export default function VariableTreeDropdown(props: VariableTreeProps) {
-  const { rootEntity, entityId, variableId, onChange } = props;
-  const entities = useStudyEntities(rootEntity);
+  const { entityId, variableId, onChange } = props;
+  const entities = useStudyEntities();
   const variable = entities
     .find((e) => e.id === entityId)
     ?.variables.find((v) => v.id === variableId);

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -243,7 +243,6 @@ export function InputVariables(props: Props) {
                       <VariableTreeDropdown
                         scope="variableTree"
                         showMultiFilterDescendants
-                        rootEntity={entities[0]}
                         disabledVariables={
                           disabledVariablesByInputName[input.name]
                         }

--- a/src/lib/core/components/visualizations/VisualizationPlugin.tsx
+++ b/src/lib/core/components/visualizations/VisualizationPlugin.tsx
@@ -14,7 +14,7 @@ export interface VisualizationPlugin<Options = undefined> {
 }
 
 export function createVisualizationPlugin<Options>(
-  config: Omit<VisualizationPlugin<Options>, 'withOptions' | 'optoins'>
+  config: Omit<VisualizationPlugin<Options>, 'withOptions' | 'options'>
 ): VisualizationPlugin<Options> {
   function withOptions(options: Options): VisualizationPlugin<Options> {
     return {

--- a/src/lib/core/components/visualizations/VisualizationPlugin.tsx
+++ b/src/lib/core/components/visualizations/VisualizationPlugin.tsx
@@ -1,0 +1,30 @@
+import {
+  IsEnabledInPickerParams,
+  SelectorProps,
+  VisualizationProps,
+} from './VisualizationTypes';
+
+export interface VisualizationPlugin<Options = undefined> {
+  fullscreenComponent: React.ComponentType<VisualizationProps<Options>>;
+  selectorComponent: React.ComponentType<SelectorProps>;
+  createDefaultConfig: () => unknown;
+  isEnabledInPicker?: (props: IsEnabledInPickerParams) => boolean;
+  withOptions: (options: Options) => VisualizationPlugin<Options>;
+  options?: Options;
+}
+
+export function createVisualizationPlugin<Options>(
+  config: Omit<VisualizationPlugin<Options>, 'withOptions' | 'optoins'>
+): VisualizationPlugin<Options> {
+  function withOptions(options: Options): VisualizationPlugin<Options> {
+    return {
+      ...config,
+      options: options,
+      withOptions,
+    };
+  }
+  return {
+    ...config,
+    withOptions,
+  };
+}

--- a/src/lib/core/components/visualizations/VisualizationPlugin.tsx
+++ b/src/lib/core/components/visualizations/VisualizationPlugin.tsx
@@ -1,30 +1,53 @@
 import {
   IsEnabledInPickerParams,
-  SelectorProps,
   VisualizationProps,
 } from './VisualizationTypes';
 
-export interface VisualizationPlugin<Options = undefined> {
+export interface VisualizationPluginSpec<Options = undefined> {
+  /** Component used to render the visualization */
   fullscreenComponent: React.ComponentType<VisualizationProps<Options>>;
-  selectorComponent: React.ComponentType<SelectorProps>;
+  /** Image URI used in selector */
+  selectorIcon: string;
+  /** Function used to create a default configuration when a visualization instance is created */
   createDefaultConfig: () => unknown;
+  /** Function used to determine if visualization is compatible with study */
   isEnabledInPicker?: (props: IsEnabledInPickerParams) => boolean;
-  withOptions: (options: Options) => VisualizationPlugin<Options>;
+}
+
+export interface VisualizationPlugin<Options = undefined>
+  extends VisualizationPluginSpec<Options> {
+  /** Options that have been set for the plugin instance */
   options?: Options;
+  /** Factory function to create a new plugin instance with options applied */
+  withOptions: (options: Options) => VisualizationPlugin<Options>;
+  /** Factory function to create a new plugin instance with a new selector icon */
+  withSelectorIcon: (icon: string) => VisualizationPlugin<Options>;
 }
 
 export function createVisualizationPlugin<Options>(
-  config: Omit<VisualizationPlugin<Options>, 'withOptions' | 'options'>
+  pluginSpec: VisualizationPluginSpec<Options>
 ): VisualizationPlugin<Options> {
   function withOptions(options: Options): VisualizationPlugin<Options> {
     return {
-      ...config,
-      options: options,
+      ...pluginSpec,
+      options,
       withOptions,
+      withSelectorIcon,
+    };
+  }
+  function withSelectorIcon(
+    selectorIcon: string
+  ): VisualizationPlugin<Options> {
+    return {
+      ...pluginSpec,
+      selectorIcon,
+      withOptions,
+      withSelectorIcon,
     };
   }
   return {
-    ...config,
+    ...pluginSpec,
     withOptions,
+    withSelectorIcon,
   };
 }

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -38,3 +38,8 @@ export interface IsEnabledInPickerParams {
   studyMetadata?: StudyMetadata; // not used yet, but you could imagine it being used to determine
   // if a viz tool should be enabled
 }
+
+export interface ComputedVariableDetails {
+  entityId: string;
+  placeholderDisplayName: string;
+}

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -30,9 +30,6 @@ export interface VisualizationProps<Options = undefined> {
   geoConfigs: GeoConfig[];
   otherVizOverviews: VisualizationOverview[];
 }
-
-export type SelectorProps = VisualizationOverview;
-
 export interface IsEnabledInPickerParams {
   geoConfigs?: GeoConfig[];
   studyMetadata?: StudyMetadata; // not used yet, but you could imagine it being used to determine

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -14,7 +14,8 @@ import {
 /**
  * Props passed to viz components
  */
-export interface VisualizationProps {
+export interface VisualizationProps<Options = undefined> {
+  options?: Options;
   visualization: Visualization;
   dataElementConstraints?: Record<string, DataElementConstraint>[];
   dataElementDependencyOrder?: string[];
@@ -36,11 +37,4 @@ export interface IsEnabledInPickerParams {
   geoConfigs?: GeoConfig[];
   studyMetadata?: StudyMetadata; // not used yet, but you could imagine it being used to determine
   // if a viz tool should be enabled
-}
-
-export interface VisualizationType {
-  fullscreenComponent: React.ComponentType<VisualizationProps>;
-  selectorComponent: React.ComponentType<SelectorProps>;
-  createDefaultConfig: () => unknown;
-  isEnabledInPicker?: (props: IsEnabledInPickerParams) => boolean;
 }

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -335,7 +335,11 @@ function NewVisualizationPicker(props: Props) {
                     }}
                   >
                     {vizType ? (
-                      <vizType.selectorComponent {...vizOverview} />
+                      <img
+                        alt="Histogram"
+                        style={{ height: '100%', width: '100%' }}
+                        src={vizType.selectorIcon}
+                      />
                     ) : (
                       <PlaceholderIcon name={vizOverview.name} />
                     )}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -20,7 +20,6 @@ import {
   VisualizationDescriptor,
 } from '../../types/visualization';
 import { Grid } from '../Grid';
-import { VisualizationType } from './VisualizationTypes';
 
 import './Visualizations.scss';
 import { ContentError } from '@veupathdb/wdk-client/lib/Components/PageStatus/ContentError';
@@ -38,6 +37,7 @@ import AddIcon from '@material-ui/icons/Add';
 import { plugins } from '../computations/plugins';
 import { AnalysisState } from '../../hooks/analysis';
 import { ComputationAppOverview } from '../../types/visualization';
+import { VisualizationPlugin } from './VisualizationPlugin';
 
 const cx = makeClassNameHelper('VisualizationsContainer');
 
@@ -50,7 +50,7 @@ interface Props {
       | Visualization[]
       | ((visualizations: Visualization[]) => Visualization[])
   ) => void;
-  visualizationTypes: Partial<Record<string, VisualizationType>>;
+  visualizationTypes: Partial<Record<string, VisualizationPlugin>>;
   visualizationsOverview: VisualizationOverview[];
   filters: Filter[];
   starredVariables: VariableDescriptor[];
@@ -560,6 +560,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
             />
           )}
           <vizType.fullscreenComponent
+            options={vizType.options}
             dataElementConstraints={constraints}
             dataElementDependencyOrder={dataElementDependencyOrder}
             visualization={viz}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -50,7 +50,7 @@ interface Props {
       | Visualization[]
       | ((visualizations: Visualization[]) => Visualization[])
   ) => void;
-  visualizationTypes: Partial<Record<string, VisualizationPlugin>>;
+  visualizationPlugins: Partial<Record<string, VisualizationPlugin>>;
   visualizationsOverview: VisualizationOverview[];
   filters: Filter[];
   starredVariables: VariableDescriptor[];
@@ -276,7 +276,7 @@ function ConfiguredVisualizations(props: Props) {
 
 function NewVisualizationPicker(props: Props) {
   const {
-    visualizationTypes,
+    visualizationPlugins,
     visualizationsOverview,
     updateVisualizations,
     computation,
@@ -296,10 +296,10 @@ function NewVisualizationPicker(props: Props) {
         {/* orderBy ensures that available visualizations render ahead of those in development */}
         {orderBy(
           visualizationsOverview,
-          [(viz) => (viz.name && visualizationTypes[viz.name] ? 1 : 0)],
+          [(viz) => (viz.name && visualizationPlugins[viz.name] ? 1 : 0)],
           ['desc']
         ).map((vizOverview, index) => {
-          const vizType = visualizationTypes[vizOverview.name!];
+          const vizType = visualizationPlugins[vizOverview.name!];
           const disabled =
             vizType == null ||
             (vizType.isEnabledInPicker != null &&
@@ -365,7 +365,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
   const {
     analysisState,
     computationAppOverview,
-    visualizationTypes,
+    visualizationPlugins,
     visualizationsOverview,
     id,
     updateVisualizations,
@@ -381,7 +381,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
   } = props;
   const history = useHistory();
   const viz = computation.visualizations.find((v) => v.visualizationId === id);
-  const vizType = viz && visualizationTypes[viz.descriptor.type];
+  const vizPugin = viz && visualizationPlugins[viz.descriptor.type];
   const overviews = useMemo(
     () =>
       groupBy(visualizationsOverview, (v) =>
@@ -441,7 +441,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
     [updateVisualizations, id]
   );
   if (viz == null) return <div>Visualization not found.</div>;
-  if (vizType == null) return <div>Visualization type not implemented.</div>;
+  if (vizPugin == null) return <div>Visualization type not implemented.</div>;
 
   const { computationId } = computation;
   const plugin = plugins[computation.descriptor.type] ?? undefined;
@@ -524,7 +524,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
         <ContentError>Visualization not found.</ContentError>
       ) : computation == null ? (
         <ContentError>Computation not found.</ContentError>
-      ) : vizType == null ? (
+      ) : vizPugin == null ? (
         <ContentError>
           <>Visualization type not implemented: {viz.descriptor.type}</>
         </ContentError>
@@ -559,8 +559,8 @@ function FullScreenVisualization(props: Props & { id: string }) {
               addNewComputation={() => null}
             />
           )}
-          <vizType.fullscreenComponent
-            options={vizType.options}
+          <vizPugin.fullscreenComponent
+            options={vizPugin.options}
             dataElementConstraints={constraints}
             dataElementDependencyOrder={dataElementDependencyOrder}
             visualization={viz}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -336,7 +336,7 @@ function NewVisualizationPicker(props: Props) {
                   >
                     {vizPlugin ? (
                       <img
-                        alt="Histogram"
+                        alt={vizOverview.displayName}
                         style={{ height: '100%', width: '100%' }}
                         src={vizPlugin.selectorIcon}
                       />
@@ -385,7 +385,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
   } = props;
   const history = useHistory();
   const viz = computation.visualizations.find((v) => v.visualizationId === id);
-  const vizPugin = viz && visualizationPlugins[viz.descriptor.type];
+  const vizPlugin = viz && visualizationPlugins[viz.descriptor.type];
   const overviews = useMemo(
     () =>
       groupBy(visualizationsOverview, (v) =>
@@ -445,7 +445,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
     [updateVisualizations, id]
   );
   if (viz == null) return <div>Visualization not found.</div>;
-  if (vizPugin == null) return <div>Visualization type not implemented.</div>;
+  if (vizPlugin == null) return <div>Visualization type not implemented.</div>;
 
   const { computationId } = computation;
   const plugin = plugins[computation.descriptor.type] ?? undefined;
@@ -528,7 +528,7 @@ function FullScreenVisualization(props: Props & { id: string }) {
         <ContentError>Visualization not found.</ContentError>
       ) : computation == null ? (
         <ContentError>Computation not found.</ContentError>
-      ) : vizPugin == null ? (
+      ) : vizPlugin == null ? (
         <ContentError>
           <>Visualization type not implemented: {viz.descriptor.type}</>
         </ContentError>
@@ -563,8 +563,8 @@ function FullScreenVisualization(props: Props & { id: string }) {
               addNewComputation={() => null}
             />
           )}
-          <vizPugin.fullscreenComponent
-            options={vizPugin.options}
+          <vizPlugin.fullscreenComponent
+            options={vizPlugin.options}
             dataElementConstraints={constraints}
             dataElementDependencyOrder={dataElementDependencyOrder}
             visualization={viz}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -299,11 +299,11 @@ function NewVisualizationPicker(props: Props) {
           [(viz) => (viz.name && visualizationPlugins[viz.name] ? 1 : 0)],
           ['desc']
         ).map((vizOverview, index) => {
-          const vizType = visualizationPlugins[vizOverview.name!];
+          const vizPlugin = visualizationPlugins[vizOverview.name!];
           const disabled =
-            vizType == null ||
-            (vizType.isEnabledInPicker != null &&
-              vizType.isEnabledInPicker({ geoConfigs }) === false);
+            vizPlugin == null ||
+            (vizPlugin.isEnabledInPicker != null &&
+              vizPlugin.isEnabledInPicker({ geoConfigs }) === false);
           // we could in future pass other study metadata, variable constraints, etc to isEnabledInPicker()
           return (
             <div
@@ -327,18 +327,18 @@ function NewVisualizationPicker(props: Props) {
                           displayName: 'Unnamed visualization',
                           descriptor: {
                             type: vizOverview.name!,
-                            configuration: vizType?.createDefaultConfig(),
+                            configuration: vizPlugin?.createDefaultConfig(),
                           },
                         })
                       );
                       history.replace(`../${computationId}/${visualizationId}`);
                     }}
                   >
-                    {vizType ? (
+                    {vizPlugin ? (
                       <img
                         alt="Histogram"
                         style={{ height: '100%', width: '100%' }}
-                        src={vizType.selectorIcon}
+                        src={vizPlugin.selectorIcon}
                       />
                     ) : (
                       <PlaceholderIcon name={vizOverview.name} />
@@ -352,8 +352,8 @@ function NewVisualizationPicker(props: Props) {
                     ?.split(/(, )/g)
                     .map((str) => (str === ', ' ? <br /> : str))}
                 </div>
-                {vizType == null && <i>(Coming soon!)</i>}
-                {vizType != null && disabled && (
+                {vizPlugin == null && <i>(Coming soon!)</i>}
+                {vizPlugin != null && disabled && (
                   <i>(Not applicable to this study)</i>
                 )}
               </div>

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -36,7 +36,7 @@ import { PlotLayout } from '../../layouts/PlotLayout';
 
 import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
-import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
+import { VisualizationProps } from '../VisualizationTypes';
 
 import bar from './selectorIcons/bar.svg';
 // import axis label unit util
@@ -73,6 +73,7 @@ import Notification from '@veupathdb/components/lib/components/widgets//Notifica
 import Button from '@veupathdb/components/lib/components/widgets/Button';
 import { useDefaultDependentAxisRange } from '../../../hooks/computeDefaultDependentAxisRange';
 import { useVizConfig } from '../../../hooks/visualizations';
+import { createVisualizationPlugin } from '../VisualizationPlugin';
 
 // export
 export type BarplotDataWithStatistics = (
@@ -97,11 +98,11 @@ const modalPlotContainerStyles = {
   margin: 'auto',
 };
 
-export const barplotVisualization: VisualizationType = {
+export const barplotVisualization = createVisualizationPlugin({
   selectorComponent: SelectorComponent,
   fullscreenComponent: FullscreenComponent,
   createDefaultConfig: createDefaultConfig,
-};
+});
 
 function SelectorComponent() {
   return (

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -102,16 +102,10 @@ const modalPlotContainerStyles = {
 };
 
 export const barplotVisualization = createVisualizationPlugin({
-  selectorComponent: SelectorComponent,
+  selectorIcon: bar,
   fullscreenComponent: FullscreenComponent,
   createDefaultConfig: createDefaultConfig,
 });
-
-function SelectorComponent() {
-  return (
-    <img alt="Bar plot" style={{ height: '100%', width: '100%' }} src={bar} />
-  );
-}
 
 function FullscreenComponent(props: VisualizationProps) {
   return <BarplotViz {...props} />;

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -10,7 +10,6 @@ import LabelledGroup from '@veupathdb/components/lib/components/widgets/Labelled
 import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
 import Switch from '@veupathdb/components/lib/components/widgets/Switch';
 
-import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import * as t from 'io-ts';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import PluginError from '../PluginError';
@@ -22,9 +21,13 @@ import DataClient, {
 } from '../../../api/DataClient';
 
 import { usePromise } from '../../../hooks/promise';
-import { useFindEntityAndVariable } from '../../../hooks/study';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
-import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
+import {
+  useDataClient,
+  useStudyMetadata,
+  useFindEntityAndVariable,
+  useStudyEntities,
+} from '../../../hooks/workspace';
 import { Filter } from '../../../types/filter';
 import { Variable } from '../../../types/study';
 import { VariableDescriptor } from '../../../types/variable';
@@ -161,11 +164,7 @@ function BarplotViz(props: VisualizationProps) {
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
-  const entities = useMemo(
-    () =>
-      Array.from(preorder(studyMetadata.rootEntity, (e) => e.children || [])),
-    [studyMetadata]
-  );
+  const entities = useStudyEntities();
   const dataClient: DataClient = useDataClient();
 
   // use useVizConfig hook
@@ -240,7 +239,7 @@ function BarplotViz(props: VisualizationProps) {
     'checkedLegendItems'
   );
 
-  const findEntityAndVariable = useFindEntityAndVariable(entities);
+  const findEntityAndVariable = useFindEntityAndVariable();
   const {
     variable,
     entity,

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -125,16 +125,10 @@ interface Options {
 }
 
 export const boxplotVisualization = createVisualizationPlugin({
-  selectorComponent: SelectorComponent,
+  selectorIcon: box,
   fullscreenComponent: FullscreenComponent,
   createDefaultConfig: createDefaultConfig,
 });
-
-function SelectorComponent() {
-  return (
-    <img alt="Box plot" style={{ height: '100%', width: '100%' }} src={box} />
-  );
-}
 
 function FullscreenComponent(props: VisualizationProps<Options>) {
   return <BoxplotViz {...props} />;

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -36,7 +36,17 @@ import { BirdsEyeView } from '../../BirdsEyeView';
 import { PlotLayout } from '../../layouts/PlotLayout';
 import PluginError from '../PluginError';
 
-import { at, groupBy, mapValues, size, head, map, values, keys } from 'lodash';
+import {
+  at,
+  groupBy,
+  mapValues,
+  size,
+  head,
+  map,
+  values,
+  keys,
+  pick,
+} from 'lodash';
 // import axis label unit util
 import { variableDisplayWithUnit } from '../../../utils/variable-display';
 import {
@@ -76,6 +86,7 @@ import { findEntityAndVariable as findCollectionVariableEntityAndVariable } from
 // type of computedVariableMetadata for computation apps such as alphadiv and abundance
 import { ComputedVariableMetadata } from '../../../api/DataClient/types';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
+import { useFindOutputEntity } from '../../../hooks/findOutputEntity';
 
 type BoxplotData = { series: BoxplotSeries };
 // type of computedVariableMetadata for computation apps such as alphadiv and abundance
@@ -277,9 +288,12 @@ function BoxplotViz(props: VisualizationProps<Options>) {
   // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams
   // Abundance boxplots already know their entity, x, and y vars. If we're in the abundance app, set
   // the output entity here so that the boxplot can appear on load.
-  const outputEntityId =
-    computedYAxisDetails?.entityId ?? vizConfig.yAxisVariable?.entityId;
-  const outputEntity = entities.find((e) => e.id === outputEntityId);
+  const outputEntity = useFindOutputEntity(
+    dataElementDependencyOrder,
+    vizConfig,
+    'yAxisVariable',
+    computedYAxisDetails?.entityId
+  );
 
   // add to support both alphadiv and abundance
   const data = usePromise(
@@ -311,7 +325,7 @@ function BoxplotViz(props: VisualizationProps<Options>) {
         studyId,
         filters,
         config: {
-          outputEntityId,
+          outputEntityId: outputEntity.id,
           // post options: 'all', 'outliers'
           points: 'outliers',
           mean: 'TRUE',

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -2,7 +2,6 @@
 import Boxplot, { BoxplotProps } from '@veupathdb/components/lib/plots/Boxplot';
 import FacetedBoxplot from '@veupathdb/components/lib/plots/facetedPlots/FacetedBoxplot';
 
-import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import * as t from 'io-ts';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 
@@ -10,7 +9,10 @@ import { useCallback, useMemo, useState, useEffect } from 'react';
 import DataClient, { BoxplotResponse } from '../../../api/DataClient';
 
 import { usePromise } from '../../../hooks/promise';
-import { useFindEntityAndVariable } from '../../../hooks/study';
+import {
+  useFindEntityAndVariable,
+  useStudyEntities,
+} from '../../../hooks/workspace';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
 import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
 import { VariableDescriptor } from '../../../types/variable';
@@ -159,11 +161,7 @@ function BoxplotViz(props: VisualizationProps<Options>) {
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
-  const entities = useMemo(
-    () =>
-      Array.from(preorder(studyMetadata.rootEntity, (e) => e.children || [])),
-    [studyMetadata]
-  );
+  const entities = useStudyEntities();
   const dataClient: DataClient = useDataClient();
 
   const [vizConfig, updateVizConfig] = useVizConfig(
@@ -203,7 +201,7 @@ function BoxplotViz(props: VisualizationProps<Options>) {
     [updateVizConfig]
   );
 
-  const findEntityAndVariable = useFindEntityAndVariable(entities);
+  const findEntityAndVariable = useFindEntityAndVariable();
 
   const providedXAxisVariable = options?.getXAxisVariable?.(
     computation.descriptor.configuration

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -53,7 +53,7 @@ import { BirdsEyeView } from '../../BirdsEyeView';
 import { PlotLayout } from '../../layouts/PlotLayout';
 import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
-import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
+import { VisualizationProps } from '../VisualizationTypes';
 import histogram from './selectorIcons/histogram.svg';
 // import axis label unit util
 import { variableDisplayWithUnit } from '../../../utils/variable-display';
@@ -99,6 +99,7 @@ import { UIState } from '../../filter/HistogramFilter';
 import { useDefaultIndependentAxisRange } from '../../../hooks/computeDefaultIndependentAxisRange';
 import { useDefaultDependentAxisRange } from '../../../hooks/computeDefaultDependentAxisRange';
 import { useVizConfig } from '../../../hooks/visualizations';
+import { createVisualizationPlugin } from '../VisualizationPlugin';
 
 export type HistogramDataWithCoverageStatistics = (
   | HistogramData
@@ -124,11 +125,11 @@ const modalPlotContainerStyles = {
   margin: 'auto',
 };
 
-export const histogramVisualization: VisualizationType = {
+export const histogramVisualization = createVisualizationPlugin({
   selectorComponent: SelectorComponent,
   fullscreenComponent: HistogramViz,
   createDefaultConfig: createDefaultConfig,
-};
+});
 
 function SelectorComponent() {
   return (

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -130,20 +130,10 @@ const modalPlotContainerStyles = {
 };
 
 export const histogramVisualization = createVisualizationPlugin({
-  selectorComponent: SelectorComponent,
+  selectorIcon: histogram,
   fullscreenComponent: HistogramViz,
   createDefaultConfig: createDefaultConfig,
 });
-
-function SelectorComponent() {
-  return (
-    <img
-      alt="Histogram"
-      style={{ height: '100%', width: '100%' }}
-      src={histogram}
-    />
-  );
-}
 
 function createDefaultConfig(): HistogramConfig {
   return {

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -38,7 +38,12 @@ import {
 } from '../../../api/DataClient';
 import DataClient from '../../../api/DataClient';
 import { PromiseHookState, usePromise } from '../../../hooks/promise';
-import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
+import {
+  useDataClient,
+  useStudyMetadata,
+  useFindEntityAndVariable,
+  useStudyEntities,
+} from '../../../hooks/workspace';
 import { Filter } from '../../../types/filter';
 import {
   DateVariable,
@@ -66,7 +71,6 @@ import {
   variablesAreUnique,
   nonUniqueWarning,
 } from '../../../utils/visualization';
-import { useFindEntityAndVariable } from '../../../hooks/study';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
 // import variable's metadata-based independent axis range utils
 import { VariablesByInputName } from '../../../utils/data-element-constraints';
@@ -190,11 +194,7 @@ function HistogramViz(props: VisualizationProps) {
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
-  const entities = useMemo(
-    () =>
-      Array.from(preorder(studyMetadata.rootEntity, (e) => e.children || [])),
-    [studyMetadata]
-  );
+  const entities = useStudyEntities();
   const dataClient: DataClient = useDataClient();
 
   const [vizConfig, updateVizConfig] = useVizConfig(
@@ -295,7 +295,7 @@ function HistogramViz(props: VisualizationProps) {
     'checkedLegendItems'
   );
 
-  const findEntityAndVariable = useFindEntityAndVariable(entities);
+  const findEntityAndVariable = useFindEntityAndVariable();
 
   const { xAxisVariable, outputEntity, valueType } = useMemo(() => {
     const { entity, variable } =

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -141,19 +141,10 @@ interface LinePlotDataWithCoverage extends CoverageStatistics {
 type LinePlotDataResponse = LineplotResponse;
 
 export const lineplotVisualization = createVisualizationPlugin({
-  selectorComponent: SelectorComponent,
+  selectorIcon: line,
   fullscreenComponent: LineplotViz,
   createDefaultConfig: createDefaultConfig,
 });
-
-// this needs a handling of text/image for scatter, line, and density plots
-function SelectorComponent() {
-  const src = line;
-
-  return (
-    <img alt="Line plot" style={{ height: '100%', width: '100%' }} src={src} />
-  );
-}
 
 // Display names to internal names
 const valueSpecLookup: Record<

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -27,7 +27,7 @@ import { PlotLayout } from '../../layouts/PlotLayout';
 
 import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
-import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
+import { VisualizationProps } from '../VisualizationTypes';
 
 import Switch from '@veupathdb/components/lib/components/widgets/Switch';
 import line from './selectorIcons/line.svg';
@@ -107,6 +107,7 @@ import Notification from '@veupathdb/components/lib/components/widgets//Notifica
 import Button from '@veupathdb/components/lib/components/widgets/Button';
 import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
 import { UIState } from '../../filter/HistogramFilter';
+import { createVisualizationPlugin } from '../VisualizationPlugin';
 
 const plotContainerStyles = {
   width: 750,
@@ -137,11 +138,11 @@ interface LinePlotDataWithCoverage extends CoverageStatistics {
 // define LinePlotDataResponse
 type LinePlotDataResponse = LineplotResponse;
 
-export const lineplotVisualization: VisualizationType = {
+export const lineplotVisualization = createVisualizationPlugin({
   selectorComponent: SelectorComponent,
   fullscreenComponent: LineplotViz,
   createDefaultConfig: createDefaultConfig,
-};
+});
 
 // this needs a handling of text/image for scatter, line, and density plots
 function SelectorComponent() {

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -3,7 +3,6 @@ import LinePlot, {
   LinePlotProps,
 } from '@veupathdb/components/lib/plots/LinePlot';
 
-import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import * as t from 'io-ts';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 
@@ -13,9 +12,13 @@ import DataClient, {
 } from '../../../api/DataClient';
 
 import { usePromise } from '../../../hooks/promise';
-import { useFindEntityAndVariable } from '../../../hooks/study';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
-import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
+import {
+  useDataClient,
+  useStudyMetadata,
+  useFindEntityAndVariable,
+  useStudyEntities,
+} from '../../../hooks/workspace';
 import { useFindOutputEntity } from '../../../hooks/findOutputEntity';
 import { Filter } from '../../../types/filter';
 
@@ -82,7 +85,6 @@ import { gray } from '../colors';
 import { ColorPaletteDefault } from '@veupathdb/components/lib/types/plots/addOns';
 // import variable's metadata-based independent axis range utils
 import { defaultIndependentAxisRange } from '../../../utils/default-independent-axis-range';
-import { axisRangeMargin } from '../../../utils/axis-range-margin';
 import { VariablesByInputName } from '../../../utils/data-element-constraints';
 import PluginError from '../PluginError';
 import PlotLegend, {
@@ -219,11 +221,7 @@ function LineplotViz(props: VisualizationProps) {
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
-  const entities = useMemo(
-    () =>
-      Array.from(preorder(studyMetadata.rootEntity, (e) => e.children || [])),
-    [studyMetadata]
-  );
+  const entities = useStudyEntities();
   const dataClient: DataClient = useDataClient();
 
   const [vizConfig, updateVizConfig] = useVizConfig(
@@ -234,7 +232,7 @@ function LineplotViz(props: VisualizationProps) {
   );
 
   // moved the location of this findEntityAndVariable
-  const findEntityAndVariable = useFindEntityAndVariable(entities);
+  const findEntityAndVariable = useFindEntityAndVariable();
 
   const {
     xAxisVariable,
@@ -410,8 +408,7 @@ function LineplotViz(props: VisualizationProps) {
   const outputEntity = useFindOutputEntity(
     dataElementDependencyOrder,
     vizConfig,
-    'yAxisVariable',
-    entities
+    'yAxisVariable'
   );
 
   const data = usePromise(

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -31,9 +31,13 @@ import { FormControl, Select, MenuItem, InputLabel } from '@material-ui/core';
 
 // viz-related imports
 import { PlotLayout } from '../../layouts/PlotLayout';
-import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
+import {
+  useDataClient,
+  useFindEntityAndVariable,
+  useStudyEntities,
+  useStudyMetadata,
+} from '../../../hooks/workspace';
 import { useMemo, useCallback, useState, useEffect } from 'react';
-import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import DataClient, {
   MapMarkersRequestParams,
   MapMarkersOverlayRequestParams,
@@ -51,7 +55,6 @@ import PluginError from '../PluginError';
 import { VariableDescriptor } from '../../../types/variable';
 import { InputVariables } from '../InputVariables';
 import { VariablesByInputName } from '../../../utils/data-element-constraints';
-import { useFindEntityAndVariable } from '../../../hooks/study';
 import PlotLegend, {
   LegendItemsProps,
 } from '@veupathdb/components/lib/components/plotControls/PlotLegend';
@@ -162,11 +165,7 @@ function MapViz(props: VisualizationProps) {
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
-  const entities = useMemo(
-    () =>
-      Array.from(preorder(studyMetadata.rootEntity, (e) => e.children || [])),
-    [studyMetadata]
-  );
+  const entities = useStudyEntities();
   const dataClient: DataClient = useDataClient();
 
   const [vizConfig, updateVizConfig] = useVizConfig(
@@ -215,7 +214,7 @@ function MapViz(props: VisualizationProps) {
     );
   }, [vizConfig.geoEntityId, geoConfigs]);
 
-  const findEntityAndVariable = useFindEntityAndVariable(entities);
+  const findEntityAndVariable = useFindEntityAndVariable();
   const [outputEntity, xAxisVariable] = useMemo(() => {
     const geoEntity =
       vizConfig.geoEntityId !== null

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -72,21 +72,11 @@ import { createVisualizationPlugin } from '../VisualizationPlugin';
 const numContinuousBins = 8;
 
 export const mapVisualization = createVisualizationPlugin({
-  selectorComponent: SelectorComponent,
+  selectorIcon: map,
   fullscreenComponent: MapViz,
   createDefaultConfig: createDefaultConfig,
   isEnabledInPicker: isEnabledInPicker,
 });
-
-function SelectorComponent() {
-  return (
-    <img
-      alt="Geographic map"
-      style={{ height: '100%', width: '100%' }}
-      src={map}
-    />
-  );
-}
 
 function createDefaultConfig(): MapConfig {
   return {

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -1,7 +1,6 @@
 import {
   IsEnabledInPickerParams,
   VisualizationProps,
-  VisualizationType,
 } from '../VisualizationTypes';
 import map from './selectorIcons/map.svg';
 import * as t from 'io-ts';
@@ -65,15 +64,16 @@ import { VariableCoverageTable } from '../../VariableCoverageTable';
 import { NumberVariable } from '../../../types/study';
 import { BinSpec, NumberRange } from '../../../types/general';
 import { useDefaultIndependentAxisRange } from '../../../hooks/computeDefaultIndependentAxisRange';
+import { createVisualizationPlugin } from '../VisualizationPlugin';
 
 const numContinuousBins = 8;
 
-export const mapVisualization: VisualizationType = {
+export const mapVisualization = createVisualizationPlugin({
   selectorComponent: SelectorComponent,
   fullscreenComponent: MapViz,
   createDefaultConfig: createDefaultConfig,
   isEnabledInPicker: isEnabledInPicker,
-};
+});
 
 function SelectorComponent() {
   return (

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -7,8 +7,6 @@ import {
   MosaicPlotData,
 } from '@veupathdb/components/lib/types/plots';
 import { ContingencyTable } from '@veupathdb/components/lib/components/ContingencyTable';
-// import { ErrorManagement } from '@veupathdb/components/lib/types/general';
-import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import * as t from 'io-ts';
 import _ from 'lodash';
 import DataClient, {
@@ -18,9 +16,13 @@ import DataClient, {
 } from '../../../api/DataClient';
 import { useCallback, useMemo, useState } from 'react';
 import { usePromise } from '../../../hooks/promise';
-import { useFindEntityAndVariable } from '../../../hooks/study';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
-import { useDataClient, useStudyMetadata } from '../../../hooks/workspace';
+import {
+  useDataClient,
+  useStudyMetadata,
+  useFindEntityAndVariable,
+  useStudyEntities,
+} from '../../../hooks/workspace';
 import { useFindOutputEntity } from '../../../hooks/findOutputEntity';
 import { Filter } from '../../../types/filter';
 import { VariableDescriptor } from '../../../types/variable';
@@ -180,11 +182,7 @@ function MosaicViz(props: Props) {
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
-  const entities = useMemo(
-    () =>
-      Array.from(preorder(studyMetadata.rootEntity, (e) => e.children || [])),
-    [studyMetadata]
-  );
+  const entities = useStudyEntities();
   const dataClient: DataClient = useDataClient();
 
   // set default tab to Mosaic in TabbedDisplay component
@@ -231,7 +229,7 @@ function MosaicViz(props: Props) {
     'showMissingness'
   );
 
-  const findEntityAndVariable = useFindEntityAndVariable(entities);
+  const findEntityAndVariable = useFindEntityAndVariable();
 
   const { xAxisVariable, yAxisVariable, facetVariable } = useMemo(() => {
     const xAxisVariable = findEntityAndVariable(vizConfig.xAxisVariable);
@@ -254,8 +252,7 @@ function MosaicViz(props: Props) {
   const outputEntity = useFindOutputEntity(
     dataElementDependencyOrder,
     vizConfig,
-    'xAxisVariable',
-    entities
+    'xAxisVariable'
   );
 
   const data = usePromise(

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -109,39 +109,19 @@ type TwoByTwoDataWithCoverage = (TwoByTwoData | FacetedData<TwoByTwoData>) &
   CoverageStatistics;
 
 export const contTableVisualization = createVisualizationPlugin({
-  selectorComponent: ContTableSelectorComponent,
+  selectorIcon: rxc,
   fullscreenComponent: ContTableFullscreenComponent,
   createDefaultConfig: createDefaultConfig,
 });
 
 export const twoByTwoVisualization = createVisualizationPlugin({
-  selectorComponent: TwoByTwoSelectorComponent,
+  selectorIcon: twoxtwo,
   fullscreenComponent: TwoByTwoFullscreenComponent,
   createDefaultConfig: createDefaultConfig,
 });
 
-function ContTableSelectorComponent() {
-  return (
-    <img
-      alt="RxC contingency table"
-      style={{ height: '100%', width: '100%' }}
-      src={rxc}
-    />
-  );
-}
-
 function ContTableFullscreenComponent(props: VisualizationProps) {
   return <MosaicViz {...props} />;
-}
-
-function TwoByTwoSelectorComponent() {
-  return (
-    <img
-      alt="2x2 contingency table"
-      style={{ height: '100%', width: '100%' }}
-      src={twoxtwo}
-    />
-  );
 }
 
 function TwoByTwoFullscreenComponent(props: VisualizationProps) {

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -30,7 +30,7 @@ import { VariableCoverageTable } from '../../VariableCoverageTable';
 import { PlotLayout } from '../../layouts/PlotLayout';
 import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
-import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
+import { VisualizationProps } from '../VisualizationTypes';
 import rxc from './selectorIcons/RxC.svg';
 import twoxtwo from './selectorIcons/2x2.svg';
 import { TabbedDisplay } from '@veupathdb/coreui';
@@ -51,6 +51,7 @@ import PluginError from '../PluginError';
 import { isFaceted } from '@veupathdb/components/lib/types/guards';
 import FacetedMosaicPlot from '@veupathdb/components/lib/plots/facetedPlots/FacetedMosaicPlot';
 import { useVizConfig } from '../../../hooks/visualizations';
+import { createVisualizationPlugin } from '../VisualizationPlugin';
 
 const plotContainerStyles = {
   width: 750,
@@ -105,17 +106,17 @@ type ContTableDataWithCoverage = (ContTableData | FacetedData<ContTableData>) &
 type TwoByTwoDataWithCoverage = (TwoByTwoData | FacetedData<TwoByTwoData>) &
   CoverageStatistics;
 
-export const contTableVisualization: VisualizationType = {
+export const contTableVisualization = createVisualizationPlugin({
   selectorComponent: ContTableSelectorComponent,
   fullscreenComponent: ContTableFullscreenComponent,
   createDefaultConfig: createDefaultConfig,
-};
+});
 
-export const twoByTwoVisualization: VisualizationType = {
+export const twoByTwoVisualization = createVisualizationPlugin({
   selectorComponent: TwoByTwoSelectorComponent,
   fullscreenComponent: TwoByTwoFullscreenComponent,
   createDefaultConfig: createDefaultConfig,
-};
+});
 
 function ContTableSelectorComponent() {
   return (

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -28,7 +28,11 @@ import { PlotLayout } from '../../layouts/PlotLayout';
 
 import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
-import { SelectorProps, VisualizationProps } from '../VisualizationTypes';
+import {
+  ComputedVariableDetails,
+  SelectorProps,
+  VisualizationProps,
+} from '../VisualizationTypes';
 
 import scatter from './selectorIcons/scatter.svg';
 
@@ -196,8 +200,9 @@ export const ScatterplotConfig = t.partial({
 });
 
 interface Options {
-  getYAxisVariable?(config: unknown): VariableDescriptor | undefined;
-  getYAxisLabel?(config: unknown): string | undefined;
+  getComputedYAxisDetails?(
+    config: unknown
+  ): ComputedVariableDetails | undefined;
   getOverlayVariable?(config: unknown): VariableDescriptor | undefined;
   getPlotSubtitle?(config: unknown): string | undefined;
   hideShowMissingnessToggle?: boolean;
@@ -234,7 +239,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     updateConfiguration
   );
 
-  const providedYAxisVariableDescriptor = options?.getYAxisVariable?.(
+  const computedYAxisDetails = options?.getComputedYAxisDetails?.(
     computation.descriptor.configuration
   );
   const providedOverlayVariableDescriptor = options?.getOverlayVariable?.(
@@ -364,8 +369,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
 
   // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams
   const outputEntityId =
-    providedYAxisVariableDescriptor?.entityId ||
-    vizConfig.yAxisVariable?.entityId;
+    computedYAxisDetails?.entityId || vizConfig.yAxisVariable?.entityId;
   const outputEntity = entities.find((e) => e.id === outputEntityId);
 
   const data = usePromise(
@@ -397,7 +401,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
       if (vizConfig.xAxisVariable == null || xAxisVariable == null)
         return undefined;
       else if (
-        providedYAxisVariableDescriptor == null &&
+        computedYAxisDetails == null &&
         (vizConfig.yAxisVariable == null || yAxisVariable == null)
       )
         return undefined;
@@ -801,7 +805,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
 
   const dependentAxisLabel =
     data?.value?.computedVariableMetadata?.displayName?.[0] ??
-    options?.getYAxisLabel?.(computation.descriptor.configuration) ??
+    computedYAxisDetails?.placeholderDisplayName ??
     variableDisplayWithUnit(yAxisVariable) ??
     'Y-axis';
 
@@ -992,7 +996,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
               name: 'yAxisVariable',
               label: 'Y-axis',
               role: 'axis',
-              readonlyValue: providedYAxisVariableDescriptor
+              readonlyValue: computedYAxisDetails
                 ? dependentAxisLabel
                 : undefined,
             },

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -466,14 +466,14 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
           response.completeCasesTable
         );
 
-      const overlayVocabulary =
-        response.scatterplot.config.computedVariableMetadata?.collectionVariable?.collectionVariableDetails?.map(
-          (variableDetails) => variableDetails.variableId
-        ) ??
-        fixLabelsForNumberVariables(
-          overlayVariable?.vocabulary,
-          overlayVariable
-        );
+      const overlayVocabulary = providedOverlayVariableDescriptor
+        ? response.scatterplot.config.computedVariableMetadata?.collectionVariable?.collectionVariableDetails?.map(
+            (variableDetails) => variableDetails.variableId
+          )
+        : fixLabelsForNumberVariables(
+            overlayVariable?.vocabulary,
+            overlayVariable
+          );
 
       const facetVocabulary = fixLabelsForNumberVariables(
         facetVariable?.vocabulary,

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -50,6 +50,7 @@ import {
   map,
   keys,
   uniqBy,
+  pick,
 } from 'lodash';
 // directly use RadioButtonGroup instead of ScatterPlotControls
 import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
@@ -117,6 +118,7 @@ import { ComputedVariableMetadata } from '../../../api/DataClient/types';
 // use Banner from CoreUI for showing message for no smoothing
 import Banner from '@veupathdb/coreui/dist/components/banners/Banner';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
+import { useFindOutputEntity } from '../../../hooks/findOutputEntity';
 
 const MAXALLOWEDDATAPOINTS = 100000;
 const SMOOTHEDMEANTEXT = 'Smoothed mean';
@@ -368,9 +370,12 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
   );
 
   // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams
-  const outputEntityId =
-    computedYAxisDetails?.entityId || vizConfig.yAxisVariable?.entityId;
-  const outputEntity = entities.find((e) => e.id === outputEntityId);
+  const outputEntity = useFindOutputEntity(
+    dataElementDependencyOrder,
+    vizConfig,
+    'yAxisVariable',
+    computedYAxisDetails?.entityId
+  );
 
   const data = usePromise(
     useCallback(async (): Promise<ScatterPlotDataWithCoverage | undefined> => {

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -25,11 +25,7 @@ import { PlotLayout } from '../../layouts/PlotLayout';
 
 import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
-import {
-  SelectorProps,
-  VisualizationProps,
-  VisualizationType,
-} from '../VisualizationTypes';
+import { SelectorProps, VisualizationProps } from '../VisualizationTypes';
 
 import scatter from './selectorIcons/scatter.svg';
 
@@ -119,6 +115,7 @@ import { findEntityAndVariable as findCollectionVariableEntityAndVariable } from
 import { ComputedVariableMetadata } from '../../../api/DataClient/types';
 // use Banner from CoreUI for showing message for no smoothing
 import Banner from '@veupathdb/coreui/dist/components/banners/Banner';
+import { createVisualizationPlugin } from '../VisualizationPlugin';
 
 const MAXALLOWEDDATAPOINTS = 100000;
 const SMOOTHEDMEANTEXT = 'Smoothed mean';
@@ -157,11 +154,11 @@ export interface ScatterPlotDataWithCoverage extends CoverageStatistics {
 // define ScatterPlotDataResponse
 type ScatterPlotDataResponse = ScatterplotResponse;
 
-export const scatterplotVisualization: VisualizationType = {
+export const scatterplotVisualization = createVisualizationPlugin({
   selectorComponent: SelectorComponent,
   fullscreenComponent: ScatterplotViz,
   createDefaultConfig: createDefaultConfig,
-};
+});
 
 function SelectorComponent({ name }: SelectorProps) {
   const src = scatter;

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -208,6 +208,7 @@ interface Options {
   getOverlayVariable?(config: unknown): VariableDescriptor | undefined;
   getPlotSubtitle?(config: unknown): string | undefined;
   hideShowMissingnessToggle?: boolean;
+  hideTrendlines?: boolean;
 }
 
 function ScatterplotViz(props: VisualizationProps<Options>) {
@@ -852,8 +853,6 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
         yAxisVariable?.type === 'date' ? 'Raw' : vizConfig.valueSpecConfig
       }
       onValueSpecChange={onValueSpecChange}
-      // send visualization.type here
-      vizType={visualization.descriptor.type}
       interactive={!isFaceted(data.value) ? true : false}
       showSpinner={filteredCounts.pending || data.pending}
       // add plotOptions to control the list of plot options
@@ -896,6 +895,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
       setTruncatedDependentAxisWarning={setTruncatedDependentAxisWarning}
       onIndependentAxisLogScaleChange={onIndependentAxisLogScaleChange}
       onDependentAxisLogScaleChange={onDependentAxisLogScaleChange}
+      allowTrendlines={!options?.hideTrendlines}
     />
   );
 
@@ -1103,7 +1103,6 @@ type ScatterplotWithControlsProps = Omit<ScatterPlotProps, 'data'> & {
   valueSpec: string | undefined;
   onValueSpecChange: (value: string) => void;
   updateThumbnail: (src: string) => void;
-  vizType: string;
   plotOptions: string[];
   // add disabledList
   disabledList: string[];
@@ -1127,6 +1126,7 @@ type ScatterplotWithControlsProps = Omit<ScatterPlotProps, 'data'> & {
   ) => void;
   onIndependentAxisLogScaleChange: (value: boolean) => void;
   onDependentAxisLogScaleChange: (value: boolean) => void;
+  allowTrendlines: boolean;
 };
 
 function ScatterplotWithControls({
@@ -1134,7 +1134,7 @@ function ScatterplotWithControls({
   // ScatterPlotControls: set initial value as 'raw' ('Raw')
   valueSpec = 'Raw',
   onValueSpecChange,
-  vizType,
+  allowTrendlines,
   // add plotOptions
   plotOptions,
   // add disabledList
@@ -1360,7 +1360,7 @@ function ScatterplotWithControls({
         />
       )}
       {/*  ScatterPlotControls: check vizType (only for scatterplot for now) */}
-      {vizType === 'scatterplot' && (
+      {allowTrendlines && (
         // use RadioButtonGroup directly instead of ScatterPlotControls
         <RadioButtonGroup
           label="Plot mode"

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -30,7 +30,6 @@ import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
 import {
   ComputedVariableDetails,
-  SelectorProps,
   VisualizationProps,
 } from '../VisualizationTypes';
 
@@ -158,22 +157,10 @@ export interface ScatterPlotDataWithCoverage extends CoverageStatistics {
 type ScatterPlotDataResponse = ScatterplotResponse;
 
 export const scatterplotVisualization = createVisualizationPlugin({
-  selectorComponent: SelectorComponent,
+  selectorIcon: scatter,
   fullscreenComponent: ScatterplotViz,
   createDefaultConfig: createDefaultConfig,
 });
-
-function SelectorComponent({ name }: SelectorProps) {
-  const src = scatter;
-
-  return (
-    <img
-      alt="Scatter plot"
-      style={{ height: '100%', width: '100%' }}
-      src={src}
-    />
-  );
-}
 
 function createDefaultConfig(): ScatterplotConfig {
   return {

--- a/src/lib/core/components/visualizations/implementations/TestVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/TestVisualization.tsx
@@ -1,15 +1,12 @@
 import { createVisualizationPlugin } from '../VisualizationPlugin';
 import { VisualizationProps } from '../VisualizationTypes';
+import selectorIcon from './selectorIcons/box.svg';
 
 export const testVisualization = createVisualizationPlugin({
-  selectorComponent: SelectorComponent,
+  selectorIcon,
   fullscreenComponent: FullscreenComponent,
   createDefaultConfig: () => undefined,
 });
-
-function SelectorComponent() {
-  return <div>Test in selector</div>;
-}
 
 function FullscreenComponent(props: VisualizationProps) {
   return <div>Test in fullscreen</div>;

--- a/src/lib/core/components/visualizations/implementations/TestVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/TestVisualization.tsx
@@ -1,10 +1,11 @@
-import { VisualizationProps, VisualizationType } from '../VisualizationTypes';
+import { createVisualizationPlugin } from '../VisualizationPlugin';
+import { VisualizationProps } from '../VisualizationTypes';
 
-export const testVisualization: VisualizationType = {
+export const testVisualization = createVisualizationPlugin({
   selectorComponent: SelectorComponent,
   fullscreenComponent: FullscreenComponent,
   createDefaultConfig: () => undefined,
-};
+});
 
 function SelectorComponent() {
   return <div>Test in selector</div>;

--- a/src/lib/core/hooks/findOutputEntity.ts
+++ b/src/lib/core/hooks/findOutputEntity.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { VariableDescriptor } from '../types/variable';
-import { StudyEntity } from '../types/study';
-import { useFindEntityAndVariable } from './study';
+import { useFindEntityAndVariable } from './workspace';
 // add NumberRange
 import { NumberOrDateRange } from '../types/general';
 
@@ -19,10 +18,9 @@ export function useFindOutputEntity(
     | NumberOrDateRange
     | undefined
   >,
-  defaultVariableName: string,
-  entities: StudyEntity[]
+  defaultVariableName: string
 ) {
-  const findEntityAndVariable = useFindEntityAndVariable(entities);
+  const findEntityAndVariable = useFindEntityAndVariable();
   return useMemo(() => {
     const variableName =
       dataElementDependencyOrder == null ||

--- a/src/lib/core/hooks/findOutputEntity.ts
+++ b/src/lib/core/hooks/findOutputEntity.ts
@@ -1,39 +1,41 @@
 import { useMemo } from 'react';
 import { VariableDescriptor } from '../types/variable';
-import { useFindEntityAndVariable } from './workspace';
-// add NumberRange
-import { NumberOrDateRange } from '../types/general';
+import { useFindEntityAndVariable, useStudyEntities } from './workspace';
 
+/**
+ * Find the output entity, given variable details of a visualization.
+ *
+ * @param dataElementDependencyOrder Describes the dependency order of variable selections.
+ * @param vizConfig Visualization configuration.
+ * @param fallbackVariableName Fallback variable name, if `dataElementDependencyOrder` is empty.
+ * @param providedEntityId Provided entity id, in cases where an app provides the output entity.
+ * @returns
+ */
 export function useFindOutputEntity(
   dataElementDependencyOrder: string[] | undefined,
-  // need to add string at Record's Type due to valueSpecConfig
-  dataElementVariables: Record<
-    string,
-    // add NumberRange
-    | VariableDescriptor
-    | string
-    | number // for binWidth at LineplotViz
-    | boolean
-    | string[]
-    | NumberOrDateRange
-    | undefined
-  >,
-  defaultVariableName: string
+  vizConfig: Record<string, unknown>,
+  fallbackVariableName: string,
+  providedEntityId?: string
 ) {
   const findEntityAndVariable = useFindEntityAndVariable();
+  const entities = useStudyEntities();
   return useMemo(() => {
+    if (providedEntityId)
+      return entities.find((e) => e.id === providedEntityId);
     const variableName =
-      dataElementDependencyOrder == null ||
-      dataElementDependencyOrder.length === 0
-        ? defaultVariableName
-        : dataElementDependencyOrder[0];
-    const variable = dataElementVariables[variableName];
-    // need to clarify 'as VariableDescriptor' due to Record Type's string (valueSpecConfig)
-    return findEntityAndVariable(variable as VariableDescriptor)?.entity;
+      dataElementDependencyOrder?.[0] ?? fallbackVariableName;
+    const variable = vizConfig[variableName];
+    // This could be more defensive and throw an error if variable is defined
+    // but is not a VariableDescriptor.
+    return VariableDescriptor.is(variable)
+      ? findEntityAndVariable(variable)?.entity
+      : undefined;
   }, [
+    providedEntityId,
+    entities,
     dataElementDependencyOrder,
-    dataElementVariables,
-    defaultVariableName,
+    fallbackVariableName,
+    vizConfig,
     findEntityAndVariable,
   ]);
 }

--- a/src/lib/core/hooks/study.ts
+++ b/src/lib/core/hooks/study.ts
@@ -211,38 +211,3 @@ export function useStudyMetadata(datasetId: string, client: SubsettingClient) {
     [datasetId, client]
   );
 }
-
-export function useFindEntityAndVariable(entities: StudyEntity[]) {
-  return useCallback(
-    (variable?: VariableDescriptor) => {
-      const entAndVar = findEntityAndVariable(entities, variable);
-      if (entAndVar == null || entAndVar.variable.type === 'category') return;
-      return entAndVar as {
-        entity: StudyEntity;
-        variable: Variable;
-      };
-    },
-    [entities]
-  );
-}
-
-export function useCollectionVariables(entity: StudyEntity) {
-  return useMemo(() => findCollections(entity).flat(), [entity]);
-}
-
-/**
- * Return an array of StudyEntities.
- *
- * @param rootEntity The entity in the entity hierarchy. All entities at this level and
- * down will be returned in a flattened array.
- *
- * @returns Essentially, this will provide you will an array of entities in a flattened structure.
- * Technically, the hierarchical structure is still embedded in each entity, but all of the
- * entities are presented as siblings in the array.
- */
-export function useStudyEntities(rootEntity: StudyEntity) {
-  return useMemo(
-    () => Array.from(preorder(rootEntity, (e) => e.children ?? [])),
-    [rootEntity]
-  );
-}

--- a/src/lib/core/hooks/workspace.ts
+++ b/src/lib/core/hooks/workspace.ts
@@ -6,8 +6,21 @@ import {
   MakeVariableLink,
   WorkspaceContext,
 } from '../context/WorkspaceContext';
-import { StudyMetadata, StudyRecord, StudyRecordClass } from '../types/study';
+import {
+  StudyEntity,
+  StudyMetadata,
+  StudyRecord,
+  StudyRecordClass,
+  Variable,
+} from '../types/study';
 import { VariableDescriptor } from '../types/variable';
+import { useCallback, useMemo } from 'react';
+import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
+import {
+  entityTreeToArray,
+  findCollections,
+  findEntityAndVariable,
+} from '../utils/study-metadata';
 
 /** Return the study identifier and a hierarchy of the study entities. */
 export function useStudyMetadata(): StudyMetadata {
@@ -33,6 +46,47 @@ export function useMakeVariableLink(): MakeVariableLink {
     useNonNullableContext(WorkspaceContext).makeVariableLink ??
     defaultMakeVariableLink
   );
+}
+export function useFindEntityAndVariable() {
+  const entities = useStudyEntities();
+  return useCallback(
+    (variable?: VariableDescriptor) => {
+      const entAndVar = findEntityAndVariable(entities, variable);
+      if (entAndVar == null || entAndVar.variable.type === 'category') return;
+      return entAndVar as {
+        entity: StudyEntity;
+        variable: Variable;
+      };
+    },
+    [entities]
+  );
+}
+
+export function useEntityAndVariable(descriptor?: VariableDescriptor) {
+  const entities = useStudyEntities();
+  return useMemo(
+    () => descriptor && findEntityAndVariable(entities, descriptor),
+    [descriptor, entities]
+  );
+}
+
+export function useCollectionVariables(entity: StudyEntity) {
+  return useMemo(() => findCollections(entity).flat(), [entity]);
+}
+
+/**
+ * Return an array of StudyEntities.
+ *
+ * @param rootEntity The entity in the entity hierarchy. All entities at this level and
+ * down will be returned in a flattened array.
+ *
+ * @returns Essentially, this will provide you will an array of entities in a flattened structure.
+ * Technically, the hierarchical structure is still embedded in each entity, but all of the
+ * entities are presented as siblings in the array.
+ */
+export function useStudyEntities() {
+  const { rootEntity } = useStudyMetadata();
+  return useMemo(() => entityTreeToArray(rootEntity), [rootEntity]);
 }
 
 function defaultMakeVariableLink({

--- a/src/lib/core/types/visualization.ts
+++ b/src/lib/core/types/visualization.ts
@@ -49,24 +49,6 @@ export const Visualization = intersection([
   }),
 ]);
 
-/**
- * Type and configuration of the app object stored in user's analysis
- */
-// alphadiv abundance: add NullType here to remove "null as any" at ZeroConfiguration
-export type ComputationConfiguration = TypeOf<
-  typeof ComputationConfiguration | NullType
->;
-export const ComputationConfiguration = intersection([
-  type({
-    name: string,
-    collectionVariable: VariableDescriptor,
-  }),
-  partial({
-    alphaDivMethod: string,
-    rankingMethod: string,
-  }),
-]);
-
 // alphadiv abundance
 export type ComputationDescriptor = TypeOf<typeof ComputationDescriptor>;
 export const ComputationDescriptor = type({

--- a/src/lib/core/utils/study-metadata.ts
+++ b/src/lib/core/utils/study-metadata.ts
@@ -8,6 +8,10 @@ import {
 import { VariableDescriptor } from '../types/variable';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 
+export function entityTreeToArray(rootEntity: StudyEntity) {
+  return Array.from(preorder(rootEntity, (e) => e.children ?? []));
+}
+
 export interface EntityAndVariable {
   entity: StudyEntity;
   variable: VariableTreeNode;

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -13,12 +13,12 @@ import {
 import { cx } from './Utils';
 
 // Definitions
-import { Status } from '../core';
+import { Status, useStudyEntities } from '../core';
 
 // Hooks
 import { useEntityCounts } from '../core/hooks/entityCounts';
 import { usePrevious } from '../core/hooks/previousValue';
-import { isStubEntity, useStudyEntities } from '../core/hooks/study';
+import { isStubEntity } from '../core/hooks/study';
 import { useSetDocumentTitle } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { useStudyMetadata, useStudyRecord } from '../core';
 import { useGeoConfig } from '../core/hooks/geoConfig';
@@ -128,7 +128,7 @@ export function AnalysisPanel({
   const filters = analysis?.descriptor.subset.descriptor;
   const filteredCounts = useEntityCounts(filters);
   const studyMetadata = useStudyMetadata();
-  const entities = useStudyEntities(studyMetadata.rootEntity);
+  const entities = useStudyEntities();
   const filteredEntities = uniq(filters?.map((f) => f.entityId));
   const geoConfigs = useGeoConfig(entities);
   const location = useLocation();

--- a/src/lib/workspace/ComputationRoute.tsx
+++ b/src/lib/workspace/ComputationRoute.tsx
@@ -106,7 +106,7 @@ export function ComputationRoute(props: Props) {
                       {...props}
                       computationId={singleAppComputationId}
                       computationAppOverview={apps[0]}
-                      visualizationTypes={plugin.visualizationTypes}
+                      visualizationPlugins={plugin.visualizationPlugins}
                       isSingleAppMode={!!singleAppMode}
                     />
                   );
@@ -154,7 +154,9 @@ export function ComputationRoute(props: Props) {
                                   {...props}
                                   computationId={c.computationId}
                                   computationAppOverview={app}
-                                  visualizationTypes={plugin.visualizationTypes}
+                                  visualizationPlugins={
+                                    plugin.visualizationPlugins
+                                  }
                                   baseUrl={`${url}/${c.computationId}`}
                                   isSingleAppMode={!!singleAppMode}
                                 />
@@ -193,7 +195,7 @@ export function ComputationRoute(props: Props) {
                       {...props}
                       computationId={routeProps.match.params.id}
                       computationAppOverview={app}
-                      visualizationTypes={plugin.visualizationTypes}
+                      visualizationPlugins={plugin.visualizationPlugins}
                       baseUrl={`${url}/${computation?.computationId}`}
                       isSingleAppMode={!!singleAppMode}
                     />

--- a/src/lib/workspace/DefaultVariableRedirect.tsx
+++ b/src/lib/workspace/DefaultVariableRedirect.tsx
@@ -1,4 +1,3 @@
-import { useStudyMetadata } from '../core';
 import { Redirect, useRouteMatch } from 'react-router';
 import { findFirstVariable } from './Utils';
 import {
@@ -6,7 +5,7 @@ import {
   useFieldTree,
   useFlattenedFields,
 } from '../core/components/variableTrees/hooks';
-import { useStudyEntities } from '../core/hooks/study';
+import { useStudyEntities } from '../core/hooks/workspace';
 
 interface Props {
   entityId?: string;
@@ -15,8 +14,7 @@ interface Props {
 export function DefaultVariableRedirect(props: Props) {
   const { entityId } = props;
   const { url } = useRouteMatch();
-  const studyMetadata = useStudyMetadata();
-  const entities = useStudyEntities(studyMetadata.rootEntity);
+  const entities = useStudyEntities();
   const flattenedFields = useFlattenedFields(entities, 'variableTree');
   const fieldTree = useFieldTree(flattenedFields);
   const featuredFields = useFeaturedFieldsFromTree(fieldTree);

--- a/src/lib/workspace/DownloadTab/index.tsx
+++ b/src/lib/workspace/DownloadTab/index.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState, useCallback } from 'react';
 
-import { AnalysisState, useStudyMetadata, useStudyRecord } from '../../core';
+import {
+  AnalysisState,
+  useStudyEntities,
+  useStudyMetadata,
+  useStudyRecord,
+} from '../../core';
 
 // Definitions
 import { EntityCounts } from '../../core/hooks/entityCounts';
@@ -11,7 +16,7 @@ import MySubset from './MySubset';
 import CurrentRelease from './CurrentRelease';
 
 // Hooks
-import { useStudyEntities, useWdkStudyReleases } from '../../core/hooks/study';
+import { useWdkStudyReleases } from '../../core/hooks/study';
 import { useEnhancedEntityData } from './hooks/useEnhancedEntityData';
 import { DownloadTabStudyReleases } from './types';
 import PastRelease from './PastRelease';
@@ -36,7 +41,7 @@ export default function DownloadTab({
 }: DownloadsTabProps) {
   const studyMetadata = useStudyMetadata();
   const studyRecord = useStudyRecord();
-  const entities = useStudyEntities(studyMetadata.rootEntity);
+  const entities = useStudyEntities();
   const enhancedEntityData = useEnhancedEntityData(
     entities,
     totalCounts,

--- a/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsettingDataGridModal.tsx
@@ -561,7 +561,7 @@ export default function SubsettingDataGridModal({
               // NOTE: We are purposely removing all child entities here because
               // we only want a user to be able to select variables from a single
               // entity at a time.
-              rootEntity={{ ...currentEntity, children: [] }}
+              filterEntity={(e) => e.id === currentEntity.id}
               scope="download"
               selectedVariableDescriptors={
                 selectedVariableDescriptorsWithMergeKeys

--- a/src/lib/workspace/Subsetting/index.tsx
+++ b/src/lib/workspace/Subsetting/index.tsx
@@ -1,12 +1,7 @@
 import { useMemo } from 'react';
 import { Redirect, useHistory } from 'react-router';
 
-import {
-  MultiFilterVariable,
-  useMakeVariableLink,
-  useStudyMetadata,
-  Variable,
-} from '../../core';
+import { MultiFilterVariable, useMakeVariableLink, Variable } from '../../core';
 
 // Components
 import { VariableDetails } from '../Variable';
@@ -16,7 +11,7 @@ import FilterChipList from '../../core/components/FilterChipList';
 // Hooks
 import { EntityCounts } from '../../core/hooks/entityCounts';
 import { useToggleStarredVariable } from '../../core/hooks/starredVariables';
-import { useStudyEntities } from '../../core/hooks/study';
+import { useStudyEntities } from '../../core/hooks/workspace';
 
 // Definitions
 import { AnalysisState } from '../../core/hooks/analysis';
@@ -46,10 +41,8 @@ export default function Subsetting({
   totalCounts,
   filteredCounts,
 }: SubsettingProps) {
-  const studyMetadata = useStudyMetadata();
-
   // Obtain all entities and associated variables.
-  const entities = useStudyEntities(studyMetadata.rootEntity);
+  const entities = useStudyEntities();
 
   // What is the current entity?
   const entity = entities.find((e) => e.id === entityId);
@@ -92,7 +85,6 @@ export default function Subsetting({
       <div className="Variables">
         <VariableTree
           scope="variableTree"
-          rootEntity={entities[0]}
           entityId={entity.id}
           starredVariables={starredVariables}
           toggleStarredVariable={toggleStarredVariable}


### PR DESCRIPTION
closes #1237 

This PR introduces the new `VisualiationPlugin` interface, and the ability for a `ComputationPlugin` to pass options to a `VisualizationPlugin`. This is needed to be able to reuse visualization with different computation plugins.

A `VisualizationPlugin` defines its own options and how to augment its behavior based on them. A `ComputationPlugin` can then create an "optioned" version of a `VisualizationPlugin` by calling the `withOptions` method.

For example, the alphadiv computation plugin looks like this:
```typescript
export const plugin: ComputationPlugin = {
  configurationComponent: AlphaDivConfiguration,
  configurationDescriptionComponent: AlphaDivConfigDescriptionComponent,
  visualizationTypes: {
    boxplot: boxplotVisualization.withOptions({
      getYAxisVariable(config) {
        if (AlphaDivConfig.is(config)) {
          return {
            entityId: config.collectionVariable.entityId,
            variableId: 'alphadiv',
          };
        }
      },
      getYAxisLabel(config) {
        if (AlphaDivConfig.is(config)) {
          return 'Alphadiv';
        }
      },
    }),
    scatterplot: scatterplotVisualization,
  },
  createDefaultComputationSpec: createDefaultComputationSpec,
};
```

You can see how it has defined `getYAxisVariable` and `getYAxisLabel`. The boxplot visualization can detect the presence of these options and act accordingly.