### PR TITLE
Reactivate scatter plot legend for smoothed mean and best fit modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.8.20",
+  "version": "3.8.21",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -917,7 +917,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
 
   const showOverlayLegend =
     (providedOverlayVariableDescriptor != null ||
-      vizConfig.overlayVariable != null) &&
+      vizConfig.overlayVariable != null ||
+      vizConfig.valueSpecConfig !== 'Raw') &&
     legendItems.length > 0;
   const legendNode = !data.pending && data.value != null && (
     <PlotLegend


### PR DESCRIPTION
Fixes https://github.com/VEuPathDB/web-eda/issues/1316