### PR TITLE
Use undefined for empty compute config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/StartPage.tsx
+++ b/src/lib/core/components/computations/StartPage.tsx
@@ -103,16 +103,9 @@ export function StartPage(props: Props) {
                                 return;
                               const computations =
                                 analysisState.analysis.descriptor.computations;
-                              const defaultComputationSpec =
-                                plugin &&
-                                plugin.createDefaultComputationSpec != null
-                                  ? plugin.createDefaultComputationSpec(
-                                      studyMetadata.rootEntity
-                                    )
-                                  : {
-                                      configuration: undefined,
-                                      displayName: '',
-                                    };
+                              const defaultComputationConfig = plugin.createDefaultConfiguration(
+                                studyMetadata.rootEntity
+                              );
                               /*
                                 The first instance of a configurable app will be derived by a default configuration.
                                 Here we're checking if a computation with a defaultConfig already exists.
@@ -121,9 +114,7 @@ export function StartPage(props: Props) {
                                 (c) =>
                                   isEqual(
                                     c.descriptor.configuration,
-                                    'configuration' in defaultComputationSpec
-                                      ? defaultComputationSpec.configuration
-                                      : {}
+                                    defaultComputationConfig
                                   ) && app.name === c.descriptor.type
                               );
                               const visualizationId = uuid();
@@ -138,7 +129,7 @@ export function StartPage(props: Props) {
                               if (!existingComputation) {
                                 const computation = createComputation(
                                   app.name,
-                                  defaultComputationSpec.configuration,
+                                  defaultComputationConfig,
                                   computations,
                                   [newVisualization]
                                 );

--- a/src/lib/core/components/computations/Types.ts
+++ b/src/lib/core/components/computations/Types.ts
@@ -45,7 +45,6 @@ export interface ComputationPlugin {
     computation: Computation;
   }>;
   visualizationPlugins: Partial<Record<string, VisualizationPlugin<any>>>;
-  createDefaultComputationSpec?: (
-    rootEntity: StudyEntity
-  ) => { configuration: unknown };
+  createDefaultConfiguration: (rootEntity: StudyEntity) => unknown;
+  isConfigurationValid: (configuration: unknown) => boolean;
 }

--- a/src/lib/core/components/computations/Utils.ts
+++ b/src/lib/core/components/computations/Utils.ts
@@ -30,6 +30,7 @@ export function createComputation(
       configuration,
     },
     visualizations,
+    displayName: '',
   };
 }
 

--- a/src/lib/core/components/computations/ZeroConfiguration.tsx
+++ b/src/lib/core/components/computations/ZeroConfiguration.tsx
@@ -13,7 +13,7 @@ export interface Props extends ComputationConfigProps {
 function ZeroConfig(props: Props) {
   const { autoCreate = false, addNewComputation } = props;
   useEffect(() => {
-    if (autoCreate) addNewComputation('Unnamed computation', null);
+    if (autoCreate) addNewComputation('Unnamed computation', undefined);
   }, [addNewComputation, autoCreate]);
 
   return null;

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -24,7 +24,8 @@ export const AbundanceConfig = t.type({
 export const plugin: ComputationPlugin = {
   configurationComponent: AbundanceConfiguration,
   configurationDescriptionComponent: AbundanceConfigDescriptionComponent,
-  createDefaultComputationSpec: createDefaultComputationSpec,
+  createDefaultConfiguration,
+  isConfigurationValid: AbundanceConfig.is,
   visualizationPlugins: {
     boxplot: boxplotVisualization.withOptions({
       getXAxisVariable(config) {
@@ -108,9 +109,9 @@ function AbundanceConfigDescriptionComponent({
   );
 }
 
-function createDefaultComputationSpec(rootEntity: StudyEntity) {
+function createDefaultConfiguration(rootEntity: StudyEntity): AbundanceConfig {
   const collections = findCollections(rootEntity);
-  const configuration: AbundanceConfig = {
+  return {
     name: 'RankedAbundanceComputation',
     collectionVariable: {
       variableId: collections[0].id,
@@ -118,7 +119,6 @@ function createDefaultComputationSpec(rootEntity: StudyEntity) {
     },
     rankingMethod: 'median',
   };
-  return { configuration };
 }
 
 // Include available methods in this array.

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -23,7 +23,8 @@ export const AlphaDivConfig = t.type({
 export const plugin: ComputationPlugin = {
   configurationComponent: AlphaDivConfiguration,
   configurationDescriptionComponent: AlphaDivConfigDescriptionComponent,
-  createDefaultComputationSpec: createDefaultComputationSpec,
+  createDefaultConfiguration,
+  isConfigurationValid: AlphaDivConfig.is,
   visualizationPlugins: {
     boxplot: boxplotVisualization.withOptions({
       getComputedYAxisDetails(config) {
@@ -87,9 +88,9 @@ function AlphaDivConfigDescriptionComponent({
   );
 }
 
-function createDefaultComputationSpec(rootEntity: StudyEntity) {
+function createDefaultConfiguration(rootEntity: StudyEntity): AlphaDivConfig {
   const collections = findCollections(rootEntity);
-  const configuration: AlphaDivConfig = {
+  return {
     name: 'AlphaDivComputation',
     collectionVariable: {
       variableId: collections[0].id,
@@ -97,7 +98,6 @@ function createDefaultComputationSpec(rootEntity: StudyEntity) {
     },
     alphaDivMethod: 'shannon',
   };
-  return { configuration };
 }
 
 // Include available methods in this array.

--- a/src/lib/core/components/computations/plugins/countsAndProportions.tsx
+++ b/src/lib/core/components/computations/plugins/countsAndProportions.tsx
@@ -1,3 +1,4 @@
+import * as t from 'io-ts';
 import { barplotVisualization } from '../../visualizations/implementations/BarplotVisualization';
 import {
   contTableVisualization,
@@ -9,6 +10,8 @@ import { ZeroConfigWithButton } from '../ZeroConfiguration';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
+  isConfigurationValid: t.undefined.is,
+  createDefaultConfiguration: () => undefined,
   visualizationPlugins: {
     testVisualization,
     twobytwo: twoByTwoVisualization,

--- a/src/lib/core/components/computations/plugins/distributions.tsx
+++ b/src/lib/core/components/computations/plugins/distributions.tsx
@@ -1,3 +1,4 @@
+import * as t from 'io-ts';
 import { boxplotVisualization } from '../../visualizations/implementations/BoxplotVisualization';
 import { histogramVisualization } from '../../visualizations/implementations/HistogramVisualization';
 import { testVisualization } from '../../visualizations/implementations/TestVisualization';
@@ -6,6 +7,8 @@ import { ZeroConfigWithButton } from '../ZeroConfiguration';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
+  isConfigurationValid: t.undefined.is,
+  createDefaultConfiguration: () => undefined,
   visualizationPlugins: {
     testVisualization,
     histogram: histogramVisualization,

--- a/src/lib/core/components/computations/plugins/pass.tsx
+++ b/src/lib/core/components/computations/plugins/pass.tsx
@@ -11,9 +11,12 @@ import { mapVisualization } from '../../visualizations/implementations/MapVisual
 import { testVisualization } from '../../visualizations/implementations/TestVisualization';
 import { ComputationPlugin } from '../Types';
 import { ZeroConfigWithButton } from '../ZeroConfiguration';
+import * as t from 'io-ts';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
+  isConfigurationValid: t.undefined.is,
+  createDefaultConfiguration: () => undefined,
   visualizationPlugins: {
     testVisualization,
     histogram: histogramVisualization,

--- a/src/lib/core/components/computations/plugins/xyRelationships.tsx
+++ b/src/lib/core/components/computations/plugins/xyRelationships.tsx
@@ -3,9 +3,12 @@ import { lineplotVisualization } from '../../visualizations/implementations/Line
 import { testVisualization } from '../../visualizations/implementations/TestVisualization';
 import { ComputationPlugin } from '../Types';
 import { ZeroConfigWithButton } from '../ZeroConfiguration';
+import * as t from 'io-ts';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
+  isConfigurationValid: t.undefined.is,
+  createDefaultConfiguration: () => undefined,
   visualizationPlugins: {
     testVisualization,
     scatterplot: scatterplotVisualization,

--- a/src/lib/core/types/visualization.ts
+++ b/src/lib/core/types/visualization.ts
@@ -63,6 +63,7 @@ export const ComputationDescriptor = type({
  */
 export interface Computation<ConfigType = unknown> {
   computationId: string;
+  displayName: string;
   descriptor: {
     type: string;
     configuration: ConfigType;
@@ -71,6 +72,7 @@ export interface Computation<ConfigType = unknown> {
 }
 export const Computation: t.Type<Computation> = t.interface({
   computationId: string,
+  displayName: string,
   descriptor: type({
     type: string,
     configuration: unknown,

--- a/src/lib/workspace/hooks/analyses.ts
+++ b/src/lib/workspace/hooks/analyses.ts
@@ -38,7 +38,13 @@ export function useWorkspaceAnalysis(
   // If using singleAppMode, create a computation object that will be used in our default analysis.
   const computation = useMemo(() => {
     return singleAppMode
-      ? createComputation(singleAppMode, null, [], [], singleAppComputationId)
+      ? createComputation(
+          singleAppMode,
+          undefined,
+          [],
+          [],
+          singleAppComputationId
+        )
       : undefined;
   }, [singleAppMode, singleAppComputationId]);
 


### PR DESCRIPTION
This PR fixes an issue where a `null` value was being passed as `computeConfig` to the "pass" app. By using the value `undefined`, the property will not be included in the payload, which will address the issue.