### PR TITLE
make displayName for computations optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.7.8",
+  "version": "3.7.9",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/types/visualization.ts
+++ b/src/lib/core/types/visualization.ts
@@ -63,7 +63,7 @@ export const ComputationDescriptor = type({
  */
 export interface Computation<ConfigType = unknown> {
   computationId: string;
-  displayName: string;
+  displayName?: string;
   descriptor: {
     type: string;
     configuration: ConfigType;
@@ -72,7 +72,6 @@ export interface Computation<ConfigType = unknown> {
 }
 export const Computation: t.Type<Computation> = t.interface({
   computationId: string,
-  displayName: string,
   descriptor: type({
     type: string,
     configuration: unknown,


### PR DESCRIPTION
Found that analyses created in v3.6 and earlier, that we were hitting an error about displayName
<img width="1649" alt="Screen Shot 2022-08-01 at 3 50 42 PM" src="https://user-images.githubusercontent.com/11710234/182233224-5150e0d8-bcf3-4bfb-9f2d-b1c92e2f1063.png">

@dmfalke found that the error was caused by displayName now being required, when previously it was optional. This PR makes displayName optional again, which allows analyses created before v3.7 to work!

