### PR TITLE
correcting dependent axis range of Lineplot Viz proportion

### DIFF
--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -5,13 +5,7 @@ import LinePlot, {
 } from '@veupathdb/components/lib/plots/LinePlot';
 
 import * as t from 'io-ts';
-import {
-  useCallback,
-  useMemo,
-  useState,
-  useEffect,
-  useDebugValue,
-} from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
 
 import DataClient, {
   LineplotRequestParams,
@@ -62,6 +56,7 @@ import {
   NumberOrTimeDelta,
   NumberOrTimeDeltaRange,
   TimeDelta,
+  NumberRange,
 } from '@veupathdb/components/lib/types/general';
 import {
   LinePlotDataSeries,
@@ -641,13 +636,21 @@ function LineplotViz(props: VisualizationProps) {
     [data]
   );
 
-  const defaultDependentAxisRange = useDefaultAxisRange(
+  let defaultDependentAxisRange = useDefaultAxisRange(
     yAxisVariable,
     data.value?.yMin,
     data.value?.yMinPos,
     data.value?.yMax,
     vizConfig.dependentAxisLogScale
   );
+
+  if (vizConfig.valueSpecConfig === 'Proportion')
+    if (vizConfig.dependentAxisLogScale)
+      defaultDependentAxisRange = {
+        min: data.value?.yMinPos,
+        max: 1,
+      } as NumberRange;
+    else defaultDependentAxisRange = { min: 0, max: 1 };
 
   // custom legend list
   const legendItems: LegendItemsProps[] = useMemo(() => {

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -644,7 +644,7 @@ function LineplotViz(props: VisualizationProps) {
     vizConfig.dependentAxisLogScale
   );
 
-  if (vizConfig.valueSpecConfig === 'Proportion')
+  if (data.value != null && vizConfig.valueSpecConfig === 'Proportion')
     if (vizConfig.dependentAxisLogScale)
       defaultDependentAxisRange = {
         min: data.value?.yMinPos,

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -12,7 +12,7 @@ import DataClient, {
   LineplotResponse,
 } from '../../../api/DataClient';
 
-import { usePromise } from '../../../hooks/promise';
+import { usePromise, PromiseHookState } from '../../../hooks/promise';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
 import {
   useDataClient,
@@ -636,21 +636,13 @@ function LineplotViz(props: VisualizationProps) {
     [data]
   );
 
-  let defaultDependentAxisRange = useDefaultAxisRange(
+  // use a hook to handle default dependent axis range for Lineplot Viz Proportion
+  const defaultDependentAxisRange = useDefaultDependentAxisRangeProportion(
+    data,
     yAxisVariable,
-    data.value?.yMin,
-    data.value?.yMinPos,
-    data.value?.yMax,
-    vizConfig.dependentAxisLogScale
+    vizConfig.dependentAxisLogScale,
+    vizConfig.valueSpecConfig
   );
-
-  if (data.value != null && vizConfig.valueSpecConfig === 'Proportion')
-    if (vizConfig.dependentAxisLogScale)
-      defaultDependentAxisRange = {
-        min: data.value?.yMinPos,
-        max: 1,
-      } as NumberRange;
-    else defaultDependentAxisRange = { min: 0, max: 1 };
 
   // custom legend list
   const legendItems: LegendItemsProps[] = useMemo(() => {
@@ -2231,4 +2223,32 @@ function isSuitableCategoricalVariable(variable?: Variable): boolean {
     variable.vocabulary != null &&
     variable.distinctValuesCount != null
   );
+}
+
+/**
+ * A hook to handle default dependent axis range for Lineplot Viz Proportion
+ */
+function useDefaultDependentAxisRangeProportion(
+  data: PromiseHookState<LinePlotDataWithCoverage | undefined>,
+  yAxisVariable?: Variable,
+  dependentAxisLogScale?: boolean,
+  valueSpecConfig?: string
+) {
+  let defaultDependentAxisRange = useDefaultAxisRange(
+    yAxisVariable,
+    data.value?.yMin,
+    data.value?.yMinPos,
+    data.value?.yMax,
+    dependentAxisLogScale
+  );
+
+  if (data.value != null && valueSpecConfig === 'Proportion')
+    if (dependentAxisLogScale)
+      defaultDependentAxisRange = {
+        min: data.value?.yMinPos,
+        max: 1,
+      } as NumberRange;
+    else defaultDependentAxisRange = { min: 0, max: 1 };
+
+  return defaultDependentAxisRange;
 }


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1360.

Initially I tried to change useDefaultAxisRange hook but current solution is more intuitive and much simpler and works just fine.

Screenshots after fixing:

![lineplot-pro-fix1](https://user-images.githubusercontent.com/12802305/189922950-46f4bdb2-3396-47ea-8d9c-b0cef084ea93.png)

![lineplot-pro-fix2](https://user-images.githubusercontent.com/12802305/189922970-d69f0252-a421-461a-bf2d-6d19292a7f6d.png)

