### PR TITLE
add plot mode for histogram and barplot vizs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -536,6 +536,23 @@ function BarplotViz(props: VisualizationProps) {
           {...plotProps}
         />
       )}
+
+      {/* Plot mode */}
+      <RadioButtonGroup
+        label="Plot mode"
+        selectedOption={vizConfig.valueSpec}
+        options={['count', 'proportion']}
+        buttonColor={'primary'}
+        margins={['1em', '0', '0', '1em']}
+        onOptionSelected={(newOption) => {
+          if (newOption === 'proportion') {
+            onValueSpecChange('proportion');
+          } else {
+            onValueSpecChange('count');
+          }
+        }}
+      />
+
       {/* Y-axis range control */}
       <div style={{ display: 'flex', flexDirection: 'row' }}>
         <LabelledGroup label="Y-axis controls">
@@ -544,19 +561,6 @@ function BarplotViz(props: VisualizationProps) {
               label="Log scale:"
               state={vizConfig.dependentAxisLogScale}
               onStateChange={onDependentAxisLogScaleChange}
-            />
-            <div style={{ width: '4em' }}>{''}</div>
-            <RadioButtonGroup
-              selectedOption={vizConfig.valueSpec}
-              options={['count', 'proportion']}
-              buttonColor={'primary'}
-              onOptionSelected={(newOption) => {
-                if (newOption === 'proportion') {
-                  onValueSpecChange('proportion');
-                } else {
-                  onValueSpecChange('count');
-                }
-              }}
             />
           </div>
           {/* Y-axis range control */}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -929,6 +929,22 @@ function HistogramPlotWithControls({
         />
       )}
 
+      {/* Plot mode */}
+      <RadioButtonGroup
+        label="Plot mode"
+        selectedOption={valueSpec}
+        options={['count', 'proportion']}
+        buttonColor={'primary'}
+        margins={['1em', '0', '0', '1em']}
+        onOptionSelected={(newOption) => {
+          if (newOption === 'proportion') {
+            onValueSpecChange('proportion');
+          } else {
+            onValueSpecChange('count');
+          }
+        }}
+      />
+
       <div style={{ display: 'flex', flexDirection: 'row' }}>
         {/* make switch and radiobutton single line with space
                  also marginRight at LabelledGroup is set to 0.5625em: default - 1.5625em*/}
@@ -1032,19 +1048,6 @@ function HistogramPlotWithControls({
               onStateChange={onDependentAxisLogScaleChange}
               containerStyles={{
                 minHeight: widgetHeight,
-              }}
-            />
-            <div style={{ width: '4em' }}>{''}</div>
-            <RadioButtonGroup
-              selectedOption={valueSpec}
-              options={['count', 'proportion']}
-              buttonColor={'primary'}
-              onOptionSelected={(newOption) => {
-                if (newOption === 'proportion') {
-                  onValueSpecChange('proportion');
-                } else {
-                  onValueSpecChange('count');
-                }
               }}
             />
           </div>


### PR DESCRIPTION
This addresses https://github.com/VEuPathDB/web-eda/issues/1277

Screenshots are attached for histogram and barplot vizs, respectively
![histogram plotMode](https://user-images.githubusercontent.com/12802305/183485579-cc615a13-47c1-47af-a1de-9e2b962d4821.png)

![barplot plotMode](https://user-images.githubusercontent.com/12802305/183485594-847cc064-3545-4381-9354-7ae56cc7d092.png)

