### PR TITLE
Fix significant figure adjustment bug: added missing abs() and fixed character loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/utils/number-significant-figures.ts
+++ b/src/lib/core/utils/number-significant-figures.ts
@@ -63,17 +63,16 @@ function adjustDown(
  **/
 function signifDigitEpsilon(x: number, digits: number): number {
   // JavaScript adds trailing zeroes by default
-  const rounded = x.toPrecision(digits);
+  const rounded = Math.abs(x).toPrecision(digits);
 
   // split into vector of single characters
   const characters = rounded.split('');
-
   const result: string[] = [];
 
   let seenSignificant = false;
   let significantCount = 0;
   // walk through string, looking for first non-zero, non decimal point character
-  for (const c in characters) {
+  for (const c of characters) {
     if (c !== '0' && c !== '.') {
       seenSignificant = true;
     }
@@ -81,7 +80,6 @@ function signifDigitEpsilon(x: number, digits: number): number {
       result.push(c);
     } else if (seenSignificant) {
       significantCount++;
-      console.log(significantCount);
       if (significantCount < digits - 1) {
         result.push('0');
       } else if (significantCount === digits - 1) {
@@ -97,6 +95,5 @@ function signifDigitEpsilon(x: number, digits: number): number {
       result.push('0');
     }
   }
-  console.log(result);
   return Number(result.join(''));
 }


### PR DESCRIPTION
Fixes #1313 

Luckily I also spotted the missing `abs(x)` 