### PR TITLE
FSM: When filtered, don't have markers appear and disappear from minimap

### DIFF
--- a/src/lib/core/components/fullScreenApps/MiniMap.tsx
+++ b/src/lib/core/components/fullScreenApps/MiniMap.tsx
@@ -57,8 +57,7 @@ export function MiniMap(props: TriggerComponentTypes) {
     computationType: 'pass',
     markerType: 'pie',
     miniMarkers: true,
-    invisibleMarkers:
-      filters.length != analysis?.descriptor.subset.descriptor.length,
+    invisibleMarkers: isDefaultView,
   });
 
   const entityDisplayName =

--- a/src/lib/core/components/fullScreenApps/MiniMap.tsx
+++ b/src/lib/core/components/fullScreenApps/MiniMap.tsx
@@ -89,7 +89,7 @@ export function MiniMap(props: TriggerComponentTypes) {
           markers={markers}
           animation={defaultAnimation}
           zoomLevelToGeohashLevel={miniGeoConfig.zoomLevelToAggregationLevel}
-          showSpinner={pending}
+          showSpinner={!isDefaultView && pending}
           showMouseToolbar={false}
           showGrid={false}
           showScale={false}

--- a/src/lib/core/components/fullScreenApps/MiniMap.tsx
+++ b/src/lib/core/components/fullScreenApps/MiniMap.tsx
@@ -43,7 +43,9 @@ export function MiniMap(props: TriggerComponentTypes) {
   // This ensures that the flyTo zoom covers the area of the full, unfiltered dataset.
   const filters = isDefaultView
     ? emptyArray
-    : analysis?.descriptor.subset.descriptor;
+    : analysis?.descriptor.subset.descriptor.length
+    ? analysis?.descriptor.subset.descriptor
+    : emptyArray;
 
   const { markers = [], pending } = useMapMarkers({
     requireOverlay: false,
@@ -55,6 +57,8 @@ export function MiniMap(props: TriggerComponentTypes) {
     computationType: 'pass',
     markerType: 'pie',
     miniMarkers: true,
+    invisibleMarkers:
+      filters.length != analysis?.descriptor.subset.descriptor.length,
   });
 
   const entityDisplayName =
@@ -75,6 +79,7 @@ export function MiniMap(props: TriggerComponentTypes) {
           minZoom={0}
           viewport={viewport}
           flyToMarkers={isDefaultView}
+          flyToMarkersDelay={1000}
           interactive={false}
           onViewportChanged={setViewport}
           onBoundsChanged={setBoundsZoomLevel}

--- a/src/lib/core/components/fullScreenApps/MiniMap.tsx
+++ b/src/lib/core/components/fullScreenApps/MiniMap.tsx
@@ -67,9 +67,13 @@ export function MiniMap(props: TriggerComponentTypes) {
   // TO DO: figure out how to make them exactly the same
   return (
     <Tooltip
-      title={`Location of ${
-        filters.length > 0 ? "current subset's " : ''
-      }${entityDisplayName}`}
+      title={
+        <div>
+          Location of {entityDisplayName}
+          {filters.length ? ' in current subset' : ''}.<br />
+          Click the map to enlarge...
+        </div>
+      }
     >
       <div className="MiniMapContainer">
         <MapVEuMap

--- a/src/lib/core/hooks/mapMarkers.tsx
+++ b/src/lib/core/hooks/mapMarkers.tsx
@@ -78,6 +78,8 @@ export interface MapMarkersProps {
   checkedLegendItems?: string[];
   /** mini markers - default = false */
   miniMarkers?: boolean;
+  /** invisible markers (special use case related to minimap fly-to) - default = false */
+  invisibleMarkers?: boolean;
 }
 
 // what this hook returns
@@ -117,6 +119,7 @@ export function useMapMarkers(props: MapMarkersProps): MapMarkers {
     dependentAxisLogScale = false,
     checkedLegendItems = undefined,
     miniMarkers = false,
+    invisibleMarkers = false,
   } = props;
 
   const dataClient: DataClient = useDataClient();
@@ -522,7 +525,11 @@ export function useMapMarkers(props: MapMarkersProps): MapMarkers {
                   dependentAxisLogScale: dependentAxisLogScale,
                 }
               : {})}
-            {...(miniMarkers ? { markerScale: 0.5 } : {})}
+            {...(miniMarkers && !invisibleMarkers
+              ? { markerScale: 0.5 }
+              : invisibleMarkers
+              ? { markerScale: 0 }
+              : {})}
           />
         );
       }


### PR DESCRIPTION
Just a small fix to improve the behaviour of the minimap.

A filterless request is necessary in order to trigger the correct `flyTo` so that all the data in the study will fit in the minimap, regardless of filters applied or removed at a later stage.

However, we don't want to confuse the user with markers appearing and then disappearing, so the first filterless request is made for `invisibleMarkers` (size = 0).

Behaviour seems acceptable to me now.

Also improved (maybe) the tooltip text