### PR TITLE
dont startCase if string includes rRNA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/DownloadTab/MySubset.tsx
+++ b/src/lib/workspace/DownloadTab/MySubset.tsx
@@ -76,9 +76,7 @@ export default function MySubset({
         <FloatingButton
           key={index}
           text={`${data.filteredCount?.toLocaleString()} of ${data.totalCount?.toLocaleString()} ${
-            data.displayNamePlural?.includes('rRNA')
-              ? data.displayNamePlural
-              : startCase(data.displayNamePlural)
+            data.displayNamePlural
           }`}
           onPress={() => {
             attemptAction(Action.download, {

--- a/src/lib/workspace/DownloadTab/MySubset.tsx
+++ b/src/lib/workspace/DownloadTab/MySubset.tsx
@@ -75,9 +75,11 @@ export default function MySubset({
       {Object.values(entities).map((data, index) => (
         <FloatingButton
           key={index}
-          text={`${data.filteredCount?.toLocaleString()} of ${data.totalCount?.toLocaleString()} ${startCase(
-            data.displayNamePlural
-          )}`}
+          text={`${data.filteredCount?.toLocaleString()} of ${data.totalCount?.toLocaleString()} ${
+            data.displayNamePlural?.includes('rRNA')
+              ? data.displayNamePlural
+              : startCase(data.displayNamePlural)
+          }`}
           onPress={() => {
             attemptAction(Action.download, {
               studyId: datasetId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3068,10 +3068,10 @@
     react-transition-group "^4.4.1"
     shape2geohash "^1.2.5"
 
-"@veupathdb/coreui@^0.17.2":
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/@veupathdb/coreui/-/coreui-0.17.2.tgz#9147f08956623882a386ee2c53ce9c4613dab05a"
-  integrity sha512-Wpp8niDk/FM7BTPCI1Mwac3BFOnSSUq5Xb3Wsx0VDSUaiQLc1FUfLn0yY6pxP1SUn3T8amgsuzNYcvnE6CfJgg==
+"@veupathdb/coreui@^0.17.4":
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/@veupathdb/coreui/-/coreui-0.17.4.tgz#82935b24d018b723751e7401324b12a7b76d75ed"
+  integrity sha512-Z8T9moK3SJK5tvi5O/4XfOo+ls6cIUMqExabPt0I7eyzoGKno3W3c2z27suKxKcOpg1p2sOIeu6OiIzanx50AQ==
   dependencies:
     "@react-hook/size" "^2.1.2"
     lodash "^4.17.21"


### PR DESCRIPTION
Resolves #1257 

We're using [startCase](https://lodash.com/docs/) to transform the entity display names in the downloads buttons. Sometimes we have biological terms (such as rRNA) that we'll never want to be startCase-ed. In order to handle these terms we could either
1. Have some complicated logic that only startCases the non-biological words
2. Just don't startCase the whole entity name (implemented now until we have a decision on the real question... see below)

Which brings me to the real question - was startCase-ing in this case an intentional decision we made a while back? Maybe because buttons should always be startCase-ed? Or do we want the button text to match the case of the entity diagram (sentence case)?
@danicahelb @SheenaTomko maybe you remember?