### PR TITLE
add download tab warning banner for improperly formatted mbio studies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.8.17",
+  "version": "3.8.18",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/DownloadTab/index.tsx
+++ b/src/lib/workspace/DownloadTab/index.tsx
@@ -14,6 +14,7 @@ import { DownloadClient } from '../../core/api/DownloadClient';
 // Components
 import MySubset from './MySubset';
 import CurrentRelease from './CurrentRelease';
+import Banner from '@veupathdb/coreui/dist/components/banners/Banner';
 
 // Hooks
 import { useWdkStudyReleases } from '../../core/hooks/study';
@@ -25,6 +26,7 @@ import { useAttemptActionCallback } from '@veupathdb/study-data-access/lib/data-
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 import { Action } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUiActions';
 import { getStudyRequestNeedsApproval } from '@veupathdb/study-data-access/lib/shared/studies';
+import { useLocalBackedState } from '@veupathdb/wdk-client/lib/Hooks/LocalBackedState';
 
 type DownloadsTabProps = {
   downloadClient: DownloadClient;
@@ -62,6 +64,38 @@ export default function DownloadTab({
     [datasetId, attemptAction]
   );
 
+  // Longitudinal studies on beta.microbiome are not formatted correctly (missing repeated measures) which affects the download files. This will be fixed for b60.
+  // For now, warn the user about improperly formatted download files.
+  const SHOULD_SHOW_DOWNLOAD_WARNING_KEY = `shouldShowDownloadWarning-${datasetId}`;
+  const [
+    shouldShowWarning,
+    setShouldShowWarning,
+  ] = useLocalBackedState<boolean>(
+    true,
+    SHOULD_SHOW_DOWNLOAD_WARNING_KEY,
+    (boolean) => String(boolean),
+    (string) => string !== 'false'
+  );
+  const studiesForDownalodWarning = [
+    'DS_b3b3ae9838', // BONUS
+    'DS_1102462e80', // Bangladesh
+    'DS_a2f8877e68', // DIABIMMUNE
+    'DS_5a4f8a1791', // DailyBaby
+    'DS_accd1b80f6', // ECAM
+    'DS_d20b9c4094', // Eco-CF
+    'DS_570856e10e', // HMP V1-V3
+    'DS_ca4404e155', // HMP V3-V5
+    'DS_72c94486c6', // MAL-ED 2yr
+    'DS_2e56313a65', // MAL-ED diarrhea
+    'DS_84fcb69f4e', // NICU NEC
+    'DS_d1b9f788dc', // Preterm Resistome I
+    'DS_b9dc726b20', // Preterm Resistome II
+  ];
+  const handleCloseWarning = () => {
+    setShouldShowWarning(false);
+  };
+  // End of this section of the temporary solution for funky download files
+
   const dataAccessDeclaration = useMemo(() => {
     if (
       !user ||
@@ -85,6 +119,7 @@ export default function DownloadTab({
         Click here to request access.
       </button>
     );
+
     return (
       <span
         style={{
@@ -93,6 +128,20 @@ export default function DownloadTab({
           fontSize: '1.4em',
         }}
       >
+        {/* The following is part of the temporary solution for funky mbio download files */}
+        {studiesForDownalodWarning.includes(datasetId) && shouldShowWarning && (
+          <Banner
+            banner={{
+              type: 'warning',
+              message:
+                'Some download files below are formatted improperly. Instead, please download files for this study from the main microbiomedb.org site. We appreciate your patience as we transfer to the new system.',
+              pinned: false,
+              intense: false,
+            }}
+            onClose={handleCloseWarning}
+          ></Banner>
+        )}
+        {/* End temporary solution section */}
         <em>
           {getDataAccessDeclaration(
             studyAccess,
@@ -106,7 +155,14 @@ export default function DownloadTab({
         </em>
       </span>
     );
-  }, [user, permission, studyRecord, handleClick, datasetId]);
+  }, [
+    user,
+    permission,
+    studyRecord,
+    handleClick,
+    datasetId,
+    shouldShowWarning,
+  ]);
 
   /**
    * Ok, this is confusing, but there are two places where we need

--- a/src/lib/workspace/DownloadTab/index.tsx
+++ b/src/lib/workspace/DownloadTab/index.tsx
@@ -76,7 +76,7 @@ export default function DownloadTab({
     (boolean) => String(boolean),
     (string) => string !== 'false'
   );
-  const studiesForDownalodWarning = [
+  const studiesForDownloadWarning = [
     'DS_b3b3ae9838', // BONUS
     'DS_1102462e80', // Bangladesh
     'DS_a2f8877e68', // DIABIMMUNE
@@ -94,6 +94,11 @@ export default function DownloadTab({
   const handleCloseWarning = () => {
     setShouldShowWarning(false);
   };
+  const downloadWarningMessage = [
+    'Download files for this dataset may be formatted improperly. Instead, please download files for this study from ',
+    <a href="https://microbiomedb.org">https://microbiomedb.org</a>,
+    '. We appreciate your patience as we transfer to the new system.',
+  ];
   // End of this section of the temporary solution for funky download files
 
   const dataAccessDeclaration = useMemo(() => {
@@ -129,12 +134,11 @@ export default function DownloadTab({
         }}
       >
         {/* The following is part of the temporary solution for funky mbio download files */}
-        {studiesForDownalodWarning.includes(datasetId) && shouldShowWarning && (
+        {studiesForDownloadWarning.includes(datasetId) && shouldShowWarning && (
           <Banner
             banner={{
               type: 'warning',
-              message:
-                'Some download files below are formatted improperly. Instead, please download files for this study from the main microbiomedb.org site. We appreciate your patience as we transfer to the new system.',
+              message: downloadWarningMessage,
               pinned: false,
               intense: false,
             }}


### PR DESCRIPTION
Resolves #1337 

In QAing [this issue](https://github.com/VEuPathDB/EdaLoadingIssues/issues/37#issuecomment-1225928487), @SheenaTomko found some of the download files are not correct, specifically the Participant and Sample files for longitudinal studies. She proposed we add a warning banner to direct users to the live site for downloads until we can fix the data issue (b60).

This PR adds the warning banner to any study that is a) longitudinal (including anything that said "prospective cohort design") and b) is missing participant repeated measures. The approach follows that taken for adding the warning banner on the visualization tab for large studies having slow visualizations.

I struggled with the language for the banner quite a bit. @SheenaTomko I'd be very grateful for your advice on this! I think some files (assays) are usually fine, but the particpant and sample ones are odd. They're not showing incorrect data as much as the mapping between variable and entity doesn't really make sense. So anyways I struggled with how to convey this in a friendly way that does not compromise trust in the future when we will have sparkly perfect download files :)



