### PR TITLE
More control over visualization plot layouts and `useMapMarkers` hook

### DIFF
--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -57,7 +57,7 @@ export const plugin: ComputationPlugin = {
           };
         }
       },
-      getOverlayVariable(config) {
+      getComputedOverlayVariable(config) {
         if (AbundanceConfig.is(config)) {
           return config.collectionVariable;
         }

--- a/src/lib/core/components/computations/plugins/pass.tsx
+++ b/src/lib/core/components/computations/plugins/pass.tsx
@@ -30,9 +30,16 @@ export const plugin: ComputationPlugin = {
     // densityplot: scatterplotVisualization,
     barplot: barplotVisualization,
     boxplot: boxplotVisualization,
-    // or...
-    // boxplotVisualization.withOptions({
-    //   layoutComponent: FloatingLayout,
-    //}), /// TEMPORARY ONLY!!! ///
+    //     or...
+    //    boxplot: boxplotVisualization.withOptions({
+    //      hideFacetInputs: true,
+    //      getOverlayVariable(_) {
+    //	return {
+    //	  "entityId": "PCO_0000024",
+    //	  "variableId": "EUPATH_0015019" // charcoal
+    //	};
+    //      },
+    //      layoutComponent: FloatingLayout,
+    //    }), /// TEMPORARY ONLY!!! ///
   },
 };

--- a/src/lib/core/components/computations/plugins/pass.tsx
+++ b/src/lib/core/components/computations/plugins/pass.tsx
@@ -12,6 +12,7 @@ import { testVisualization } from '../../visualizations/implementations/TestVisu
 import { ComputationPlugin } from '../Types';
 import { ZeroConfigWithButton } from '../ZeroConfiguration';
 import * as t from 'io-ts';
+import { FloatingLayout } from '../../layouts/FloatingLayout';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
@@ -28,6 +29,8 @@ export const plugin: ComputationPlugin = {
     // placeholder for densityplot
     // densityplot: scatterplotVisualization,
     barplot: barplotVisualization,
-    boxplot: boxplotVisualization,
+    boxplot: boxplotVisualization.withOptions({
+      layoutComponent: FloatingLayout,
+    }), /// TEMPORARY ONLY!!! ///
   },
 };

--- a/src/lib/core/components/computations/plugins/pass.tsx
+++ b/src/lib/core/components/computations/plugins/pass.tsx
@@ -30,14 +30,14 @@ export const plugin: ComputationPlugin = {
     // densityplot: scatterplotVisualization,
     barplot: barplotVisualization,
     boxplot: boxplotVisualization,
-    //     or...
+    // or...
     //    boxplot: boxplotVisualization.withOptions({
     //      hideFacetInputs: true,
     //      getOverlayVariable(_) {
-    //	return {
-    //	  "entityId": "PCO_0000024",
-    //	  "variableId": "EUPATH_0015019" // charcoal
-    //	};
+    //	      return {
+    //	        "entityId": "PCO_0000024",
+    //	        "variableId": "EUPATH_0015019" // charcoal
+    //	      };
     //      },
     //      layoutComponent: FloatingLayout,
     //    }), /// TEMPORARY ONLY!!! ///

--- a/src/lib/core/components/computations/plugins/pass.tsx
+++ b/src/lib/core/components/computations/plugins/pass.tsx
@@ -29,8 +29,10 @@ export const plugin: ComputationPlugin = {
     // placeholder for densityplot
     // densityplot: scatterplotVisualization,
     barplot: barplotVisualization,
-    boxplot: boxplotVisualization.withOptions({
-      layoutComponent: FloatingLayout,
-    }), /// TEMPORARY ONLY!!! ///
+    boxplot: boxplotVisualization,
+    // or...
+    // boxplotVisualization.withOptions({
+    //   layoutComponent: FloatingLayout,
+    //}), /// TEMPORARY ONLY!!! ///
   },
 };

--- a/src/lib/core/components/layouts/FacetedPlotLayout.tsx
+++ b/src/lib/core/components/layouts/FacetedPlotLayout.tsx
@@ -34,6 +34,7 @@ export function FacetedPlotLayout({
   legendNode,
   legendStyles,
   plotNode,
+  controlsNode,
   plotStyles,
   tableGroupNode,
   tableGroupStyles,
@@ -53,7 +54,10 @@ export function FacetedPlotLayout({
         )}
         {tableGroupNode}
       </div>
-      <div style={{ ...defaultPlotStyles, ...plotStyles }}>{plotNode}</div>
+      <div style={{ ...defaultPlotStyles, ...plotStyles }}>
+        {plotNode}
+        {controlsNode}
+      </div>
     </div>
   );
 }

--- a/src/lib/core/components/layouts/FloatingLayout.tsx
+++ b/src/lib/core/components/layouts/FloatingLayout.tsx
@@ -19,21 +19,10 @@ const defaultPlotStyles: CSSProperties = {
   flexDirection: 'column',
 };
 
-const defaultTableGroupStyles: CSSProperties = {
-  margin: '0em 1.5em',
-  display: 'grid',
-  gridAutoFlow: 'row',
-  gap: '1.5em',
-};
-
-export function SinglePlotLayout({
+export function FloatingLayout({
   containerStyles,
-  legendNode,
-  legendStyles,
   plotNode,
   plotStyles,
-  tableGroupNode,
-  tableGroupStyles,
   showRequiredInputsPrompt,
   isMosaicPlot,
 }: Props) {
@@ -44,10 +33,6 @@ export function SinglePlotLayout({
           <RequiredInputsPrompt isMosaicPlot={isMosaicPlot} />
         )}
         {plotNode}
-      </div>
-      <div style={{ ...defaultTableGroupStyles, ...tableGroupStyles }}>
-        {legendNode && <div style={{ ...legendStyles }}>{legendNode}</div>}
-        {tableGroupNode}
       </div>
     </div>
   );

--- a/src/lib/core/components/layouts/PlotLayout.tsx
+++ b/src/lib/core/components/layouts/PlotLayout.tsx
@@ -9,13 +9,10 @@ import {
   SinglePlotLayout,
 } from './SinglePlotLayout';
 
-import { StyleProps } from './types';
+import { StyleProps, LayoutProps } from './types';
 
-export interface PlotLayoutProps {
+export interface PlotLayoutProps extends LayoutProps {
   isFaceted: boolean;
-  legendNode?: ReactNode;
-  plotNode: ReactNode;
-  tableGroupNode: ReactNode;
   singlePlotStyles?: StyleProps<SinglePlotLayoutProps>;
   facetedPlotStyles?: StyleProps<FacetedPlotLayoutProps>;
   showRequiredInputsPrompt?: boolean;
@@ -31,6 +28,7 @@ export function PlotLayout({
   isFaceted,
   legendNode,
   plotNode,
+  controlsNode,
   tableGroupNode,
   singlePlotStyles,
   facetedPlotStyles,
@@ -48,6 +46,7 @@ export function PlotLayout({
     <SinglePlotLayout
       legendNode={legendNode}
       plotNode={plotNode}
+      controlsNode={controlsNode}
       tableGroupNode={tableGroupNode}
       showRequiredInputsPrompt={showRequiredInputsPrompt}
       isMosaicPlot={isMosaicPlot}

--- a/src/lib/core/components/layouts/PlotLayout.tsx
+++ b/src/lib/core/components/layouts/PlotLayout.tsx
@@ -11,7 +11,7 @@ import {
 
 import { StyleProps } from './types';
 
-interface Props {
+export interface PlotLayoutProps {
   isFaceted: boolean;
   legendNode?: ReactNode;
   plotNode: ReactNode;
@@ -36,7 +36,7 @@ export function PlotLayout({
   facetedPlotStyles,
   showRequiredInputsPrompt,
   isMosaicPlot,
-}: Props) {
+}: PlotLayoutProps) {
   return isFaceted ? (
     <FacetedPlotLayout
       legendNode={legendNode}

--- a/src/lib/core/components/layouts/PlotLayout.tsx
+++ b/src/lib/core/components/layouts/PlotLayout.tsx
@@ -39,6 +39,7 @@ export function PlotLayout({
     <FacetedPlotLayout
       legendNode={legendNode}
       plotNode={plotNode}
+      controlsNode={controlsNode}
       tableGroupNode={tableGroupNode}
       {...facetedPlotStyles}
     />

--- a/src/lib/core/components/layouts/RequiredInputPrompts.tsx
+++ b/src/lib/core/components/layouts/RequiredInputPrompts.tsx
@@ -1,0 +1,45 @@
+import { CSSProperties } from 'react';
+
+const requiredInputsContainerStyles: CSSProperties = {
+  position: 'relative',
+  height: '0',
+  width: '0',
+};
+
+const requiredInputsHeaderStyles: CSSProperties = {
+  position: 'absolute',
+  width: 'max-content',
+  left: '4.25em',
+  zIndex: '1000',
+  fontWeight: '500',
+  fontStyle: 'normal',
+  backgroundColor: '#fff',
+  padding: '0.5em',
+};
+
+const requiredTextStyles: CSSProperties = {
+  color: '#dd314e',
+};
+
+interface RequiredPromptProps {
+  isMosaicPlot: boolean | undefined;
+}
+
+export function RequiredInputsPrompt({ isMosaicPlot }: RequiredPromptProps) {
+  return (
+    <div style={requiredInputsContainerStyles}>
+      <h3
+        style={{
+          ...requiredInputsHeaderStyles,
+          top: isMosaicPlot ? '4em' : '0.5em',
+        }}
+      >
+        Please select all{' '}
+        <span style={requiredTextStyles}>
+          required<sup>*</sup>
+        </span>{' '}
+        parameters.
+      </h3>
+    </div>
+  );
+}

--- a/src/lib/core/components/layouts/SinglePlotLayout.tsx
+++ b/src/lib/core/components/layouts/SinglePlotLayout.tsx
@@ -31,6 +31,7 @@ export function SinglePlotLayout({
   legendNode,
   legendStyles,
   plotNode,
+  controlsNode,
   plotStyles,
   tableGroupNode,
   tableGroupStyles,
@@ -44,6 +45,7 @@ export function SinglePlotLayout({
           <RequiredInputsPrompt isMosaicPlot={isMosaicPlot} />
         )}
         {plotNode}
+        {controlsNode}
       </div>
       <div style={{ ...defaultTableGroupStyles, ...tableGroupStyles }}>
         {legendNode && <div style={{ ...legendStyles }}>{legendNode}</div>}

--- a/src/lib/core/components/layouts/types.ts
+++ b/src/lib/core/components/layouts/types.ts
@@ -12,3 +12,12 @@ export interface LayoutProps {
 }
 
 export type StyleProps<P> = Pick<P, keyof P & `${string}Styles`>;
+
+export interface LayoutOptions {
+  layoutComponent?: (props: LayoutProps) => JSX.Element;
+  hideShowMissingnessToggle?: boolean;
+}
+
+export interface TitleOptions {
+  getPlotSubtitle?(config: unknown): string | undefined;
+}

--- a/src/lib/core/components/layouts/types.ts
+++ b/src/lib/core/components/layouts/types.ts
@@ -5,6 +5,7 @@ export interface LayoutProps {
   legendNode?: ReactNode;
   legendStyles?: CSSProperties;
   plotNode: ReactNode;
+  controlsNode?: ReactNode;
   plotStyles?: CSSProperties;
   tableGroupNode: ReactNode;
   tableGroupStyles?: CSSProperties;

--- a/src/lib/core/components/layouts/types.ts
+++ b/src/lib/core/components/layouts/types.ts
@@ -16,6 +16,7 @@ export type StyleProps<P> = Pick<P, keyof P & `${string}Styles`>;
 export interface LayoutOptions {
   layoutComponent?: (props: LayoutProps) => JSX.Element;
   hideShowMissingnessToggle?: boolean;
+  hideFacetInputs?: boolean;
 }
 
 export interface TitleOptions {

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react';
 import { EntityCounts } from '../../hooks/entityCounts';
 import { PromiseHookState } from '../../hooks/promise';
 import { Filter } from '../../types/filter';

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -10,7 +10,6 @@ import {
   Visualization,
   VisualizationOverview,
 } from '../../types/visualization';
-import { PlotLayoutProps } from '../layouts/PlotLayout';
 
 /**
  * Props passed to viz components
@@ -30,10 +29,6 @@ export interface VisualizationProps<Options = undefined> {
   filteredCounts: PromiseHookState<EntityCounts>;
   geoConfigs: GeoConfig[];
   otherVizOverviews: VisualizationOverview[];
-}
-
-export interface GlobalVisualizationOptions {
-  layoutComponent?: (props: PlotLayoutProps) => JSX.Element;
 }
 
 export interface IsEnabledInPickerParams {

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -1,4 +1,4 @@
-import { string } from 'fp-ts';
+import { ReactNode } from 'react';
 import { EntityCounts } from '../../hooks/entityCounts';
 import { PromiseHookState } from '../../hooks/promise';
 import { Filter } from '../../types/filter';
@@ -11,6 +11,7 @@ import {
   Visualization,
   VisualizationOverview,
 } from '../../types/visualization';
+import { PlotLayoutProps } from '../layouts/PlotLayout';
 
 /**
  * Props passed to viz components
@@ -31,6 +32,11 @@ export interface VisualizationProps<Options = undefined> {
   geoConfigs: GeoConfig[];
   otherVizOverviews: VisualizationOverview[];
 }
+
+export interface GlobalVisualizationOptions {
+  layoutComponent?: (props: PlotLayoutProps) => JSX.Element;
+}
+
 export interface IsEnabledInPickerParams {
   geoConfigs?: GeoConfig[];
   studyMetadata?: StudyMetadata; // not used yet, but you could imagine it being used to determine

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -707,9 +707,11 @@ function BarplotViz(props: VisualizationProps<Options>) {
               label: 'Overlay',
               role: 'stratification',
               readonlyValue:
-                options?.getOverlayVariable != null && providedOverlayVariable
-                  ? overlayLabel
-                  : 'none',
+                options?.getOverlayVariable != null
+                  ? providedOverlayVariable
+                    ? overlayLabel
+                    : 'none'
+                  : undefined,
               // TO DO: verbiage for 'none'
             },
             ...(options?.hideFacetInputs

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -81,6 +81,7 @@ import {
   barplotDefaultDependentAxisMinPos,
 } from '../../../utils/axis-range-calculations';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
+import { LayoutOptions } from '../../layouts/types';
 
 // export
 export type BarplotDataWithStatistics = (
@@ -111,7 +112,9 @@ export const barplotVisualization = createVisualizationPlugin({
   createDefaultConfig: createDefaultConfig,
 });
 
-function FullscreenComponent(props: VisualizationProps) {
+interface Options extends LayoutOptions {}
+
+function FullscreenComponent(props: VisualizationProps<Options>) {
   return <BarplotViz {...props} />;
 }
 
@@ -146,8 +149,9 @@ export const BarplotConfig = t.intersection([
   }),
 ]);
 
-function BarplotViz(props: VisualizationProps) {
+function BarplotViz(props: VisualizationProps<Options>) {
   const {
+    options,
     computation,
     visualization,
     updateConfiguration,
@@ -536,7 +540,11 @@ function BarplotViz(props: VisualizationProps) {
           {...plotProps}
         />
       )}
+    </>
+  );
 
+  const controlsNode = (
+    <>
       {/* Plot mode */}
       <RadioButtonGroup
         label="Plot mode"
@@ -666,6 +674,8 @@ function BarplotViz(props: VisualizationProps) {
       .every((reqdVar) => !!(vizConfig as any)[reqdVar[0]]);
   }, [dataElementConstraints, vizConfig.xAxisVariable]);
 
+  const LayoutComponent = options?.layoutComponent ?? PlotLayout;
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
@@ -716,9 +726,10 @@ function BarplotViz(props: VisualizationProps) {
 
       <PluginError error={data.error} outputSize={outputSize} />
       <OutputEntityTitle entity={entity} outputSize={outputSize} />
-      <PlotLayout
+      <LayoutComponent
         isFaceted={isFaceted(data.value)}
         plotNode={plotNode}
+        controlsNode={controlsNode}
         legendNode={showOverlayLegend ? legendNode : null}
         tableGroupNode={tableGroupNode}
         showRequiredInputsPrompt={!areRequiredInputsSelected}

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -37,7 +37,7 @@ import { CoverageStatistics } from '../../../types/visualization';
 import { BirdsEyeView } from '../../BirdsEyeView';
 import { PlotLayout } from '../../layouts/PlotLayout';
 
-import { InputVariables } from '../InputVariables';
+import { InputSpec, InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
 import { VisualizationProps } from '../VisualizationTypes';
 
@@ -719,7 +719,7 @@ function BarplotViz(props: VisualizationProps<Options>) {
                     name: 'facetVariable',
                     label: 'Facet',
                     role: 'stratification',
-                  },
+                  } as InputSpec,
                 ]),
           ]}
           entities={entities}

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -37,7 +37,7 @@ import { CoverageStatistics } from '../../../types/visualization';
 import { BirdsEyeView } from '../../BirdsEyeView';
 import { PlotLayout } from '../../layouts/PlotLayout';
 
-import { InputSpec, InputVariables } from '../InputVariables';
+import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
 import { VisualizationProps } from '../VisualizationTypes';
 
@@ -721,7 +721,7 @@ function BarplotViz(props: VisualizationProps<Options>) {
                     name: 'facetVariable',
                     label: 'Facet',
                     role: 'stratification',
-                  } as InputSpec,
+                  } as const,
                 ]),
           ]}
           entities={entities}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -555,7 +555,7 @@ function BoxplotViz(props: VisualizationProps<Options>) {
     <PlotLegend
       legendItems={legendItems}
       checkedLegendItems={checkedLegendItems}
-      legendTitle={variableDisplayWithUnit(overlayVariable)}
+      legendTitle={overlayLabel}
       onCheckedLegendItemsChange={onCheckedLegendItemsChange}
       // add a condition to show legend even for single overlay data and check legendItems exist
       showOverlayLegend={showOverlayLegend}
@@ -627,7 +627,7 @@ function BoxplotViz(props: VisualizationProps<Options>) {
           },
           {
             role: 'Overlay',
-            display: variableDisplayWithUnit(overlayVariable),
+            display: overlayLabel,
             variable: vizConfig.overlayVariable,
           },
           {

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -681,9 +681,11 @@ function BoxplotViz(props: VisualizationProps<Options>) {
               label: 'Overlay',
               role: 'stratification',
               readonlyValue:
-                options?.getOverlayVariable != null && providedOverlayVariable
-                  ? overlayLabel
-                  : 'none',
+                options?.getOverlayVariable != null
+                  ? providedOverlayVariable
+                    ? overlayLabel
+                    : 'none'
+                  : undefined,
               // TO DO: verbiage for 'none'
             },
             ...(options?.hideFacetInputs

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -23,7 +23,6 @@ import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
 import {
   ComputedVariableDetails,
-  GlobalVisualizationOptions,
   VisualizationProps,
 } from '../VisualizationTypes';
 import box from './selectorIcons/box.svg';
@@ -79,6 +78,7 @@ import { ComputedVariableMetadata } from '../../../api/DataClient/types';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
 import { useFindOutputEntity } from '../../../hooks/findOutputEntity';
 import { boxplotDefaultDependentAxisMinMax } from '../../../utils/axis-range-calculations';
+import { LayoutOptions, TitleOptions } from '../../layouts/types';
 
 type BoxplotData = { series: BoxplotSeries };
 // type of computedVariableMetadata for computation apps such as alphadiv and abundance
@@ -107,13 +107,11 @@ const modalPlotContainerStyles = {
   margin: 'auto',
 };
 
-interface Options extends GlobalVisualizationOptions {
+interface Options extends LayoutOptions, TitleOptions {
   getXAxisVariable?: (computeConfig: unknown) => VariableDescriptor | undefined;
   getComputedYAxisDetails?: (
     computeConfig: unknown
   ) => ComputedVariableDetails | undefined;
-  getPlotSubtitle?: (computeConfig: unknown) => string | undefined;
-  hideShowMissingnessToggle?: boolean;
 }
 
 export const boxplotVisualization = createVisualizationPlugin({

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -695,7 +695,7 @@ function BoxplotViz(props: VisualizationProps<Options>) {
                     name: 'facetVariable',
                     label: 'Facet',
                     role: 'stratification',
-                  } as InputSpec, // compiler flummoxed by ...()?
+                  } as const,
                 ]),
           ]}
           entities={entities}

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -23,6 +23,7 @@ import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
 import {
   ComputedVariableDetails,
+  GlobalVisualizationOptions,
   VisualizationProps,
 } from '../VisualizationTypes';
 import box from './selectorIcons/box.svg';
@@ -116,7 +117,7 @@ const modalPlotContainerStyles = {
   margin: 'auto',
 };
 
-interface Options {
+interface Options extends GlobalVisualizationOptions {
   getXAxisVariable?: (computeConfig: unknown) => VariableDescriptor | undefined;
   getComputedYAxisDetails?: (
     computeConfig: unknown
@@ -644,6 +645,8 @@ function BoxplotViz(props: VisualizationProps<Options>) {
     vizConfig.yAxisVariable,
   ]);
 
+  const LayoutComponent = options?.layoutComponent ?? PlotLayout;
+
   // for handling alphadiv abundance
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -707,7 +710,7 @@ function BoxplotViz(props: VisualizationProps<Options>) {
         outputSize={outputSize}
         subtitle={plotSubtitle}
       />
-      <PlotLayout
+      <LayoutComponent
         isFaceted={isFaceted(data.value)}
         legendNode={showOverlayLegend ? legendNode : null}
         plotNode={plotNode}

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -101,6 +101,7 @@ import { useDefaultAxisRange } from '../../../hooks/computeDefaultAxisRange';
 import { useVizConfig } from '../../../hooks/visualizations';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
 import { histogramDefaultDependentAxisMinMax } from '../../../utils/axis-range-calculations';
+import { LayoutOptions } from '../../layouts/types';
 
 export type HistogramDataWithCoverageStatistics = (
   | HistogramData
@@ -165,8 +166,11 @@ export const HistogramConfig = t.intersection([
   }),
 ]);
 
-function HistogramViz(props: VisualizationProps) {
+interface Options extends LayoutOptions {}
+
+function HistogramViz(props: VisualizationProps<Options>) {
   const {
+    options,
     computation,
     visualization,
     updateConfiguration,
@@ -540,226 +544,41 @@ function HistogramViz(props: VisualizationProps) {
       .every((reqdVar) => !!(vizConfig as any)[reqdVar[0]]);
   }, [dataElementConstraints, vizConfig.xAxisVariable]);
 
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
-        <InputVariables
-          inputs={[
-            {
-              name: 'xAxisVariable',
-              label: 'Main',
-              role: 'axis',
-            },
-            {
-              name: 'overlayVariable',
-              label: 'Overlay',
-              role: 'stratification',
-            },
-            {
-              name: 'facetVariable',
-              label: 'Facet',
-              role: 'stratification',
-            },
-          ]}
-          entities={entities}
-          selectedVariables={{
-            xAxisVariable: vizConfig.xAxisVariable,
-            overlayVariable: vizConfig.overlayVariable,
-            facetVariable: vizConfig.facetVariable,
-          }}
-          onChange={handleInputVariableChange}
-          constraints={dataElementConstraints}
-          dataElementDependencyOrder={dataElementDependencyOrder}
-          starredVariables={starredVariables}
-          toggleStarredVariable={toggleStarredVariable}
-          enableShowMissingnessToggle={
-            (overlayVariable != null || facetVariable != null) &&
-            data.value?.completeCasesAllVars !==
-              data.value?.completeCasesAxesVars
-          }
-          showMissingness={vizConfig.showMissingness}
-          // this can be used to show and hide no data control
-          onShowMissingnessChange={
-            computation.descriptor.type === 'pass'
-              ? onShowMissingnessChange
-              : undefined
-          }
-          outputEntity={outputEntity}
-        />
-      </div>
-
-      <PluginError error={data.error} outputSize={outputSize} />
-      <HistogramPlotWithControls
-        data={data.value}
-        error={data.error}
-        onBinWidthChange={onBinWidthChange}
-        dependentAxisLogScale={vizConfig.dependentAxisLogScale}
-        onDependentAxisLogScaleChange={onDependentAxisLogScaleChange}
-        valueSpec={vizConfig.valueSpec}
-        onValueSpecChange={onValueSpecChange}
-        updateThumbnail={updateThumbnail}
-        containerStyles={
-          !isFaceted(data.value) ? plotContainerStyles : undefined
-        }
-        spacingOptions={!isFaceted(data.value) ? spacingOptions : undefined}
-        orientation={'vertical'}
-        barLayout={'stack'}
-        displayLegend={false}
-        outputEntity={outputEntity}
-        independentAxisVariable={vizConfig.xAxisVariable}
-        independentAxisLabel={variableDisplayWithUnit(xAxisVariable) ?? 'Main'}
-        interactive={!isFaceted(data.value) ? true : false}
-        showSpinner={data.pending || filteredCounts.pending}
-        filters={filters}
-        outputSize={outputSize}
-        completeCases={data.pending ? undefined : data.value?.completeCases}
-        completeCasesAllVars={
-          data.pending ? undefined : data.value?.completeCasesAllVars
-        }
-        completeCasesAxesVars={
-          data.pending ? undefined : data.value?.completeCasesAxesVars
-        }
-        showMissingness={vizConfig.showMissingness ?? false}
-        overlayVariable={vizConfig.overlayVariable}
-        overlayLabel={variableDisplayWithUnit(overlayVariable)}
-        facetVariable={vizConfig.facetVariable}
-        facetLabel={variableDisplayWithUnit(facetVariable)}
-        legendTitle={variableDisplayWithUnit(overlayVariable)}
-        dependentAxisLabel={
-          vizConfig.valueSpec === 'count' ? 'Count' : 'Proportion'
-        }
-        // for custom legend passing checked state in the  checkbox to PlotlyPlot
-        legendItems={legendItems}
-        checkedLegendItems={checkedLegendItems}
-        onCheckedLegendItemsChange={onCheckedLegendItemsChange}
-        totalCounts={totalCounts}
-        filteredCounts={filteredCounts}
-        // axis range control
-        vizConfig={vizConfig}
-        updateVizConfig={updateVizConfig}
-        valueType={valueType}
-        defaultUIState={defaultUIState}
-        defaultIndependentRange={defaultIndependentRange}
-        // add dependent axis range for better displaying tick labels in log-scale
-        defaultDependentAxisRange={defaultDependentAxisRange}
-        // pass truncation warning props
-        truncatedIndependentAxisWarning={truncatedIndependentAxisWarning}
-        setTruncatedIndependentAxisWarning={setTruncatedIndependentAxisWarning}
-        truncatedDependentAxisWarning={truncatedDependentAxisWarning}
-        setTruncatedDependentAxisWarning={setTruncatedDependentAxisWarning}
-        dependentMinPosMax={dependentMinPosMax}
-        areRequiredInputsSelected={areRequiredInputsSelected}
-      />
-    </div>
-  );
-}
-
-type HistogramPlotWithControlsProps = Omit<HistogramProps, 'data'> & {
-  data?: HistogramData | FacetedData<HistogramData>;
-  onBinWidthChange: (newBinWidth: NumberOrTimeDelta) => void;
-  onDependentAxisLogScaleChange: (newState?: boolean) => void;
-  filters?: Filter[];
-  outputEntity?: StudyEntity;
-  independentAxisVariable?: VariableDescriptor;
-  overlayVariable?: VariableDescriptor;
-  overlayLabel?: string;
-  facetVariable?: VariableDescriptor;
-  facetLabel?: string;
-  valueSpec: ValueSpec;
-  onValueSpecChange: (newValueSpec: ValueSpec) => void;
-  showMissingness: boolean;
-  updateThumbnail: (src: string) => void;
-  error: unknown;
-  // add props for custom legend
-  legendItems: LegendItemsProps[];
-  checkedLegendItems: string[] | undefined;
-  onCheckedLegendItemsChange: (checkedLegendItems: string[]) => void;
-  totalCounts: PromiseHookState<EntityCounts>;
-  filteredCounts: PromiseHookState<EntityCounts>;
-  // define types for axis range control
-  vizConfig: HistogramConfig;
-  updateVizConfig: (newConfig: Partial<HistogramConfig>) => void;
-  valueType: 'number' | 'date';
-  defaultUIState: UIState;
-  defaultIndependentRange: NumberOrDateRange | undefined;
-  defaultDependentAxisRange: NumberRange | undefined;
-  // pass truncation warning props
-  truncatedIndependentAxisWarning: string;
-  setTruncatedIndependentAxisWarning: (
-    truncatedIndependentAxisWarning: string
-  ) => void;
-  truncatedDependentAxisWarning: string;
-  setTruncatedDependentAxisWarning: (
-    truncatedDependentAxisWarning: string
-  ) => void;
-  outputSize?: number;
-  dependentMinPosMax: NumberRange | undefined;
-  areRequiredInputsSelected: boolean;
-} & Partial<CoverageStatistics>;
-
-function HistogramPlotWithControls({
-  data,
-  error,
-  onBinWidthChange,
-  onDependentAxisLogScaleChange,
-  filters,
-  completeCases,
-  completeCasesAllVars,
-  completeCasesAxesVars,
-  outputEntity,
-  independentAxisVariable,
-  overlayVariable,
-  overlayLabel,
-  facetVariable,
-  facetLabel,
-  valueSpec,
-  onValueSpecChange,
-  showMissingness,
-  updateThumbnail,
-  // add props for custom legend
-  legendItems,
-  checkedLegendItems,
-  onCheckedLegendItemsChange,
-  totalCounts,
-  filteredCounts,
-  // for axis range control
-  vizConfig,
-  updateVizConfig,
-  valueType,
-  defaultUIState,
-  defaultIndependentRange,
-  defaultDependentAxisRange,
-  // pass truncation warning props
-  truncatedIndependentAxisWarning,
-  setTruncatedIndependentAxisWarning,
-  truncatedDependentAxisWarning,
-  setTruncatedDependentAxisWarning,
-  outputSize,
-  dependentMinPosMax,
-  areRequiredInputsSelected,
-  ...histogramProps
-}: HistogramPlotWithControlsProps) {
-  const displayLibraryControls = false;
-  const opacity = 100;
-
-  const plotRef = useUpdateThumbnailEffect(
-    updateThumbnail,
-    plotContainerStyles,
-    [
-      data,
-      checkedLegendItems,
-      histogramProps.dependentAxisLogScale,
-      vizConfig.dependentAxisRange,
-    ]
-  );
-
   const widgetHeight = '4em';
 
   // controls need the bin info from just one facet (not an empty one)
-  const data0 = isFaceted(data)
-    ? data.facets.find(({ data }) => data != null && data.series.length > 0)
-        ?.data
-    : data;
+  const data0 = isFaceted(data.value)
+    ? data.value.facets.find(
+        ({ data }) => data != null && data.series.length > 0
+      )?.data
+    : data.value;
+
+  // set truncation flags: will see if this is reusable with other application
+  const {
+    truncationConfigIndependentAxisMin,
+    truncationConfigIndependentAxisMax,
+    truncationConfigDependentAxisMin,
+    truncationConfigDependentAxisMax,
+  } = useMemo(
+    () =>
+      truncationConfig(
+        {
+          ...defaultUIState, // using annotated range, NOT the actual data
+          ...(dependentMinPosMax != null
+            ? { dependentAxisRange: dependentMinPosMax }
+            : {}),
+        },
+        vizConfig,
+        {}, // no overrides
+        true // use inclusive less than equal for the range min
+      ),
+    [
+      defaultUIState,
+      dependentMinPosMax,
+      vizConfig.independentAxisRange,
+      vizConfig.dependentAxisRange,
+    ]
+  );
 
   // axis range control
   const handleIndependentAxisRangeChange = useCallback(
@@ -815,33 +634,6 @@ function HistogramPlotWithControls({
     setTruncatedDependentAxisWarning('');
   }, [updateVizConfig, setTruncatedDependentAxisWarning]);
 
-  // set truncation flags: will see if this is reusable with other application
-  const {
-    truncationConfigIndependentAxisMin,
-    truncationConfigIndependentAxisMax,
-    truncationConfigDependentAxisMin,
-    truncationConfigDependentAxisMax,
-  } = useMemo(
-    () =>
-      truncationConfig(
-        {
-          ...defaultUIState, // using annotated range, NOT the actual data
-          ...(dependentMinPosMax != null
-            ? { dependentAxisRange: dependentMinPosMax }
-            : {}),
-        },
-        vizConfig,
-        {}, // no overrides
-        true // use inclusive less than equal for the range min
-      ),
-    [
-      defaultUIState,
-      dependentMinPosMax,
-      vizConfig.independentAxisRange,
-      vizConfig.dependentAxisRange,
-    ]
-  );
-
   // set useEffect for changing truncation warning message
   useEffect(() => {
     if (
@@ -870,15 +662,36 @@ function HistogramPlotWithControls({
     setTruncatedDependentAxisWarning,
   ]);
 
-  // send histogramProps with additional props
-  const histogramPlotProps = {
-    ...histogramProps,
-    // axis range control
+  const plotRef = useUpdateThumbnailEffect(
+    updateThumbnail,
+    plotContainerStyles,
+    [
+      data,
+      checkedLegendItems,
+      vizConfig.dependentAxisLogScale,
+      vizConfig.dependentAxisRange,
+    ]
+  );
+
+  const histogramProps: HistogramProps = {
+    dependentAxisLogScale: vizConfig.dependentAxisLogScale,
+    independentAxisLabel: variableDisplayWithUnit(xAxisVariable) ?? 'Main',
+    dependentAxisLabel:
+      vizConfig.valueSpec === 'count' ? 'Count' : 'Proportion',
+    showSpinner: data.pending || filteredCounts.pending,
+    displayLegend: false,
+    displayLibraryControls: false,
+    legendTitle: variableDisplayWithUnit(overlayVariable),
+    spacingOptions: !isFaceted(data.value) ? spacingOptions : undefined,
+    interactive: !isFaceted(data.value) ? true : false,
+    opacity: 100,
+    showValues: false,
+    barLayout: 'stack',
+    orientation: 'vertical',
     independentAxisRange:
       vizConfig.independentAxisRange ?? defaultIndependentRange,
     dependentAxisRange:
       vizConfig.dependentAxisRange ?? defaultDependentAxisRange,
-    // pass axisTruncationConfig props
     axisTruncationConfig: {
       independentAxis: {
         min: truncationConfigIndependentAxisMin,
@@ -893,56 +706,34 @@ function HistogramPlotWithControls({
 
   const plotNode = (
     <>
-      {isFaceted(data) ? (
+      {isFaceted(data.value) ? (
         <FacetedHistogram
-          data={data}
-          // send histogramProps with additional props
-          componentProps={histogramPlotProps}
+          data={data.value}
+          componentProps={histogramProps}
           modalComponentProps={{
-            independentAxisLabel: histogramProps.independentAxisLabel,
-            dependentAxisLabel: histogramProps.dependentAxisLabel,
-            displayLegend: histogramProps.displayLegend,
+            ...histogramProps,
             containerStyles: modalPlotContainerStyles,
           }}
           facetedPlotRef={plotRef}
-          // for custom legend: pass checkedLegendItems to PlotlyPlot
           checkedLegendItems={checkedLegendItems}
         />
       ) : (
         <Histogram
           {...histogramProps}
           ref={plotRef}
-          data={data}
-          opacity={opacity}
-          displayLibraryControls={displayLibraryControls}
-          showValues={false}
-          // for custom legend: pass checkedLegendItems to PlotlyPlot
+          data={data.value}
           checkedLegendItems={checkedLegendItems}
-          // axis range control
-          independentAxisRange={
-            vizConfig.independentAxisRange ?? defaultIndependentRange
-          }
-          dependentAxisRange={
-            vizConfig.dependentAxisRange ?? defaultDependentAxisRange
-          }
-          // pass axisTruncationConfig
-          axisTruncationConfig={{
-            independentAxis: {
-              min: truncationConfigIndependentAxisMin,
-              max: truncationConfigIndependentAxisMax,
-            },
-            dependentAxis: {
-              min: truncationConfigDependentAxisMin,
-              max: truncationConfigDependentAxisMax,
-            },
-          }}
         />
       )}
+    </>
+  );
 
+  const controlsNode = (
+    <>
       {/* Plot mode */}
       <RadioButtonGroup
         label="Plot mode"
-        selectedOption={valueSpec}
+        selectedOption={vizConfig.valueSpec}
         options={['count', 'proportion']}
         buttonColor={'primary'}
         margins={['1em', '0', '0', '1em']}
@@ -1120,52 +911,109 @@ function HistogramPlotWithControls({
   const tableGroupNode = (
     <>
       <BirdsEyeView
-        completeCasesAllVars={completeCasesAllVars}
-        completeCasesAxesVars={completeCasesAxesVars}
+        completeCasesAllVars={
+          data.pending ? undefined : data.value?.completeCasesAllVars
+        }
+        completeCasesAxesVars={
+          data.pending ? undefined : data.value?.completeCasesAxesVars
+        }
         outputEntity={outputEntity}
         stratificationIsActive={
           overlayVariable != null || facetVariable != null
         }
-        enableSpinner={independentAxisVariable != null && !error}
+        enableSpinner={vizConfig.xAxisVariable != null && !data.error}
         totalCounts={totalCounts.value}
         filteredCounts={filteredCounts.value}
       />
       <VariableCoverageTable
-        completeCases={completeCases}
+        completeCases={data.pending ? undefined : data.value?.completeCases}
         filteredCounts={filteredCounts}
-        outputEntityId={independentAxisVariable?.entityId}
+        outputEntityId={outputEntity?.id}
         variableSpecs={[
           {
             role: 'Main',
             required: true,
             display: histogramProps.independentAxisLabel,
-            variable: independentAxisVariable,
+            variable: vizConfig.xAxisVariable,
           },
           {
             role: 'Overlay',
-            display: overlayLabel,
-            variable: overlayVariable,
+            display: variableDisplayWithUnit(overlayVariable),
+            variable: vizConfig.overlayVariable,
           },
           {
             role: 'Facet',
-            display: facetLabel,
-            variable: facetVariable,
+            display: variableDisplayWithUnit(facetVariable),
+            variable: vizConfig.facetVariable,
           },
         ]}
       />
     </>
   );
 
+  const LayoutComponent = options?.layoutComponent ?? PlotLayout;
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
-      <PlotLayout
-        isFaceted={isFaceted(data)}
-        plotNode={plotNode}
-        legendNode={showOverlayLegend ? legendNode : null}
-        tableGroupNode={tableGroupNode}
-        showRequiredInputsPrompt={!areRequiredInputsSelected}
-      />
+      <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
+        <InputVariables
+          inputs={[
+            {
+              name: 'xAxisVariable',
+              label: 'Main',
+              role: 'axis',
+            },
+            {
+              name: 'overlayVariable',
+              label: 'Overlay',
+              role: 'stratification',
+            },
+            {
+              name: 'facetVariable',
+              label: 'Facet',
+              role: 'stratification',
+            },
+          ]}
+          entities={entities}
+          selectedVariables={{
+            xAxisVariable: vizConfig.xAxisVariable,
+            overlayVariable: vizConfig.overlayVariable,
+            facetVariable: vizConfig.facetVariable,
+          }}
+          onChange={handleInputVariableChange}
+          constraints={dataElementConstraints}
+          dataElementDependencyOrder={dataElementDependencyOrder}
+          starredVariables={starredVariables}
+          toggleStarredVariable={toggleStarredVariable}
+          enableShowMissingnessToggle={
+            (overlayVariable != null || facetVariable != null) &&
+            data.value?.completeCasesAllVars !==
+              data.value?.completeCasesAxesVars
+          }
+          showMissingness={vizConfig.showMissingness}
+          // this can be used to show and hide no data control
+          onShowMissingnessChange={
+            computation.descriptor.type === 'pass'
+              ? onShowMissingnessChange
+              : undefined
+          }
+          outputEntity={outputEntity}
+        />
+      </div>
+
+      <PluginError error={data.error} outputSize={outputSize} />
+
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
+        <LayoutComponent
+          isFaceted={isFaceted(data.value)}
+          plotNode={plotNode}
+          controlsNode={controlsNode}
+          legendNode={showOverlayLegend ? legendNode : null}
+          tableGroupNode={tableGroupNode}
+          showRequiredInputsPrompt={!areRequiredInputsSelected}
+        />
+      </div>
     </div>
   );
 }

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -48,7 +48,7 @@ import { CoverageStatistics } from '../../../types/visualization';
 import { VariableCoverageTable } from '../../VariableCoverageTable';
 import { BirdsEyeView } from '../../BirdsEyeView';
 import { PlotLayout } from '../../layouts/PlotLayout';
-import { InputSpec, InputVariables } from '../InputVariables';
+import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
 import { VisualizationProps } from '../VisualizationTypes';
 import histogram from './selectorIcons/histogram.svg';
@@ -974,9 +974,11 @@ function HistogramViz(props: VisualizationProps<Options>) {
               label: 'Overlay',
               role: 'stratification',
               readonlyValue:
-                options?.getOverlayVariable != null && providedOverlayVariable
-                  ? overlayLabel
-                  : 'none',
+                options?.getOverlayVariable != null
+                  ? providedOverlayVariable
+                    ? overlayLabel
+                    : 'none'
+                  : undefined,
               // TO DO: verbiage for 'none'
             },
             ...(options?.hideFacetInputs
@@ -986,7 +988,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
                     name: 'facetVariable',
                     label: 'Facet',
                     role: 'stratification',
-                  } as InputSpec,
+                  } as const,
                 ]),
           ]}
           entities={entities}

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -4,13 +4,7 @@ import LinePlot, {
 } from '@veupathdb/components/lib/plots/LinePlot';
 
 import * as t from 'io-ts';
-import {
-  useCallback,
-  useMemo,
-  useState,
-  useEffect,
-  useDebugValue,
-} from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
 
 import DataClient, {
   LineplotRequestParams,
@@ -113,11 +107,11 @@ import { truncationConfig } from '../../../utils/truncation-config-utils';
 import Notification from '@veupathdb/components/lib/components/widgets//Notification';
 import Button from '@veupathdb/components/lib/components/widgets/Button';
 import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
-import { UIState } from '../../filter/HistogramFilter';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
 import { useDefaultAxisRange } from '../../../hooks/computeDefaultAxisRange';
 
 import useSnackbar from '@veupathdb/coreui/dist/components/notifications/useSnackbar';
+import { LayoutOptions } from '../../layouts/types';
 
 const plotContainerStyles = {
   width: 750,
@@ -210,8 +204,11 @@ export const LineplotConfig = t.intersection([
   }),
 ]);
 
-function LineplotViz(props: VisualizationProps) {
+interface Options extends LayoutOptions {}
+
+function LineplotViz(props: VisualizationProps<Options>) {
   const {
+    options,
     computation,
     visualization,
     updateConfiguration,
@@ -701,18 +698,6 @@ function LineplotViz(props: VisualizationProps) {
     vizConfig.checkedLegendItems
   );
 
-  // axis range control
-  const defaultUIState = useMemo(() => {
-    if (xAxisVariable != null)
-      return {
-        independentAxisRange: defaultIndependentAxisRange,
-      };
-    else
-      return {
-        independentAxisRange: undefined,
-      };
-  }, [xAxisVariable, defaultIndependentAxisRange]);
-
   const areRequiredInputsSelected = useMemo(() => {
     if (!dataElementConstraints) return false;
     if (
@@ -736,69 +721,512 @@ function LineplotViz(props: VisualizationProps) {
     vizConfig.numeratorValues,
   ]);
 
-  const plotNode = (
-    <LineplotWithControls
-      // data.value
-      data={data.value?.dataSetProcess}
-      updateThumbnail={updateThumbnail}
-      containerStyles={
-        !isFaceted(data.value?.dataSetProcess) ? plotContainerStyles : undefined
-      }
-      spacingOptions={
-        !isFaceted(data.value?.dataSetProcess) ? plotSpacingOptions : undefined
-      }
-      displayLegend={false}
-      independentAxisLabel={variableDisplayWithUnit(xAxisVariable) ?? 'X-axis'}
-      // set dependent axis label as Proportion conditionally
-      dependentAxisLabel={
-        vizConfig.valueSpecConfig === 'Proportion'
-          ? 'Proportion'
-          : variableDisplayWithUnit(yAxisVariable)
-          ? vizConfig.valueSpecConfig === 'Mean'
-            ? 'Mean: ' + variableDisplayWithUnit(yAxisVariable)
-            : vizConfig.valueSpecConfig === 'Median'
-            ? 'Median: ' + variableDisplayWithUnit(yAxisVariable)
-            : 'Y-axis'
+  // set truncation flags: will see if this is reusable with other application
+  const {
+    truncationConfigIndependentAxisMin,
+    truncationConfigIndependentAxisMax,
+    truncationConfigDependentAxisMin,
+    truncationConfigDependentAxisMax,
+  } = useMemo(
+    () =>
+      truncationConfig(
+        {
+          independentAxisRange: xMinMaxDataRange,
+          dependentAxisRange: yMinMaxDataRange,
+        },
+        vizConfig,
+        {
+          // overrides for logscale when values go zero or negative
+          ...(vizConfig.independentAxisLogScale &&
+          xMinMaxDataRange?.min != null &&
+          xMinMaxDataRange.min <= 0
+            ? { truncationConfigIndependentAxisMin: true }
+            : {}),
+          ...(vizConfig.dependentAxisLogScale &&
+          yMinMaxDataRange?.min != null &&
+          yMinMaxDataRange.min <= 0
+            ? { truncationConfigDependentAxisMin: true }
+            : {}),
+        }
+      ),
+    [
+      xMinMaxDataRange,
+      yMinMaxDataRange,
+      vizConfig.independentAxisRange,
+      vizConfig.dependentAxisRange,
+      vizConfig.independentAxisLogScale,
+      vizConfig.dependentAxisLogScale,
+    ]
+  );
+
+  const plotRef = useUpdateThumbnailEffect(
+    updateThumbnail,
+    plotContainerStyles,
+    [
+      data,
+      checkedLegendItems,
+      // considering axis range control too
+      vizConfig.independentAxisRange,
+      vizConfig.dependentAxisRange,
+      vizConfig.independentAxisLogScale,
+      vizConfig.dependentAxisLogScale,
+    ]
+  );
+
+  const lineplotProps: LinePlotProps = {
+    independentAxisLabel: variableDisplayWithUnit(xAxisVariable) ?? 'X-axis',
+    dependentAxisLabel:
+      vizConfig.valueSpecConfig === 'Proportion'
+        ? 'Proportion'
+        : variableDisplayWithUnit(yAxisVariable)
+        ? vizConfig.valueSpecConfig === 'Mean'
+          ? 'Mean: ' + variableDisplayWithUnit(yAxisVariable)
+          : vizConfig.valueSpecConfig === 'Median'
+          ? 'Median: ' + variableDisplayWithUnit(yAxisVariable)
           : 'Y-axis'
-      }
-      // set valueSpec as Raw when yAxisVariable = date
-      onBinWidthChange={onBinWidthChange}
-      vizType={visualization.descriptor.type}
-      interactive={!isFaceted(data.value) ? true : false}
-      showSpinner={filteredCounts.pending || data.pending}
-      // axis range control: make default as number format
-      independentValueType={
-        DateVariable.is(xAxisVariable)
-          ? 'date'
-          : StringVariable.is(xAxisVariable)
-          ? 'string'
-          : 'number'
-      }
-      dependentValueType={DateVariable.is(yAxisVariable) ? 'date' : 'number'}
-      legendTitle={variableDisplayWithUnit(overlayVariable)}
-      checkedLegendItems={checkedLegendItems}
-      onCheckedLegendItemsChange={onCheckedLegendItemsChange}
-      useBinning={vizConfig.useBinning}
-      onUseBinningChange={onUseBinningChange}
-      showErrorBars={vizConfig.showErrorBars ?? false}
-      onShowErrorBarsChange={onShowErrorBarsChange}
-      // axis range control
-      vizConfig={vizConfig}
-      updateVizConfig={updateVizConfig}
-      defaultUIState={defaultUIState}
-      defaultIndependentRange={defaultIndependentAxisRange}
-      // add dependent axis range for better displaying tick labels in log-scale
-      defaultDependentAxisRange={defaultDependentAxisRange}
-      // pass useState of truncation warnings
-      truncatedIndependentAxisWarning={truncatedIndependentAxisWarning}
-      setTruncatedIndependentAxisWarning={setTruncatedIndependentAxisWarning}
-      truncatedDependentAxisWarning={truncatedDependentAxisWarning}
-      setTruncatedDependentAxisWarning={setTruncatedDependentAxisWarning}
-      onIndependentAxisLogScaleChange={onIndependentAxisLogScaleChange}
-      onDependentAxisLogScaleChange={onDependentAxisLogScaleChange}
-      xMinMaxDataRange={xMinMaxDataRange}
-      yMinMaxDataRange={yMinMaxDataRange}
-    />
+        : 'Y-axis',
+    displayLegend: false,
+    containerStyles: !isFaceted(data.value?.dataSetProcess)
+      ? plotContainerStyles
+      : undefined,
+    spacingOptions: !isFaceted(data.value?.dataSetProcess)
+      ? plotSpacingOptions
+      : undefined,
+    interactive: !isFaceted(data.value?.dataSetProcess) ? true : false,
+
+    independentValueType: DateVariable.is(xAxisVariable)
+      ? 'date'
+      : StringVariable.is(xAxisVariable)
+      ? 'string'
+      : 'number',
+    dependentValueType: DateVariable.is(yAxisVariable) ? 'date' : 'number',
+
+    axisTruncationConfig: {
+      independentAxis: {
+        min: truncationConfigIndependentAxisMin,
+        max: truncationConfigIndependentAxisMax,
+      },
+      dependentAxis: {
+        min: truncationConfigDependentAxisMin,
+        max: truncationConfigDependentAxisMax,
+      },
+    },
+    independentAxisLogScale: vizConfig.independentAxisLogScale,
+    dependentAxisLogScale: vizConfig.dependentAxisLogScale,
+
+    independentAxisRange:
+      vizConfig.independentAxisRange ?? defaultIndependentAxisRange,
+    dependentAxisRange:
+      vizConfig.dependentAxisRange ?? defaultDependentAxisRange,
+  };
+
+  const plotNode = (
+    <>
+      {isFaceted(data.value?.dataSetProcess) ? (
+        <FacetedLinePlot
+          data={data.value?.dataSetProcess}
+          // considering axis range control
+          componentProps={lineplotProps}
+          modalComponentProps={{
+            ...lineplotProps,
+            containerStyles: modalPlotContainerStyles,
+          }}
+          facetedPlotRef={plotRef}
+          checkedLegendItems={checkedLegendItems}
+        />
+      ) : (
+        <LinePlot
+          {...lineplotProps}
+          ref={plotRef}
+          data={data.value?.dataSetProcess}
+          // add controls
+          displayLibraryControls={false}
+          // custom legend: pass checkedLegendItems to PlotlyPlot
+          checkedLegendItems={checkedLegendItems}
+        />
+      )}
+    </>
+  );
+
+  const [
+    dismissedIndependentAllNegativeWarning,
+    setDismissedIndependentAllNegativeWarning,
+  ] = useState<boolean>(false);
+  const independentAllNegative = // or zero
+    vizConfig.independentAxisLogScale &&
+    xMinMaxDataRange?.max != null &&
+    xMinMaxDataRange.max <= 0;
+
+  const [
+    dismissedDependentAllNegativeWarning,
+    setDismissedDependentAllNegativeWarning,
+  ] = useState<boolean>(false);
+  const dependentAllNegative = // or zero
+    vizConfig.dependentAxisLogScale &&
+    yMinMaxDataRange?.max != null &&
+    yMinMaxDataRange.max <= 0;
+
+  const { enqueueSnackbar } = useSnackbar();
+
+  const widgetHeight = '4em';
+
+  // controls need the bin info from just one facet (not an empty one)
+  const data0 = isFaceted(data.value?.dataSetProcess)
+    ? data.value?.dataSetProcess.facets.find(
+        ({ data }) => data != null && data.series.length > 0
+      )?.data
+    : data.value?.dataSetProcess;
+
+  const neverUseBinning = data0?.binWidthSlider == null; // for ordinal string x-variables
+  // axis range control
+  const neverShowErrorBars = lineplotProps.dependentValueType === 'date';
+
+  // axis range control
+  const handleIndependentAxisRangeChange = useCallback(
+    (newRange?: NumberOrDateRange) => {
+      updateVizConfig({
+        independentAxisRange:
+          newRange &&
+          ({
+            min:
+              typeof newRange.min === 'string'
+                ? padISODateTime(newRange.min)
+                : newRange.min,
+            max:
+              typeof newRange.max === 'string'
+                ? padISODateTime(newRange.max)
+                : newRange.max,
+          } as NumberOrDateRange),
+      });
+    },
+    [updateVizConfig]
+  );
+
+  const handleIndependentAxisSettingsReset = useCallback(() => {
+    updateVizConfig({
+      independentAxisRange: undefined,
+      independentAxisLogScale: false,
+    });
+    // add reset for truncation message: including dependent axis warning as well
+    setTruncatedIndependentAxisWarning('');
+  }, [updateVizConfig, setTruncatedIndependentAxisWarning]);
+
+  const handleDependentAxisRangeChange = useCallback(
+    (newRange?: NumberOrDateRange) => {
+      updateVizConfig({
+        dependentAxisRange:
+          newRange &&
+          ({
+            min:
+              typeof newRange.min === 'string'
+                ? padISODateTime(newRange.min)
+                : newRange.min,
+            max:
+              typeof newRange.max === 'string'
+                ? padISODateTime(newRange.max)
+                : newRange.max,
+          } as NumberOrDateRange),
+      });
+    },
+    [updateVizConfig]
+  );
+
+  const handleDependentAxisSettingsReset = useCallback(() => {
+    updateVizConfig({
+      dependentAxisRange: undefined,
+      dependentAxisLogScale: false,
+    });
+    // add reset for truncation message as well
+    setTruncatedDependentAxisWarning('');
+  }, [updateVizConfig, setTruncatedDependentAxisWarning]);
+
+  // set useEffect for changing truncation warning message
+  useEffect(() => {
+    if (
+      truncationConfigIndependentAxisMin ||
+      truncationConfigIndependentAxisMax
+    ) {
+      setTruncatedIndependentAxisWarning(
+        'Data may have been truncated by range selection, as indicated by the yellow shading'
+      );
+    }
+  }, [
+    truncationConfigIndependentAxisMin,
+    truncationConfigIndependentAxisMax,
+    setTruncatedIndependentAxisWarning,
+  ]);
+
+  useEffect(() => {
+    if (
+      // (truncationConfigDependentAxisMin || truncationConfigDependentAxisMax) &&
+      // !scatterplotProps.showSpinner
+      truncationConfigDependentAxisMin ||
+      truncationConfigDependentAxisMax
+    ) {
+      setTruncatedDependentAxisWarning(
+        'Data may have been truncated by range selection, as indicated by the yellow shading'
+      );
+    }
+  }, [
+    truncationConfigDependentAxisMin,
+    truncationConfigDependentAxisMax,
+    setTruncatedDependentAxisWarning,
+  ]);
+
+  const controlsNode = (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'row' }}>
+        <LabelledGroup
+          label="X-axis controls"
+          containerStyles={{
+            marginRight: '1em',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              marginTop: '0.8em',
+              marginBottom: '0.8em',
+            }}
+          >
+            <Switch
+              label="Log scale (will exclude values &le; 0):"
+              state={vizConfig.independentAxisLogScale}
+              onStateChange={(newValue: boolean) => {
+                setDismissedIndependentAllNegativeWarning(false);
+                onIndependentAxisLogScaleChange(newValue);
+                if (newValue && vizConfig.useBinning)
+                  enqueueSnackbar(
+                    'Binning is no longer appropriate and has been disabled'
+                  );
+              }}
+              disabled={lineplotProps.independentValueType === 'date'}
+            />
+          </div>
+          {independentAllNegative && !dismissedIndependentAllNegativeWarning ? (
+            <Notification
+              title={''}
+              text={
+                'Nothing can be plotted with log scale because all values are zero or negative'
+              }
+              color={'#5586BE'}
+              onAcknowledgement={() =>
+                setDismissedIndependentAllNegativeWarning(true)
+              }
+              showWarningIcon={true}
+              containerStyles={{ maxWidth: '350px' }}
+            />
+          ) : null}
+          <Switch
+            label={`Binning ${vizConfig.useBinning ? 'on' : 'off'}`}
+            state={vizConfig.useBinning}
+            onStateChange={(newValue: boolean) => {
+              onUseBinningChange(newValue);
+              if (newValue && vizConfig.independentAxisLogScale)
+                enqueueSnackbar(
+                  'Log scale is no longer appropriate and has been disabled'
+                );
+            }}
+            disabled={neverUseBinning}
+          />
+          <BinWidthControl
+            binWidth={data0?.binWidthSlider?.binWidth}
+            onBinWidthChange={onBinWidthChange}
+            binWidthRange={data0?.binWidthSlider?.binWidthRange}
+            binWidthStep={data0?.binWidthSlider?.binWidthStep}
+            valueType={data0?.binWidthSlider?.valueType}
+            binUnit={
+              data0?.binWidthSlider?.valueType === 'date'
+                ? (data0?.binWidthSlider?.binWidth as TimeDelta).unit
+                : undefined
+            }
+            binUnitOptions={
+              data0?.binWidthSlider?.valueType === 'date'
+                ? ['day', 'week', 'month', 'year']
+                : undefined
+            }
+            containerStyles={{
+              minHeight: widgetHeight,
+              // considering axis range control
+              maxWidth:
+                lineplotProps.independentValueType === 'date'
+                  ? '250px'
+                  : '350px',
+            }}
+            disabled={!vizConfig.useBinning || neverUseBinning}
+          />
+          {/* X-Axis range control */}
+          {/* designed to disable X-axis range control for categorical X */}
+          <AxisRangeControl
+            // change label for disabled case
+            label={
+              lineplotProps.independentValueType === 'string'
+                ? 'Range (not available)'
+                : 'Range'
+            }
+            range={
+              vizConfig.independentAxisRange ?? defaultIndependentAxisRange
+            }
+            onRangeChange={handleIndependentAxisRangeChange}
+            // will disable for categorical X so this is sufficient
+            valueType={
+              lineplotProps.independentValueType === 'date' ? 'date' : 'number'
+            }
+            // set maxWidth
+            containerStyles={{ maxWidth: '350px' }}
+            // input forms are diabled for categorical X
+            disabled={lineplotProps.independentValueType === 'string'}
+          />
+          {/* truncation notification */}
+          {truncatedIndependentAxisWarning && !independentAllNegative ? (
+            <Notification
+              title={''}
+              text={truncatedIndependentAxisWarning}
+              // this was defined as LIGHT_BLUE
+              color={'#5586BE'}
+              onAcknowledgement={() => {
+                setTruncatedIndependentAxisWarning('');
+              }}
+              showWarningIcon={true}
+              // set maxWidth per type
+              containerStyles={{
+                maxWidth:
+                  lineplotProps.independentValueType === 'date'
+                    ? '350px'
+                    : '350px',
+              }}
+            />
+          ) : null}
+          <Button
+            type={'outlined'}
+            text={'Reset to defaults'}
+            onClick={handleIndependentAxisSettingsReset}
+            containerStyles={{
+              paddingTop: '1.0em',
+              width: '50%',
+              float: 'right',
+              // to match reset button with date range form
+              marginRight:
+                lineplotProps.independentValueType === 'date' ? '-1em' : '',
+            }}
+            // reset button is diabled for categorical X
+            disabled={lineplotProps.independentValueType === 'string'}
+          />
+        </LabelledGroup>
+
+        {/* add vertical line in btw Y- and X- controls */}
+        <div
+          style={{
+            display: 'inline-flex',
+            borderLeft: '2px solid lightgray',
+            height: '19.3em',
+            position: 'relative',
+            marginLeft: '-1px',
+            top: '1.5em',
+          }}
+        >
+          {' '}
+        </div>
+        <LabelledGroup
+          label="Y-axis controls"
+          containerStyles={{
+            marginRight: '0em',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              marginTop: '0.8em',
+              marginBottom: '0.8em',
+            }}
+          >
+            <Switch
+              label="Log scale (will exclude values &le; 0):"
+              state={vizConfig.dependentAxisLogScale}
+              onStateChange={(newValue: boolean) => {
+                setDismissedDependentAllNegativeWarning(false);
+                onDependentAxisLogScaleChange(newValue);
+                if (newValue && vizConfig.showErrorBars)
+                  enqueueSnackbar(
+                    'Error bars are no longer appropriate and have been disabled'
+                  );
+              }}
+              disabled={lineplotProps.dependentValueType === 'date'}
+            />
+          </div>
+          {dependentAllNegative && !dismissedDependentAllNegativeWarning ? (
+            <Notification
+              title={''}
+              text={
+                'Nothing can be plotted with log scale because all values are zero or negative'
+              }
+              color={'#5586BE'}
+              onAcknowledgement={() =>
+                setDismissedDependentAllNegativeWarning(true)
+              }
+              showWarningIcon={true}
+              containerStyles={{ maxWidth: '350px' }}
+            />
+          ) : null}
+          <Switch
+            label="Show error bars (95% C.I.)"
+            state={vizConfig.showErrorBars}
+            onStateChange={(newValue: boolean) => {
+              onShowErrorBarsChange(newValue);
+              if (newValue && vizConfig.dependentAxisLogScale)
+                enqueueSnackbar(
+                  'Log scale is no longer appropriate and has been disabled'
+                );
+            }}
+            disabled={neverShowErrorBars}
+          />
+          {/* Y-axis range control */}
+          {/* make some space to match with X-axis range control */}
+          <div style={{ height: '4em' }} />
+          <AxisRangeControl
+            label="Range"
+            range={vizConfig.dependentAxisRange ?? defaultDependentAxisRange}
+            valueType={
+              lineplotProps.dependentValueType === 'date' ? 'date' : 'number'
+            }
+            onRangeChange={(newRange?: NumberOrDateRange) => {
+              handleDependentAxisRangeChange(newRange);
+            }}
+            // set maxWidth
+            containerStyles={{ maxWidth: '350px' }}
+          />
+          {/* truncation notification */}
+          {truncatedDependentAxisWarning && !dependentAllNegative ? (
+            <Notification
+              title={''}
+              text={truncatedDependentAxisWarning}
+              // this was defined as LIGHT_BLUE
+              color={'#5586BE'}
+              onAcknowledgement={() => {
+                setTruncatedDependentAxisWarning('');
+              }}
+              showWarningIcon={true}
+              // change maxWidth
+              containerStyles={{ maxWidth: '350px' }}
+            />
+          ) : null}
+          <Button
+            type={'outlined'}
+            // change text
+            text={'Reset to defaults'}
+            onClick={handleDependentAxisSettingsReset}
+            containerStyles={{
+              paddingTop: '1.0em',
+              width: '50%',
+              float: 'right',
+              // to match reset button with date range form
+              marginRight:
+                lineplotProps.dependentValueType === 'date' ? '-1em' : '',
+            }}
+          />
+        </LabelledGroup>
+      </div>
+    </>
   );
 
   const showOverlayLegend =
@@ -980,6 +1408,8 @@ function LineplotViz(props: VisualizationProps) {
     </div>
   );
 
+  const LayoutComponent = options?.layoutComponent ?? PlotLayout;
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
@@ -1050,550 +1480,15 @@ function LineplotViz(props: VisualizationProps) {
 
       <PluginError error={data.error} outputSize={outputSize} />
       <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
-      <PlotLayout
+      <LayoutComponent
         isFaceted={isFaceted(data.value?.dataSetProcess)}
         legendNode={showOverlayLegend ? legendNode : null}
         plotNode={plotNode}
+        controlsNode={controlsNode}
         tableGroupNode={tableGroupNode}
         showRequiredInputsPrompt={!areRequiredInputsSelected}
       />
     </div>
-  );
-}
-
-type LineplotWithControlsProps = Omit<LinePlotProps, 'data'> & {
-  data?: LinePlotData | FacetedData<LinePlotData>;
-  onBinWidthChange: (newBinWidth: NumberOrTimeDelta) => void;
-  updateThumbnail: (src: string) => void;
-  vizType: string;
-  // custom legend
-  checkedLegendItems: string[] | undefined;
-  onCheckedLegendItemsChange: (checkedLegendItems: string[]) => void;
-  useBinning: boolean;
-  onUseBinningChange: (newValue: boolean) => void;
-  showErrorBars: boolean;
-  onShowErrorBarsChange: (newValue: boolean) => void;
-  // define types for axis range control
-  vizConfig: LineplotConfig;
-  updateVizConfig: (newConfig: Partial<LineplotConfig>) => void;
-  defaultUIState: Partial<UIState>;
-  defaultIndependentRange: NumberOrDateRange | undefined;
-  defaultDependentAxisRange: NumberOrDateRange | undefined;
-  // pass useState of truncation warnings
-  truncatedIndependentAxisWarning: string;
-  setTruncatedIndependentAxisWarning: (
-    truncatedIndependentAxisWarning: string
-  ) => void;
-  truncatedDependentAxisWarning: string;
-  setTruncatedDependentAxisWarning: (
-    truncatedDependentAxisWarning: string
-  ) => void;
-  onIndependentAxisLogScaleChange: (value: boolean) => void;
-  onDependentAxisLogScaleChange: (value: boolean) => void;
-  xMinMaxDataRange: NumberOrDateRange | undefined;
-  yMinMaxDataRange: NumberOrDateRange | undefined;
-};
-
-function LineplotWithControls({
-  data,
-  // LinePlotControls: set initial value as 'raw' ('Raw')
-  onBinWidthChange,
-  vizType,
-  updateThumbnail,
-  // custom legend
-  checkedLegendItems,
-  onCheckedLegendItemsChange,
-  useBinning,
-  onUseBinningChange,
-  showErrorBars,
-  onShowErrorBarsChange,
-  // for axis range control
-  vizConfig,
-  updateVizConfig,
-  independentValueType,
-  dependentValueType,
-  defaultUIState,
-  defaultIndependentRange,
-  defaultDependentAxisRange,
-  truncatedIndependentAxisWarning,
-  setTruncatedIndependentAxisWarning,
-  truncatedDependentAxisWarning,
-  setTruncatedDependentAxisWarning,
-  onIndependentAxisLogScaleChange,
-  onDependentAxisLogScaleChange,
-  xMinMaxDataRange,
-  yMinMaxDataRange,
-  ...lineplotProps
-}: LineplotWithControlsProps) {
-  const plotRef = useUpdateThumbnailEffect(
-    updateThumbnail,
-    plotContainerStyles,
-    [
-      data,
-      checkedLegendItems,
-      // considering axis range control too
-      vizConfig.independentAxisRange,
-      vizConfig.dependentAxisRange,
-      vizConfig.independentAxisLogScale,
-      vizConfig.dependentAxisLogScale,
-    ]
-  );
-
-  const widgetHeight = '4em';
-
-  // controls need the bin info from just one facet (not an empty one)
-  const data0 = isFaceted(data)
-    ? data.facets.find(({ data }) => data != null && data.series.length > 0)
-        ?.data
-    : data;
-
-  const neverUseBinning = data0?.binWidthSlider == null; // for ordinal string x-variables
-  // axis range control
-  const neverShowErrorBars = dependentValueType === 'date';
-
-  // axis range control
-  const handleIndependentAxisRangeChange = useCallback(
-    (newRange?: NumberOrDateRange) => {
-      updateVizConfig({
-        independentAxisRange:
-          newRange &&
-          ({
-            min:
-              typeof newRange.min === 'string'
-                ? padISODateTime(newRange.min)
-                : newRange.min,
-            max:
-              typeof newRange.max === 'string'
-                ? padISODateTime(newRange.max)
-                : newRange.max,
-          } as NumberOrDateRange),
-      });
-    },
-    [updateVizConfig]
-  );
-
-  const handleIndependentAxisSettingsReset = useCallback(() => {
-    updateVizConfig({
-      independentAxisRange: undefined,
-      independentAxisLogScale: false,
-    });
-    // add reset for truncation message: including dependent axis warning as well
-    setTruncatedIndependentAxisWarning('');
-  }, [updateVizConfig, setTruncatedIndependentAxisWarning]);
-
-  const handleDependentAxisRangeChange = useCallback(
-    (newRange?: NumberOrDateRange) => {
-      updateVizConfig({
-        dependentAxisRange:
-          newRange &&
-          ({
-            min:
-              typeof newRange.min === 'string'
-                ? padISODateTime(newRange.min)
-                : newRange.min,
-            max:
-              typeof newRange.max === 'string'
-                ? padISODateTime(newRange.max)
-                : newRange.max,
-          } as NumberOrDateRange),
-      });
-    },
-    [updateVizConfig]
-  );
-
-  const handleDependentAxisSettingsReset = useCallback(() => {
-    updateVizConfig({
-      dependentAxisRange: undefined,
-      dependentAxisLogScale: false,
-    });
-    // add reset for truncation message as well
-    setTruncatedDependentAxisWarning('');
-  }, [updateVizConfig, setTruncatedDependentAxisWarning]);
-
-  // set truncation flags: will see if this is reusable with other application
-  const {
-    truncationConfigIndependentAxisMin,
-    truncationConfigIndependentAxisMax,
-    truncationConfigDependentAxisMin,
-    truncationConfigDependentAxisMax,
-  } = useMemo(
-    () =>
-      truncationConfig(
-        {
-          independentAxisRange: xMinMaxDataRange,
-          dependentAxisRange: yMinMaxDataRange,
-        },
-        vizConfig,
-        {
-          // overrides for logscale when values go zero or negative
-          ...(vizConfig.independentAxisLogScale &&
-          xMinMaxDataRange?.min != null &&
-          xMinMaxDataRange.min <= 0
-            ? { truncationConfigIndependentAxisMin: true }
-            : {}),
-          ...(vizConfig.dependentAxisLogScale &&
-          yMinMaxDataRange?.min != null &&
-          yMinMaxDataRange.min <= 0
-            ? { truncationConfigDependentAxisMin: true }
-            : {}),
-        }
-      ),
-    [
-      xMinMaxDataRange,
-      yMinMaxDataRange,
-      vizConfig.independentAxisRange,
-      vizConfig.dependentAxisRange,
-      vizConfig.independentAxisLogScale,
-      vizConfig.dependentAxisLogScale,
-    ]
-  );
-
-  // set useEffect for changing truncation warning message
-  useEffect(() => {
-    if (
-      truncationConfigIndependentAxisMin ||
-      truncationConfigIndependentAxisMax
-    ) {
-      setTruncatedIndependentAxisWarning(
-        'Data may have been truncated by range selection, as indicated by the yellow shading'
-      );
-    }
-  }, [
-    truncationConfigIndependentAxisMin,
-    truncationConfigIndependentAxisMax,
-    setTruncatedIndependentAxisWarning,
-  ]);
-
-  useEffect(() => {
-    if (
-      // (truncationConfigDependentAxisMin || truncationConfigDependentAxisMax) &&
-      // !scatterplotProps.showSpinner
-      truncationConfigDependentAxisMin ||
-      truncationConfigDependentAxisMax
-    ) {
-      setTruncatedDependentAxisWarning(
-        'Data may have been truncated by range selection, as indicated by the yellow shading'
-      );
-    }
-  }, [
-    truncationConfigDependentAxisMin,
-    truncationConfigDependentAxisMax,
-    setTruncatedDependentAxisWarning,
-  ]);
-
-  const lineplotPlotProps = {
-    ...lineplotProps,
-    // axis range control
-    independentAxisRange:
-      vizConfig.independentAxisRange ?? defaultIndependentRange,
-    dependentAxisRange:
-      vizConfig.dependentAxisRange ?? defaultDependentAxisRange,
-    // pass valueTypes
-    independentValueType: independentValueType,
-    dependentValueType: dependentValueType,
-    // pass axisTruncationConfig
-    axisTruncationConfig: {
-      independentAxis: {
-        min: truncationConfigIndependentAxisMin,
-        max: truncationConfigIndependentAxisMax,
-      },
-      dependentAxis: {
-        min: truncationConfigDependentAxisMin,
-        max: truncationConfigDependentAxisMax,
-      },
-    },
-    independentAxisLogScale: vizConfig.independentAxisLogScale,
-    dependentAxisLogScale: vizConfig.dependentAxisLogScale,
-  };
-
-  const [
-    dismissedIndependentAllNegativeWarning,
-    setDismissedIndependentAllNegativeWarning,
-  ] = useState<boolean>(false);
-  const independentAllNegative = // or zero
-    vizConfig.independentAxisLogScale &&
-    xMinMaxDataRange?.max != null &&
-    xMinMaxDataRange.max <= 0;
-
-  const [
-    dismissedDependentAllNegativeWarning,
-    setDismissedDependentAllNegativeWarning,
-  ] = useState<boolean>(false);
-  const dependentAllNegative = // or zero
-    vizConfig.dependentAxisLogScale &&
-    yMinMaxDataRange?.max != null &&
-    yMinMaxDataRange.max <= 0;
-
-  // snackbar
-  const { enqueueSnackbar } = useSnackbar();
-
-  return (
-    <>
-      {isFaceted(data) ? (
-        <FacetedLinePlot
-          data={data}
-          // considering axis range control
-          componentProps={lineplotPlotProps}
-          modalComponentProps={{
-            independentAxisLabel: lineplotProps.independentAxisLabel,
-            dependentAxisLabel: lineplotProps.dependentAxisLabel,
-            displayLegend: lineplotProps.displayLegend,
-            containerStyles: modalPlotContainerStyles,
-          }}
-          facetedPlotRef={plotRef}
-          checkedLegendItems={checkedLegendItems}
-        />
-      ) : (
-        <LinePlot
-          {...lineplotPlotProps}
-          ref={plotRef}
-          data={data}
-          // add controls
-          displayLibraryControls={false}
-          // custom legend: pass checkedLegendItems to PlotlyPlot
-          checkedLegendItems={checkedLegendItems}
-        />
-      )}
-
-      {/* add axis range control */}
-      <div style={{ display: 'flex', flexDirection: 'row' }}>
-        <LabelledGroup
-          label="X-axis controls"
-          containerStyles={{
-            marginRight: '1em',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              marginTop: '0.8em',
-              marginBottom: '0.8em',
-            }}
-          >
-            <Switch
-              label="Log scale (will exclude values &le; 0):"
-              state={vizConfig.independentAxisLogScale}
-              onStateChange={(newValue: boolean) => {
-                setDismissedIndependentAllNegativeWarning(false);
-                onIndependentAxisLogScaleChange(newValue);
-                if (newValue && useBinning)
-                  enqueueSnackbar(
-                    'Binning is no longer appropriate and has been disabled'
-                  );
-              }}
-              disabled={independentValueType === 'date'}
-            />
-          </div>
-          {independentAllNegative && !dismissedIndependentAllNegativeWarning ? (
-            <Notification
-              title={''}
-              text={
-                'Nothing can be plotted with log scale because all values are zero or negative'
-              }
-              color={'#5586BE'}
-              onAcknowledgement={() =>
-                setDismissedIndependentAllNegativeWarning(true)
-              }
-              showWarningIcon={true}
-              containerStyles={{ maxWidth: '350px' }}
-            />
-          ) : null}
-          <Switch
-            label={`Binning ${useBinning ? 'on' : 'off'}`}
-            state={useBinning}
-            onStateChange={(newValue: boolean) => {
-              onUseBinningChange(newValue);
-              if (newValue && vizConfig.independentAxisLogScale)
-                enqueueSnackbar(
-                  'Log scale is no longer appropriate and has been disabled'
-                );
-            }}
-            disabled={neverUseBinning}
-          />
-          <BinWidthControl
-            binWidth={data0?.binWidthSlider?.binWidth}
-            onBinWidthChange={onBinWidthChange}
-            binWidthRange={data0?.binWidthSlider?.binWidthRange}
-            binWidthStep={data0?.binWidthSlider?.binWidthStep}
-            valueType={data0?.binWidthSlider?.valueType}
-            binUnit={
-              data0?.binWidthSlider?.valueType === 'date'
-                ? (data0?.binWidthSlider?.binWidth as TimeDelta).unit
-                : undefined
-            }
-            binUnitOptions={
-              data0?.binWidthSlider?.valueType === 'date'
-                ? ['day', 'week', 'month', 'year']
-                : undefined
-            }
-            containerStyles={{
-              minHeight: widgetHeight,
-              // considering axis range control
-              maxWidth: independentValueType === 'date' ? '250px' : '350px',
-            }}
-            disabled={!useBinning || neverUseBinning}
-          />
-          {/* X-Axis range control */}
-          {/* designed to disable X-axis range control for categorical X */}
-          <AxisRangeControl
-            // change label for disabled case
-            label={
-              independentValueType === 'string'
-                ? 'Range (not available)'
-                : 'Range'
-            }
-            range={vizConfig.independentAxisRange ?? defaultIndependentRange}
-            onRangeChange={handleIndependentAxisRangeChange}
-            // will disable for categorical X so this is sufficient
-            valueType={independentValueType === 'date' ? 'date' : 'number'}
-            // set maxWidth
-            containerStyles={{ maxWidth: '350px' }}
-            // input forms are diabled for categorical X
-            disabled={independentValueType === 'string'}
-          />
-          {/* truncation notification */}
-          {truncatedIndependentAxisWarning && !independentAllNegative ? (
-            <Notification
-              title={''}
-              text={truncatedIndependentAxisWarning}
-              // this was defined as LIGHT_BLUE
-              color={'#5586BE'}
-              onAcknowledgement={() => {
-                setTruncatedIndependentAxisWarning('');
-              }}
-              showWarningIcon={true}
-              // set maxWidth per type
-              containerStyles={{
-                maxWidth: independentValueType === 'date' ? '350px' : '350px',
-              }}
-            />
-          ) : null}
-          <Button
-            type={'outlined'}
-            text={'Reset to defaults'}
-            onClick={handleIndependentAxisSettingsReset}
-            containerStyles={{
-              paddingTop: '1.0em',
-              width: '50%',
-              float: 'right',
-              // to match reset button with date range form
-              marginRight: independentValueType === 'date' ? '-1em' : '',
-            }}
-            // reset button is diabled for categorical X
-            disabled={independentValueType === 'string'}
-          />
-        </LabelledGroup>
-
-        {/* add vertical line in btw Y- and X- controls */}
-        <div
-          style={{
-            display: 'inline-flex',
-            borderLeft: '2px solid lightgray',
-            height: '19.3em',
-            position: 'relative',
-            marginLeft: '-1px',
-            top: '1.5em',
-          }}
-        >
-          {' '}
-        </div>
-        <LabelledGroup
-          label="Y-axis controls"
-          containerStyles={{
-            marginRight: '0em',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              marginTop: '0.8em',
-              marginBottom: '0.8em',
-            }}
-          >
-            <Switch
-              label="Log scale (will exclude values &le; 0):"
-              state={vizConfig.dependentAxisLogScale}
-              onStateChange={(newValue: boolean) => {
-                setDismissedDependentAllNegativeWarning(false);
-                onDependentAxisLogScaleChange(newValue);
-                if (newValue && showErrorBars)
-                  enqueueSnackbar(
-                    'Error bars are no longer appropriate and have been disabled'
-                  );
-              }}
-              disabled={dependentValueType === 'date'}
-            />
-          </div>
-          {dependentAllNegative && !dismissedDependentAllNegativeWarning ? (
-            <Notification
-              title={''}
-              text={
-                'Nothing can be plotted with log scale because all values are zero or negative'
-              }
-              color={'#5586BE'}
-              onAcknowledgement={() =>
-                setDismissedDependentAllNegativeWarning(true)
-              }
-              showWarningIcon={true}
-              containerStyles={{ maxWidth: '350px' }}
-            />
-          ) : null}
-          <Switch
-            label="Show error bars (95% C.I.)"
-            state={showErrorBars}
-            onStateChange={(newValue: boolean) => {
-              onShowErrorBarsChange(newValue);
-              if (newValue && vizConfig.dependentAxisLogScale)
-                enqueueSnackbar(
-                  'Log scale is no longer appropriate and has been disabled'
-                );
-            }}
-            disabled={neverShowErrorBars}
-          />
-          {/* Y-axis range control */}
-          {/* make some space to match with X-axis range control */}
-          <div style={{ height: '4em' }} />
-          <AxisRangeControl
-            label="Range"
-            range={vizConfig.dependentAxisRange ?? defaultDependentAxisRange}
-            valueType={dependentValueType === 'date' ? 'date' : 'number'}
-            onRangeChange={(newRange?: NumberOrDateRange) => {
-              handleDependentAxisRangeChange(newRange);
-            }}
-            // set maxWidth
-            containerStyles={{ maxWidth: '350px' }}
-          />
-          {/* truncation notification */}
-          {truncatedDependentAxisWarning && !dependentAllNegative ? (
-            <Notification
-              title={''}
-              text={truncatedDependentAxisWarning}
-              // this was defined as LIGHT_BLUE
-              color={'#5586BE'}
-              onAcknowledgement={() => {
-                setTruncatedDependentAxisWarning('');
-              }}
-              showWarningIcon={true}
-              // change maxWidth
-              containerStyles={{ maxWidth: '350px' }}
-            />
-          ) : null}
-          <Button
-            type={'outlined'}
-            // change text
-            text={'Reset to defaults'}
-            onClick={handleDependentAxisSettingsReset}
-            containerStyles={{
-              paddingTop: '1.0em',
-              width: '50%',
-              float: 'right',
-              // to match reset button with date range form
-              marginRight: dependentValueType === 'date' ? '-1em' : '',
-            }}
-          />
-        </LabelledGroup>
-      </div>
-    </>
   );
 }
 

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -218,6 +218,7 @@ function MapViz(props: VisualizationProps<Options>) {
     basicMarkerError,
     overlayError,
   } = useMapMarkers({
+    requireOverlay: false,
     boundsZoomLevel,
     vizConfig,
     geoConfig,

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -218,7 +218,7 @@ function MapViz(props: VisualizationProps<Options>) {
     basicMarkerError,
     overlayError,
   } = useMapMarkers({
-    requireOverlay: false,
+    requireOverlay: true,
     boundsZoomLevel,
     vizConfig,
     geoConfig,

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -4,7 +4,7 @@ import {
 } from '../VisualizationTypes';
 import map from './selectorIcons/map.svg';
 import * as t from 'io-ts';
-import { isEqual, zip, some, sum } from 'lodash';
+import { isEqual } from 'lodash';
 
 // map component related imports
 import MapVEuMap, {
@@ -13,18 +13,7 @@ import MapVEuMap, {
 } from '@veupathdb/components/lib/map/MapVEuMap';
 import { defaultAnimationDuration } from '@veupathdb/components/lib/map/config/map';
 import geohashAnimation from '@veupathdb/components/lib/map/animation_functions/geohash';
-import {
-  BoundsViewport,
-  Bounds,
-  LatLng,
-} from '@veupathdb/components/lib/map/Types';
-import DonutMarker from '@veupathdb/components/lib/map/DonutMarker';
-import ChartMarker from '@veupathdb/components/lib/map/ChartMarker';
-
-import {
-  ColorPaletteDefault,
-  gradientSequentialColorscaleMap,
-} from '@veupathdb/components/lib/types/plots/addOns';
+import { BoundsViewport } from '@veupathdb/components/lib/map/Types';
 
 // general ui imports
 import { FormControl, Select, MenuItem, InputLabel } from '@material-ui/core';
@@ -32,49 +21,31 @@ import { FormControl, Select, MenuItem, InputLabel } from '@material-ui/core';
 // viz-related imports
 import { PlotLayout } from '../../layouts/PlotLayout';
 import {
-  useDataClient,
   useFindEntityAndVariable,
   useStudyEntities,
   useStudyMetadata,
 } from '../../../hooks/workspace';
 import { useMemo, useCallback, useState, useEffect } from 'react';
-import DataClient, {
-  MapMarkersRequestParams,
-  MapMarkersOverlayRequestParams,
-  MapMarkersOverlayResponse,
-} from '../../../api/DataClient';
 import { useVizConfig } from '../../../hooks/visualizations';
-import { usePromise } from '../../../hooks/promise';
-// the next import is unused, but leaving it there as a reminder to
-// test more types of variable in future (e.g. low cardinality numbers?)
-import { fixLabelsForNumberVariables } from '../../../utils/visualization';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
 import { OutputEntityTitle } from '../OutputEntityTitle';
-import { values } from 'lodash';
 import PluginError from '../PluginError';
 import { VariableDescriptor } from '../../../types/variable';
 import { InputVariables } from '../InputVariables';
 import { VariablesByInputName } from '../../../utils/data-element-constraints';
-import PlotLegend, {
-  LegendItemsProps,
-} from '@veupathdb/components/lib/components/plotControls/PlotLegend';
+import PlotLegend from '@veupathdb/components/lib/components/plotControls/PlotLegend';
 import { useCheckedLegendItemsStatus } from '../../../hooks/checkedLegendItemsStatus';
 import { variableDisplayWithUnit } from '../../../utils/variable-display';
 import { BirdsEyeView } from '../../BirdsEyeView';
 import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
 import { MouseMode } from '@veupathdb/components/lib/map/MouseTools';
-import { kFormatter, mFormatter } from '../../../utils/big-number-formatters';
 import { VariableCoverageTable } from '../../VariableCoverageTable';
-import { NumberVariable } from '../../../types/study';
-import { BinSpec, NumberRange } from '../../../types/general';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
 
 import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
 import Switch from '@veupathdb/components/lib/components/widgets/Switch';
-import { useDefaultAxisRange } from '../../../hooks/computeDefaultAxisRange';
 import { LayoutOptions } from '../../layouts/types';
-
-const numContinuousBins = 8;
+import { useMapMarkers } from '../../../hooks/mapMarkers';
 
 export const mapVisualization = createVisualizationPlugin({
   selectorIcon: map,
@@ -106,7 +77,7 @@ const defaultAnimation = {
   duration: defaultAnimationDuration,
 };
 
-type MapConfig = t.TypeOf<typeof MapConfig>;
+export type MapConfig = t.TypeOf<typeof MapConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 const MapConfig = t.intersection([
   t.type({
@@ -135,22 +106,6 @@ const MapConfig = t.intersection([
   }),
 ]);
 
-type BasicMarkerData = {
-  completeCasesGeoVar: number;
-  markerData: {
-    geoAggregateValue: string;
-    entityCount: number;
-    position: LatLng;
-    bounds: Bounds;
-    isAtomic: boolean;
-  }[];
-};
-
-type MapMarkersOverlayData = Record<
-  string,
-  { entityCount: number; data: { label: string; value: number }[] }
->;
-
 interface Options extends LayoutOptions {}
 
 function MapViz(props: VisualizationProps<Options>) {
@@ -171,7 +126,6 @@ function MapViz(props: VisualizationProps<Options>) {
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
   const entities = useStudyEntities();
-  const dataClient: DataClient = useDataClient();
 
   const [vizConfig, updateVizConfig] = useVizConfig(
     visualization.descriptor.configuration,
@@ -253,299 +207,26 @@ function MapViz(props: VisualizationProps<Options>) {
     findEntityAndVariable,
   ]);
 
-  // prepare some info that the map-markers and overlay requests both need
   const {
-    latitudeVariable,
-    longitudeVariable,
-    geoAggregateVariable,
-  } = useMemo(() => {
-    if (
-      boundsZoomLevel == null ||
-      geoConfig == null ||
-      vizConfig.geoEntityId == null
-    )
-      return {};
-
-    const latitudeVariable = {
-      entityId: vizConfig.geoEntityId,
-      variableId: geoConfig.latitudeVariableId,
-    };
-    const longitudeVariable = {
-      entityId: vizConfig.geoEntityId,
-      variableId: geoConfig.longitudeVariableId,
-    };
-    const geoAggregateVariable = {
-      entityId: vizConfig.geoEntityId,
-      variableId:
-        geoConfig.aggregationVariableIds[
-          geoConfig.zoomLevelToAggregationLevel(boundsZoomLevel.zoomLevel) - 1
-        ],
-    };
-
-    return {
-      latitudeVariable,
-      longitudeVariable,
-      geoAggregateVariable,
-    };
-  }, [boundsZoomLevel, vizConfig.geoEntityId, geoConfig]);
-
-  const basicMarkerData = usePromise<BasicMarkerData | undefined>(
-    useCallback(async () => {
-      // check all required vizConfigs are provided
-      if (
-        boundsZoomLevel == null ||
-        vizConfig.geoEntityId == null ||
-        geoConfig == null ||
-        latitudeVariable == null ||
-        longitudeVariable == null ||
-        geoAggregateVariable == null ||
-        outputEntity == null ||
-        vizConfig.xAxisVariable == null
-      )
-        return undefined;
-
-      const {
-        northEast: { lat: xMax, lng: right },
-        southWest: { lat: xMin, lng: left },
-      } = boundsZoomLevel.bounds;
-
-      // now prepare the rest of the request params
-      const requestParams: MapMarkersRequestParams = {
-        studyId,
-        filters: filters || [],
-        config: {
-          outputEntityId: outputEntity.id, // might be quicker to use geoEntity.id but numbers in white markers will be wrong, momentarily
-          geoAggregateVariable,
-          latitudeVariable,
-          longitudeVariable,
-          viewport: {
-            latitude: {
-              xMin,
-              xMax,
-            },
-            longitude: {
-              left,
-              right,
-            },
-          },
-        },
-      };
-
-      // now get the data
-      const response = await dataClient.getMapMarkers(
-        computation.descriptor.type,
-        requestParams
-      );
-
-      return {
-        markerData: response.mapElements.map(
-          ({
-            avgLat,
-            avgLon,
-            minLat,
-            minLon,
-            maxLat,
-            maxLon,
-            entityCount,
-            geoAggregateValue,
-          }) => {
-            const isAtomic = false; // TO DO: work with Danielle to get this info from back end
-            return {
-              geoAggregateValue,
-              entityCount: entityCount,
-              position: { lat: avgLat, lng: avgLon },
-              bounds: {
-                southWest: { lat: minLat, lng: minLon },
-                northEast: { lat: maxLat, lng: maxLon },
-              },
-              isAtomic,
-            };
-          }
-        ),
-        completeCasesGeoVar: response.config.completeCasesGeoVar,
-      };
-    }, [
-      studyId,
-      filters,
-      dataClient,
-      // we don't want to allow vizConfig.mapCenterAndZoom to trigger an update,
-      // because boundsZoomLevel does the same thing, but they can trigger two separate updates
-      // (baseLayer doesn't matter either) - so we cherry pick properties of vizConfig
-      vizConfig.geoEntityId,
-      vizConfig.xAxisVariable,
-      geoAggregateVariable,
-      latitudeVariable,
-      longitudeVariable,
-      outputEntity,
-      boundsZoomLevel,
-      computation.descriptor.type,
-      geoConfig,
-    ])
-  );
-
-  const defaultOverlayRange = useDefaultAxisRange(xAxisVariable);
-
-  /**
-   * Now we deal with the optional second request to map-markers-overlay
-   */
-  const proportionMode = vizConfig.markerType === 'proportion';
-  const overlayResponse = usePromise<MapMarkersOverlayResponse | undefined>(
-    useCallback(async () => {
-      // check all required vizConfigs are provided
-      if (
-        boundsZoomLevel == null ||
-        vizConfig.xAxisVariable == null ||
-        geoAggregateVariable == null ||
-        outputEntity == null ||
-        latitudeVariable == undefined ||
-        longitudeVariable == undefined
-      )
-        return undefined;
-
-      const {
-        northEast: { lat: xMax, lng: right },
-        southWest: { lat: xMin, lng: left },
-      } = boundsZoomLevel.bounds;
-
-      // For now, just calculate a static binSpec from variable metadata for numeric continous only
-      // TO DO: date variables when we have testable data (UMSP has them but difficult to test, and back end was giving 500s)
-      // date variables need special date maths for calculating the width, and probably rounding aggressively to whole months/years etc - not trivial.
-      const binSpec: BinSpec | undefined =
-        NumberVariable.is(xAxisVariable) &&
-        defaultOverlayRange != null &&
-        NumberRange.is(defaultOverlayRange)
-          ? {
-              range: defaultOverlayRange,
-              type: 'binWidth',
-              value:
-                (defaultOverlayRange.max - defaultOverlayRange.min) /
-                numContinuousBins,
-            }
-          : // : DateVariable.is(xAxisVariable) && DateRange.is(defaultOverlayRange) ? ... TO DO
-            undefined;
-
-      // prepare request
-      const requestParams: MapMarkersOverlayRequestParams = {
-        studyId,
-        filters: filters || [],
-        config: {
-          outputEntityId: outputEntity.id,
-          xAxisVariable: vizConfig.xAxisVariable,
-          latitudeVariable: latitudeVariable,
-          longitudeVariable: longitudeVariable,
-          geoAggregateVariable: geoAggregateVariable,
-          showMissingness: 'noVariables', // current back end 'showMissing' behaviour applies to facet variable
-          valueSpec: proportionMode ? 'proportion' : 'count',
-          binSpec: binSpec ?? {},
-          viewport: {
-            latitude: {
-              xMin,
-              xMax,
-            },
-            longitude: {
-              left,
-              right,
-            },
-          },
-        },
-      };
-
-      // send request
-      return await dataClient.getMapMarkersOverlay(
-        computation.descriptor.type,
-        requestParams
-      );
-    }, [
-      studyId,
-      dataClient,
-      xAxisVariable,
-      vizConfig.xAxisVariable,
-      proportionMode,
-      boundsZoomLevel,
-      computation.descriptor.type,
-      geoAggregateVariable,
-      outputEntity,
-      filters,
-    ])
-  );
-  const overlayData = useMemo(() => {
-    // process response and return a map of "geoAgg key" => donut labels and counts
-    return !overlayResponse.pending && overlayResponse.value
-      ? overlayResponse.value.mapMarkers.data.reduce(
-          (map, { geoAggregateVariableDetails, label, value }) => {
-            const geoAggKey = geoAggregateVariableDetails.value;
-            if (overlayResponse.value)
-              // don't know why TS makes us do this check *again*...
-              map[geoAggKey] = {
-                // sum up the entity count from the sampleSizeTable because
-                // the data.label values might be proportions (and sum to 1)
-                entityCount: sum(
-                  overlayResponse.value.sampleSizeTable.find(
-                    (item) =>
-                      item.geoAggregateVariableDetails != null &&
-                      item.geoAggregateVariableDetails.value === geoAggKey
-                  )?.size
-                ),
-                data: zip(label, value).map(([label, value]) => ({
-                  label: label!,
-                  value: value!,
-                })),
-              };
-            return map;
-          },
-          {} as MapMarkersOverlayData
-        )
-      : undefined;
-  }, [overlayResponse]);
-
-  const valueMax = useMemo(
-    () =>
-      overlayData
-        ? values(overlayData) // it's a Record 'object'
-            .map((record) => record.data)
-            .flat() // flatten all the arrays into one
-            .reduce(
-              (accum, elem) => (elem.value > accum ? elem.value : accum),
-              0
-            ) // find max value
-        : 0,
-    [overlayData]
-  );
-
-  const valueMinPos = useMemo(
-    () =>
-      overlayData
-        ? values(overlayData)
-            .map((record) => record.data)
-            .flat()
-            .reduce<number | undefined>(
-              (accum, elem) =>
-                elem.value > 0 && (accum == null || elem.value < accum)
-                  ? elem.value
-                  : accum,
-              undefined
-            )
-        : undefined,
-    [overlayData]
-  );
-
-  const defaultDependentAxisRange = useDefaultAxisRange(
-    null,
-    0,
-    valueMinPos,
-    valueMax,
-    vizConfig.dependentAxisLogScale
-  ) as NumberRange;
-
-  // If it's a string variable and a small vocabulary, use it as-is from the study metadata.
-  // This ensures that for low cardinality categoricals, the colours are always the same.
-  // Otherwise use the overlayValues from the back end (which are either bins or a Top7+Other)
-  const vocabulary =
-    xAxisVariable?.type === 'string' &&
-    xAxisVariable?.vocabulary != null &&
-    xAxisVariable.vocabulary.length <= 8
-      ? xAxisVariable.vocabulary
-      : overlayResponse.value?.mapMarkers.config.overlayValues;
+    markers,
+    totalEntityCount,
+    completeCasesAllVars,
+    completeCases,
+    vocabulary,
+    legendItems,
+    pending,
+    basicMarkerError,
+    overlayError,
+  } = useMapMarkers({
+    boundsZoomLevel,
+    vizConfig,
+    geoConfig,
+    outputEntity,
+    studyId,
+    filters,
+    computation,
+    xAxisVariable,
+  });
 
   /**
    * Reset checkedLegendItems to all-checked (actually none checked)
@@ -565,115 +246,6 @@ function MapViz(props: VisualizationProps<Options>) {
     )
       updateVizConfig({ checkedLegendItems: undefined });
   }, [vocabulary, vizConfig.checkedLegendItems, updateVizConfig]);
-
-  /**
-   * Merge the overlay data into the basicMarkerData, if available,
-   * and create markers.
-   */
-  const markers = useMemo(() => {
-    if (vocabulary == null) return undefined;
-
-    return basicMarkerData.value?.markerData.map(
-      ({ geoAggregateValue, entityCount, bounds, position }) => {
-        const donutData =
-          overlayData?.[geoAggregateValue] != null
-            ? overlayData[geoAggregateValue].data
-                .map(({ label, value }) => ({
-                  label,
-                  value,
-                  color:
-                    xAxisVariable?.type === 'string'
-                      ? ColorPaletteDefault[vocabulary.indexOf(label!)]
-                      : gradientSequentialColorscaleMap(
-                          vocabulary.indexOf(label!) / (vocabulary.length - 1)
-                        ),
-                }))
-                // DonutMarkers don't handle checkedLegendItems automatically, like our
-                // regular PlotlyPlot components, so we do the filtering here
-                .filter(
-                  ({ label }) =>
-                    vizConfig.checkedLegendItems == null ||
-                    vizConfig.checkedLegendItems.indexOf(label) > -1
-                )
-            : [];
-
-        // now reorder the data, adding zeroes if necessary.
-        const reorderedData = vocabulary.map(
-          (
-            overlayLabel // overlay label can be 'female' or a bin label '(0,100]'
-          ) =>
-            donutData.find(({ label }) => label === overlayLabel) ?? {
-              label: overlayLabel,
-              value: 0,
-            }
-        );
-
-        // provide the 'plain white' donut data if all legend items unchecked
-        // or if there is no overlay data
-        const safeDonutData =
-          reorderedData.length > 0
-            ? reorderedData
-            : [
-                {
-                  label: 'unknown',
-                  value: entityCount,
-                  color: 'white',
-                },
-              ];
-
-        // TO DO: find out if MarkerProps.id is obsolete
-        const MarkerComponent =
-          vizConfig.markerType == null || vizConfig.markerType === 'pie'
-            ? DonutMarker
-            : ChartMarker;
-
-        const count =
-          overlayData != null
-            ? vizConfig.markerType == null || vizConfig.markerType === 'pie'
-              ? // pies always show sum of legend checked items (donutData is already filtered on checkboxes)
-                donutData.reduce((sum, item) => (sum = sum + item.value), 0)
-              : // the bar/histogram charts always show the constant entity count
-                // however, if there is no data at all we can safely infer a zero
-                overlayData[geoAggregateValue]?.entityCount ?? 0
-            : entityCount;
-
-        const formattedCount =
-          MarkerComponent === ChartMarker
-            ? mFormatter(count)
-            : kFormatter(count);
-
-        return (
-          <MarkerComponent
-            id={geoAggregateValue}
-            key={geoAggregateValue}
-            bounds={bounds}
-            position={position}
-            data={safeDonutData}
-            duration={defaultAnimationDuration}
-            markerLabel={formattedCount}
-            {...(vizConfig.markerType !== 'pie'
-              ? {
-                  dependentAxisRange: defaultDependentAxisRange,
-                  dependentAxisLogScale: vizConfig.dependentAxisLogScale,
-                }
-              : {})}
-          />
-        );
-      }
-    );
-  }, [
-    basicMarkerData.value,
-    vocabulary,
-    overlayData,
-    vizConfig.checkedLegendItems,
-    vizConfig.markerType,
-    xAxisVariable,
-    outputEntity,
-    // add vizConfig.dependentAxisLogScale to reflect its state change
-    vizConfig.dependentAxisLogScale,
-  ]);
-
-  const totalEntityCount = basicMarkerData.value?.completeCasesGeoVar;
 
   /**
    * Now render the visualization
@@ -723,7 +295,7 @@ function MapViz(props: VisualizationProps<Options>) {
           )
         }
         flyToMarkersDelay={500}
-        showSpinner={basicMarkerData.pending || overlayResponse.pending}
+        showSpinner={pending}
         // whether to show scale at map
         showScale={zoomLevel != null && zoomLevel > 4 ? true : false}
         // show mouse tool
@@ -796,37 +368,6 @@ function MapViz(props: VisualizationProps<Options>) {
     [updateVizConfig]
   );
 
-  /**
-   * create custom legend data
-   */
-
-  const legendItems: LegendItemsProps[] = useMemo(() => {
-    if (vocabulary == null) return [];
-
-    return vocabulary.map((label) => ({
-      label,
-      marker: 'square',
-      markerColor:
-        xAxisVariable?.type === 'string'
-          ? ColorPaletteDefault[vocabulary.indexOf(label)]
-          : gradientSequentialColorscaleMap(
-              vocabulary.indexOf(label) / (vocabulary.length - 1)
-            ),
-      // has any geo-facet got an array of overlay data
-      // containing at least one element that satisfies label==label
-      // (do not check that value > 0, because the back end doesn't return
-      // zero counts, but does sometimes return near-zero counts that get
-      // rounded to zero)
-      hasData: overlayData
-        ? some(overlayData, (pieData) =>
-            some(pieData.data, (data) => data.label === label)
-          )
-        : false,
-      group: 1,
-      rank: 1,
-    }));
-  }, [xAxisVariable, vocabulary, overlayData]);
-
   // set checkedLegendItems
   const checkedLegendItems = useCheckedLegendItemsStatus(
     legendItems,
@@ -855,10 +396,8 @@ function MapViz(props: VisualizationProps<Options>) {
   const tableGroupNode = (
     <>
       <BirdsEyeView
-        completeCasesAxesVars={basicMarkerData.value?.completeCasesGeoVar}
-        completeCasesAllVars={
-          overlayResponse.value?.mapMarkers.config.completeCasesAllVars
-        }
+        completeCasesAxesVars={totalEntityCount}
+        completeCasesAllVars={completeCasesAllVars}
         outputEntity={outputEntity}
         stratificationIsActive={
           false /* this disables the 'strata and axes' bar/impulse */
@@ -867,9 +406,9 @@ function MapViz(props: VisualizationProps<Options>) {
         totalCounts={totalCounts.value}
         filteredCounts={filteredCounts.value}
       />
-      {!overlayResponse.pending && overlayResponse.value ? (
+      {!pending && completeCases != null ? (
         <VariableCoverageTable
-          completeCases={overlayResponse.value.completeCasesTable}
+          completeCases={completeCases}
           filteredCounts={filteredCounts}
           outputEntityId={outputEntity?.id}
           variableSpecs={[
@@ -883,8 +422,7 @@ function MapViz(props: VisualizationProps<Options>) {
               role: 'Geo',
               required: true,
               display: 'Geolocation',
-              variable:
-                overlayResponse.value.completeCasesTable[1].variableDetails,
+              variable: completeCases[1].variableDetails,
             },
           ]}
         />
@@ -941,14 +479,8 @@ function MapViz(props: VisualizationProps<Options>) {
         />
       </div>
 
-      <PluginError
-        error={basicMarkerData.error}
-        outputSize={totalEntityCount}
-      />
-      <PluginError
-        error={overlayResponse.error}
-        outputSize={totalEntityCount}
-      />
+      <PluginError error={basicMarkerError} outputSize={totalEntityCount} />
+      <PluginError error={overlayError} outputSize={totalEntityCount} />
       <OutputEntityTitle entity={outputEntity} outputSize={totalEntityCount} />
       <LayoutComponent
         isFaceted={false}

--- a/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MapVisualization.tsx
@@ -72,6 +72,7 @@ import { createVisualizationPlugin } from '../VisualizationPlugin';
 import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
 import Switch from '@veupathdb/components/lib/components/widgets/Switch';
 import { useDefaultAxisRange } from '../../../hooks/computeDefaultAxisRange';
+import { LayoutOptions } from '../../layouts/types';
 
 const numContinuousBins = 8;
 
@@ -150,8 +151,11 @@ type MapMarkersOverlayData = Record<
   { entityCount: number; data: { label: string; value: number }[] }
 >;
 
-function MapViz(props: VisualizationProps) {
+interface Options extends LayoutOptions {}
+
+function MapViz(props: VisualizationProps<Options>) {
   const {
+    options,
     computation,
     visualization,
     updateConfiguration,
@@ -727,6 +731,11 @@ function MapViz(props: VisualizationProps) {
         mouseMode={vizConfig.mouseMode ?? createDefaultConfig().mouseMode}
         onMouseModeChange={onMouseModeChange}
       />
+    </>
+  );
+
+  const controlsNode = (
+    <>
       <RadioButtonGroup
         label="Plot mode"
         selectedOption={vizConfig.markerType || 'pie'}
@@ -883,6 +892,8 @@ function MapViz(props: VisualizationProps) {
     </>
   );
 
+  const LayoutComponent = options?.layoutComponent ?? PlotLayout;
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <div
@@ -939,10 +950,11 @@ function MapViz(props: VisualizationProps) {
         outputSize={totalEntityCount}
       />
       <OutputEntityTitle entity={outputEntity} outputSize={totalEntityCount} />
-      <PlotLayout
+      <LayoutComponent
         isFaceted={false}
         legendNode={legendNode}
         plotNode={plotNode}
+        controlsNode={controlsNode}
         tableGroupNode={tableGroupNode}
         /**
          * unlike all other visualizations, dataElementsContraints does not include xAxisVariable as a required variable;

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1468,10 +1468,11 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
                     label: 'Overlay',
                     role: 'stratification',
                     readonlyValue:
-                      options?.getOverlayVariable != null &&
-                      providedOverlayVariable
-                        ? legendTitle
-                        : 'none',
+                      options?.getOverlayVariable != null
+                        ? providedOverlayVariable
+                          ? legendTitle
+                          : 'none'
+                        : undefined,
                     // TO DO: verbiage for 'none'
                   } as const,
                 ]),

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1054,6 +1054,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     vizConfig.yAxisVariable,
   ]);
 
+  const LayoutComponent = options?.layoutComponent ?? PlotLayout;
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
@@ -1155,7 +1157,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
         outputSize={outputSize}
         subtitle={plotSubtitle}
       />
-      <PlotLayout
+      <LayoutComponent
         isFaceted={isFaceted(data.value?.dataSetProcess)}
         legendNode={showOverlayLegend ? legendNode : null}
         plotNode={plotNode}

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -30,6 +30,7 @@ import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
 import {
   ComputedVariableDetails,
+  GlobalVisualizationOptions,
   VisualizationProps,
 } from '../VisualizationTypes';
 
@@ -192,7 +193,7 @@ export const ScatterplotConfig = t.partial({
   dependentAxisLogScale: t.boolean,
 });
 
-interface Options {
+interface Options extends GlobalVisualizationOptions {
   getComputedYAxisDetails?(
     config: unknown
   ): ComputedVariableDetails | undefined;

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -30,7 +30,6 @@ import { InputVariables } from '../InputVariables';
 import { OutputEntityTitle } from '../OutputEntityTitle';
 import {
   ComputedVariableDetails,
-  GlobalVisualizationOptions,
   VisualizationProps,
 } from '../VisualizationTypes';
 
@@ -119,6 +118,7 @@ import { createVisualizationPlugin } from '../VisualizationPlugin';
 import { useFindOutputEntity } from '../../../hooks/findOutputEntity';
 
 import useSnackbar from '@veupathdb/coreui/dist/components/notifications/useSnackbar';
+import { LayoutOptions, TitleOptions } from '../../layouts/types';
 
 const MAXALLOWEDDATAPOINTS = 100000;
 const SMOOTHEDMEANTEXT = 'Smoothed mean';
@@ -193,13 +193,11 @@ export const ScatterplotConfig = t.partial({
   dependentAxisLogScale: t.boolean,
 });
 
-interface Options extends GlobalVisualizationOptions {
+interface Options extends LayoutOptions, TitleOptions {
   getComputedYAxisDetails?(
     config: unknown
   ): ComputedVariableDetails | undefined;
   getOverlayVariable?(config: unknown): VariableDescriptor | undefined;
-  getPlotSubtitle?(config: unknown): string | undefined;
-  hideShowMissingnessToggle?: boolean;
   hideTrendlines?: boolean;
 }
 

--- a/src/lib/core/components/visualizations/options/types.ts
+++ b/src/lib/core/components/visualizations/options/types.ts
@@ -1,0 +1,11 @@
+import { VariableDescriptor } from '../../../types/variable';
+
+export interface XAxisOptions {
+  getXAxisVariable?: (computeConfig: unknown) => VariableDescriptor | undefined;
+}
+
+export interface OverlayOptions {
+  getOverlayVariable?: (
+    computeConfig: unknown
+  ) => VariableDescriptor | undefined;
+}

--- a/src/lib/core/hooks/mapMarkers.tsx
+++ b/src/lib/core/hooks/mapMarkers.tsx
@@ -1,0 +1,556 @@
+import { BoundsDriftMarkerProps } from '@veupathdb/components/lib/map/BoundsDriftMarker';
+import { ReactElement, useCallback, useMemo } from 'react';
+import { usePromise } from './promise';
+import {
+  BoundsViewport,
+  Bounds,
+  LatLng,
+} from '@veupathdb/components/lib/map/Types';
+import { MapConfig } from '../components/visualizations/implementations/MapVisualization';
+import { GeoConfig } from '../types/geoConfig';
+import { NumberVariable, StudyEntity, Variable } from '../types/study';
+import DataClient, {
+  CompleteCasesTable,
+  MapMarkersOverlayRequestParams,
+  MapMarkersOverlayResponse,
+  MapMarkersRequestParams,
+} from '../api/DataClient';
+import { Filter } from '../types/filter';
+import { useDataClient } from './workspace';
+import { Computation } from '../types/visualization';
+import { BinSpec, NumberRange } from '../types/general';
+import { useDefaultAxisRange } from './computeDefaultAxisRange';
+import { zip, sum, values, some } from 'lodash';
+import {
+  ColorPaletteDefault,
+  gradientSequentialColorscaleMap,
+} from '@veupathdb/components/lib/types/plots';
+import DonutMarker from '@veupathdb/components/lib/map/DonutMarker';
+import ChartMarker from '@veupathdb/components/lib/map/ChartMarker';
+import { kFormatter, mFormatter } from '../utils/big-number-formatters';
+import { defaultAnimationDuration } from '@veupathdb/components/lib/map/config/map';
+import { LegendItemsProps } from '@veupathdb/components/lib/components/plotControls/PlotLegend';
+
+// TO DO: move to configuration somewhere?
+const numContinuousBins = 8;
+
+/**
+ * Provides markers for use in the MapVEuMap component
+ * Also provides associated data (stats, legend items), pending status and back end errors.
+ */
+
+type BasicMarkerData = {
+  completeCasesGeoVar: number;
+  markerData: {
+    geoAggregateValue: string;
+    entityCount: number;
+    position: LatLng;
+    bounds: Bounds;
+    isAtomic: boolean;
+  }[];
+};
+
+type MapMarkersOverlayData = Record<
+  string,
+  { entityCount: number; data: { label: string; value: number }[] }
+>;
+
+export interface MapMarkersProps {
+  boundsZoomLevel: BoundsViewport | undefined;
+  vizConfig: MapConfig;
+  geoConfig: GeoConfig | undefined;
+  outputEntity: StudyEntity | undefined;
+  studyId: string;
+  filters: Filter[] | undefined;
+  computation: Computation;
+  xAxisVariable: Variable | undefined;
+}
+
+// what this hook returns
+interface MapMarkers {
+  /** the markers */
+  markers: ReactElement<BoundsDriftMarkerProps>[] | undefined;
+  /** various stats for birds eye etc */
+  totalEntityCount: number | undefined;
+  completeCasesAllVars: number | undefined;
+  completeCases: CompleteCasesTable | undefined;
+  /** the possible values for the overlay variable (e.g. back-end derived bin labels) */
+  vocabulary: string[] | undefined;
+  /** data for creating a legend */
+  legendItems: LegendItemsProps[];
+  /** are any requests still pending */
+  pending: boolean;
+  /** errors from the basic request */
+  basicMarkerError: unknown;
+  /** errors from the overlay request */
+  overlayError: unknown;
+}
+
+export function useMapMarkers(props: MapMarkersProps): MapMarkers {
+  const {
+    boundsZoomLevel,
+    vizConfig,
+    geoConfig,
+    outputEntity,
+    studyId,
+    filters,
+    computation,
+    xAxisVariable,
+  } = props;
+
+  const dataClient: DataClient = useDataClient();
+
+  // prepare some info that the map-markers and overlay requests both need
+  const {
+    latitudeVariable,
+    longitudeVariable,
+    geoAggregateVariable,
+  } = useMemo(() => {
+    if (
+      boundsZoomLevel == null ||
+      geoConfig == null ||
+      vizConfig.geoEntityId == null
+    )
+      return {};
+
+    const latitudeVariable = {
+      entityId: vizConfig.geoEntityId,
+      variableId: geoConfig.latitudeVariableId,
+    };
+    const longitudeVariable = {
+      entityId: vizConfig.geoEntityId,
+      variableId: geoConfig.longitudeVariableId,
+    };
+    const geoAggregateVariable = {
+      entityId: vizConfig.geoEntityId,
+      variableId:
+        geoConfig.aggregationVariableIds[
+          geoConfig.zoomLevelToAggregationLevel(boundsZoomLevel.zoomLevel) - 1
+        ],
+    };
+
+    return {
+      latitudeVariable,
+      longitudeVariable,
+      geoAggregateVariable,
+    };
+  }, [boundsZoomLevel, vizConfig.geoEntityId, geoConfig]);
+
+  // now do the first request
+  const basicMarkerData = usePromise<BasicMarkerData | undefined>(
+    useCallback(async () => {
+      // check all required vizConfigs are provided
+      if (
+        boundsZoomLevel == null ||
+        vizConfig.geoEntityId == null ||
+        geoConfig == null ||
+        latitudeVariable == null ||
+        longitudeVariable == null ||
+        geoAggregateVariable == null ||
+        outputEntity == null ||
+        vizConfig.xAxisVariable == null
+      )
+        return undefined;
+
+      const {
+        northEast: { lat: xMax, lng: right },
+        southWest: { lat: xMin, lng: left },
+      } = boundsZoomLevel.bounds;
+
+      // now prepare the rest of the request params
+      const requestParams: MapMarkersRequestParams = {
+        studyId,
+        filters: filters || [],
+        config: {
+          outputEntityId: outputEntity.id, // might be quicker to use geoEntity.id but numbers in white markers will be wrong, momentarily
+          geoAggregateVariable,
+          latitudeVariable,
+          longitudeVariable,
+          viewport: {
+            latitude: {
+              xMin,
+              xMax,
+            },
+            longitude: {
+              left,
+              right,
+            },
+          },
+        },
+      };
+
+      // now get the data
+      const response = await dataClient.getMapMarkers(
+        computation.descriptor.type,
+        requestParams
+      );
+
+      return {
+        markerData: response.mapElements.map(
+          ({
+            avgLat,
+            avgLon,
+            minLat,
+            minLon,
+            maxLat,
+            maxLon,
+            entityCount,
+            geoAggregateValue,
+          }) => {
+            const isAtomic = false; // TO DO: work with Danielle to get this info from back end
+            return {
+              geoAggregateValue,
+              entityCount: entityCount,
+              position: { lat: avgLat, lng: avgLon },
+              bounds: {
+                southWest: { lat: minLat, lng: minLon },
+                northEast: { lat: maxLat, lng: maxLon },
+              },
+              isAtomic,
+            };
+          }
+        ),
+        completeCasesGeoVar: response.config.completeCasesGeoVar,
+      };
+    }, [
+      studyId,
+      filters,
+      dataClient,
+      // we don't want to allow vizConfig.mapCenterAndZoom to trigger an update,
+      // because boundsZoomLevel does the same thing, but they can trigger two separate updates
+      // (baseLayer doesn't matter either) - so we cherry pick properties of vizConfig
+      vizConfig.geoEntityId,
+      vizConfig.xAxisVariable,
+      geoAggregateVariable,
+      latitudeVariable,
+      longitudeVariable,
+      outputEntity,
+      boundsZoomLevel,
+      computation.descriptor.type,
+      geoConfig,
+    ])
+  );
+
+  const totalEntityCount = basicMarkerData.value?.completeCasesGeoVar;
+
+  /**
+   * Now get the overlay data
+   */
+
+  const defaultOverlayRange = useDefaultAxisRange(xAxisVariable);
+  const proportionMode = vizConfig.markerType === 'proportion';
+
+  const overlayResponse = usePromise<MapMarkersOverlayResponse | undefined>(
+    useCallback(async () => {
+      // check all required vizConfigs are provided
+      if (
+        boundsZoomLevel == null ||
+        vizConfig.xAxisVariable == null ||
+        geoAggregateVariable == null ||
+        outputEntity == null ||
+        latitudeVariable == undefined ||
+        longitudeVariable == undefined
+      )
+        return undefined;
+
+      const {
+        northEast: { lat: xMax, lng: right },
+        southWest: { lat: xMin, lng: left },
+      } = boundsZoomLevel.bounds;
+
+      // For now, just calculate a static binSpec from variable metadata for numeric continous only
+      // TO DO: date variables when we have testable data (UMSP has them but difficult to test, and back end was giving 500s)
+      // date variables need special date maths for calculating the width, and probably rounding aggressively to whole months/years etc - not trivial.
+      const binSpec: BinSpec | undefined =
+        NumberVariable.is(xAxisVariable) &&
+        defaultOverlayRange != null &&
+        NumberRange.is(defaultOverlayRange)
+          ? {
+              range: defaultOverlayRange,
+              type: 'binWidth',
+              value:
+                (defaultOverlayRange.max - defaultOverlayRange.min) /
+                numContinuousBins,
+            }
+          : // : DateVariable.is(xAxisVariable) && DateRange.is(defaultOverlayRange) ? ... TO DO
+            undefined;
+
+      // prepare request
+      const requestParams: MapMarkersOverlayRequestParams = {
+        studyId,
+        filters: filters || [],
+        config: {
+          outputEntityId: outputEntity.id,
+          xAxisVariable: vizConfig.xAxisVariable,
+          latitudeVariable: latitudeVariable,
+          longitudeVariable: longitudeVariable,
+          geoAggregateVariable: geoAggregateVariable,
+          showMissingness: 'noVariables', // current back end 'showMissing' behaviour applies to facet variable
+          valueSpec: proportionMode ? 'proportion' : 'count',
+          binSpec: binSpec ?? {},
+          viewport: {
+            latitude: {
+              xMin,
+              xMax,
+            },
+            longitude: {
+              left,
+              right,
+            },
+          },
+        },
+      };
+
+      // send request
+      return await dataClient.getMapMarkersOverlay(
+        computation.descriptor.type,
+        requestParams
+      );
+    }, [
+      studyId,
+      dataClient,
+      xAxisVariable,
+      vizConfig.xAxisVariable,
+      proportionMode,
+      boundsZoomLevel,
+      computation.descriptor.type,
+      geoAggregateVariable,
+      outputEntity,
+      filters,
+    ])
+  );
+
+  // If it's a string variable and a small vocabulary, use it as-is from the study metadata.
+  // This ensures that for low cardinality categoricals, the colours are always the same.
+  // Otherwise use the overlayValues from the back end (which are either bins or a Top7+Other)
+  const vocabulary =
+    xAxisVariable?.type === 'string' &&
+    xAxisVariable?.vocabulary != null &&
+    xAxisVariable.vocabulary.length <= 8
+      ? xAxisVariable.vocabulary
+      : overlayResponse.value?.mapMarkers.config.overlayValues;
+
+  const completeCasesAllVars =
+    overlayResponse.value?.mapMarkers.config.completeCasesAllVars;
+  const completeCases = overlayResponse.value?.completeCasesTable;
+
+  const overlayData = useMemo(() => {
+    // process response and return a map of "geoAgg key" => donut labels and counts
+    return !overlayResponse.pending && overlayResponse.value
+      ? overlayResponse.value.mapMarkers.data.reduce(
+          (map, { geoAggregateVariableDetails, label, value }) => {
+            const geoAggKey = geoAggregateVariableDetails.value;
+            if (overlayResponse.value)
+              // don't know why TS makes us do this check *again*...
+              map[geoAggKey] = {
+                // sum up the entity count from the sampleSizeTable because
+                // the data.label values might be proportions (and sum to 1)
+                entityCount: sum(
+                  overlayResponse.value.sampleSizeTable.find(
+                    (item) =>
+                      item.geoAggregateVariableDetails != null &&
+                      item.geoAggregateVariableDetails.value === geoAggKey
+                  )?.size
+                ),
+                data: zip(label, value).map(([label, value]) => ({
+                  label: label!,
+                  value: value!,
+                })),
+              };
+            return map;
+          },
+          {} as MapMarkersOverlayData
+        )
+      : undefined;
+  }, [overlayResponse]);
+
+  // calculate minPos and max for chart marker dependent axis
+  const valueMax = useMemo(
+    () =>
+      overlayData
+        ? values(overlayData) // it's a Record 'object'
+            .map((record) => record.data)
+            .flat() // flatten all the arrays into one
+            .reduce(
+              (accum, elem) => (elem.value > accum ? elem.value : accum),
+              0
+            ) // find max value
+        : 0,
+    [overlayData]
+  );
+
+  const valueMinPos = useMemo(
+    () =>
+      overlayData
+        ? values(overlayData)
+            .map((record) => record.data)
+            .flat()
+            .reduce<number | undefined>(
+              (accum, elem) =>
+                elem.value > 0 && (accum == null || elem.value < accum)
+                  ? elem.value
+                  : accum,
+              undefined
+            )
+        : undefined,
+    [overlayData]
+  );
+
+  const defaultDependentAxisRange = useDefaultAxisRange(
+    null,
+    0,
+    valueMinPos,
+    valueMax,
+    vizConfig.dependentAxisLogScale
+  ) as NumberRange;
+
+  /**
+   * Merge the overlay data into the basicMarkerData, if available,
+   * and create markers.
+   */
+  const markers = useMemo(() => {
+    if (vocabulary == null) return undefined;
+
+    return basicMarkerData.value?.markerData.map(
+      ({ geoAggregateValue, entityCount, bounds, position }) => {
+        const donutData =
+          overlayData?.[geoAggregateValue] != null
+            ? overlayData[geoAggregateValue].data
+                .map(({ label, value }) => ({
+                  label,
+                  value,
+                  color:
+                    xAxisVariable?.type === 'string'
+                      ? ColorPaletteDefault[vocabulary.indexOf(label!)]
+                      : gradientSequentialColorscaleMap(
+                          vocabulary.indexOf(label!) / (vocabulary.length - 1)
+                        ),
+                }))
+                // DonutMarkers don't handle checkedLegendItems automatically, like our
+                // regular PlotlyPlot components, so we do the filtering here
+                .filter(
+                  ({ label }) =>
+                    vizConfig.checkedLegendItems == null ||
+                    vizConfig.checkedLegendItems.indexOf(label) > -1
+                )
+            : [];
+
+        // now reorder the data, adding zeroes if necessary.
+        const reorderedData = vocabulary.map(
+          (
+            overlayLabel // overlay label can be 'female' or a bin label '(0,100]'
+          ) =>
+            donutData.find(({ label }) => label === overlayLabel) ?? {
+              label: overlayLabel,
+              value: 0,
+            }
+        );
+
+        // provide the 'plain white' donut data if all legend items unchecked
+        // or if there is no overlay data
+        const safeDonutData =
+          reorderedData.length > 0
+            ? reorderedData
+            : [
+                {
+                  label: 'unknown',
+                  value: entityCount,
+                  color: 'white',
+                },
+              ];
+
+        // TO DO: find out if MarkerProps.id is obsolete
+        const MarkerComponent =
+          vizConfig.markerType == null || vizConfig.markerType === 'pie'
+            ? DonutMarker
+            : ChartMarker;
+
+        const count =
+          overlayData != null
+            ? vizConfig.markerType == null || vizConfig.markerType === 'pie'
+              ? // pies always show sum of legend checked items (donutData is already filtered on checkboxes)
+                donutData.reduce((sum, item) => (sum = sum + item.value), 0)
+              : // the bar/histogram charts always show the constant entity count
+                // however, if there is no data at all we can safely infer a zero
+                overlayData[geoAggregateValue]?.entityCount ?? 0
+            : entityCount;
+
+        const formattedCount =
+          MarkerComponent === ChartMarker
+            ? mFormatter(count)
+            : kFormatter(count);
+
+        return (
+          <MarkerComponent
+            id={geoAggregateValue}
+            key={geoAggregateValue}
+            bounds={bounds}
+            position={position}
+            data={safeDonutData}
+            duration={defaultAnimationDuration}
+            markerLabel={formattedCount}
+            {...(vizConfig.markerType !== 'pie'
+              ? {
+                  dependentAxisRange: defaultDependentAxisRange,
+                  dependentAxisLogScale: vizConfig.dependentAxisLogScale,
+                }
+              : {})}
+          />
+        );
+      }
+    );
+  }, [
+    basicMarkerData.value,
+    vocabulary,
+    overlayData,
+    vizConfig.checkedLegendItems,
+    vizConfig.markerType,
+    xAxisVariable,
+    outputEntity,
+    // add vizConfig.dependentAxisLogScale to reflect its state change
+    vizConfig.dependentAxisLogScale,
+  ]);
+
+  /**
+   * create custom legend data
+   */
+
+  const legendItems: LegendItemsProps[] = useMemo(() => {
+    if (vocabulary == null) return [];
+
+    return vocabulary.map((label) => ({
+      label,
+      marker: 'square',
+      markerColor:
+        xAxisVariable?.type === 'string'
+          ? ColorPaletteDefault[vocabulary.indexOf(label)]
+          : gradientSequentialColorscaleMap(
+              vocabulary.indexOf(label) / (vocabulary.length - 1)
+            ),
+      // has any geo-facet got an array of overlay data
+      // containing at least one element that satisfies label==label
+      // (do not check that value > 0, because the back end doesn't return
+      // zero counts, but does sometimes return near-zero counts that get
+      // rounded to zero)
+      hasData: overlayData
+        ? some(overlayData, (pieData) =>
+            some(pieData.data, (data) => data.label === label)
+          )
+        : false,
+      group: 1,
+      rank: 1,
+    }));
+  }, [xAxisVariable, vocabulary, overlayData]);
+
+  return {
+    markers,
+    totalEntityCount,
+    completeCasesAllVars,
+    completeCases,
+    vocabulary,
+    legendItems,
+    pending: basicMarkerData.pending || overlayResponse.pending,
+    basicMarkerError: basicMarkerData.error,
+    overlayError: overlayResponse.error,
+  };
+}

--- a/src/lib/core/hooks/mapMarkers.tsx
+++ b/src/lib/core/hooks/mapMarkers.tsx
@@ -238,6 +238,7 @@ export function useMapMarkers(props: MapMarkersProps): MapMarkers {
       boundsZoomLevel,
       computation.descriptor.type,
       geoConfig,
+      requireOverlay,
     ])
   );
 


### PR DESCRIPTION
Fixes #1333 

Made a start on this, looking for feedback while still in draft please.

I extended the `XyzVisualization.withOptions()` approach to allow the optional customization of `layoutComponent` (see new `GlobalVisualizationOptions`).

By default each component will use the regular `PlotLayout` but you can instantiate a visualization with a different layout method. See the commented out code in `pass.tsx` that gives you a very minimal Boxplot (inputs, plot, and nothing else).

The worst part was disentangling the plot from the controls (`BoxplotWithControls` -> two separate components/functions). It wasn't difficult, just fiddly and a lot of moving stuff around. TS helps massively of course.

I have also refactored the fetching of map marker data into its own custom hook (`useMapMarkers`) but currently this only works when an overlay variable is provided.   It has a new prop `requireOverlay` which when `true` makes the hook behave as desired for the old map vizualization, and when `false` produces simple count-only markers when no overlay variable (confusingly also called xAxisVariable, but that does also make sense) is provided.

HistogramVisualization major refactor to avoid a large amount of prop-passing.

Now all visualizations are refactored to avoid having a "XyzPlotWithControls" sub-component with a ton of prop-passing. It means that the main component function is monolithic, but everything is named clearly and all vizs are the same structure now, so further refactoring should be easier.

All visualizations **apart from** Mosaic and Map (which we won't make available as floating visualizations for now) now have the `options.getOverlayVariable()` override for use as a floating visualization.
