### PR TITLE
enabling mouseMode

### DIFF
--- a/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
+++ b/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
@@ -174,7 +174,7 @@ function FullScreenMap(props: FullScreenComponentProps) {
     computationType: 'pass',
     markerType: appState.markerType,
     // Endpoint can't currently handle checkedLegendItems
-    // checkedLegendItems: appState.checkedLegendItems,
+    checkedLegendItems: appState.checkedLegendItems,
     //TO DO: maybe dependentAxisLogScale
   });
 
@@ -330,7 +330,6 @@ function FullScreenMap(props: FullScreenComponentProps) {
         animation={defaultAnimation}
         viewport={viewport}
         markers={markers}
-        mouseMode={mouseMode}
         flyToMarkers={
           markers &&
           markers.length > 0 &&
@@ -339,6 +338,9 @@ function FullScreenMap(props: FullScreenComponentProps) {
         flyToMarkersDelay={500}
         onBoundsChanged={setBoundsZoomLevel}
         onViewportChanged={onViewportChanged}
+        // show mouse tool
+        showMouseToolbar={true}
+        mouseMode={mouseMode}
         onMouseModeChange={onMouseModeChange}
       />
       {/* </div> */}


### PR DESCRIPTION
@dmfalke @bobular @chowington 
I have tested FSM with legend too and it seems to work fine overall, esp. for demo purpose 👍 I noticed that mouseMode was implemented but not functional so I examined the issue and found that it actually missed a prop, showMouseToolbar. Also enabled checkedLegendItems as it seems to work fine too. 
For this reason, this PR is branched out from fsm-legend but one can just change the fsm-legend directly.

Here is an example screenshot with mouseMode at FSM

![mouseMode1](https://user-images.githubusercontent.com/12802305/189690431-d7c649c3-4368-4b0a-bf9b-51cb9e38f59b.png)
