### PR TITLE
FSM: handle constraints on provided overlay variable for floating visualizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/plugins/pass.tsx
+++ b/src/lib/core/components/computations/plugins/pass.tsx
@@ -12,7 +12,6 @@ import { testVisualization } from '../../visualizations/implementations/TestVisu
 import { ComputationPlugin } from '../Types';
 import { ZeroConfigWithButton } from '../ZeroConfiguration';
 import * as t from 'io-ts';
-import { FloatingLayout } from '../../layouts/FloatingLayout';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
@@ -30,16 +29,5 @@ export const plugin: ComputationPlugin = {
     // densityplot: scatterplotVisualization,
     barplot: barplotVisualization,
     boxplot: boxplotVisualization,
-    // or...
-    //    boxplot: boxplotVisualization.withOptions({
-    //      hideFacetInputs: true,
-    //      getOverlayVariable(_) {
-    //	      return {
-    //	        "entityId": "PCO_0000024",
-    //	        "variableId": "EUPATH_0015019" // charcoal
-    //	      };
-    //      },
-    //      layoutComponent: FloatingLayout,
-    //    }), /// TEMPORARY ONLY!!! ///
   },
 };

--- a/src/lib/core/components/fullScreenApps/FullScreenContainer.tsx
+++ b/src/lib/core/components/fullScreenApps/FullScreenContainer.tsx
@@ -6,9 +6,9 @@ import { AnalysisState } from '../../hooks/analysis';
 import { useAnalysisClient } from '../../hooks/workspace';
 import { isSavedAnalysis } from '../../utils/analysis';
 import makeSnackbarProvider from '@veupathdb/coreui/dist/components/notifications/SnackbarProvider';
+import { Close, FilledButton } from '@veupathdb/coreui';
 
 const SnackbarProvider = makeSnackbarProvider();
-import { Close, FilledButton } from '@veupathdb/coreui';
 
 interface Props {
   analysisState: AnalysisState;

--- a/src/lib/core/components/fullScreenApps/FullScreenContainer.tsx
+++ b/src/lib/core/components/fullScreenApps/FullScreenContainer.tsx
@@ -6,6 +6,9 @@ import { AnalysisState } from '../../hooks/analysis';
 import { useAnalysisClient } from '../../hooks/workspace';
 import { isSavedAnalysis } from '../../utils/analysis';
 import { Close, FloatingButton } from '@veupathdb/coreui';
+import makeSnackbarProvider from '@veupathdb/coreui/dist/components/notifications/SnackbarProvider';
+
+const SnackbarProvider = makeSnackbarProvider();
 
 interface Props {
   analysisState: AnalysisState;
@@ -36,50 +39,52 @@ export default function FullScreenContainer(props: Props) {
   if (plugin == null) return <div>Unknown plugin</div>;
   return nodeRef
     ? createPortal(
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            zIndex: 1,
-            background: 'white',
-          }}
-        >
+        <SnackbarProvider domRoot={nodeRef} styleProps={{}}>
           <div
             style={{
-              position: 'absolute',
-              zIndex: 2,
-              right: 12,
-              top: 8,
-              transform: 'scale(1.5)',
-            }}
-          >
-            <FloatingButton
-              onPress={props.onClose}
-              text=""
-              icon={Close}
-              themeRole="primary"
-            />
-          </div>
-          <div
-            style={{
-              position: 'absolute',
+              position: 'fixed',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
               zIndex: 1,
-              height: '100%',
-              width: '100%',
+              background: 'white',
             }}
           >
-            {loading ? null : (
-              <plugin.fullScreenComponent
-                appState={appState}
-                persistAppState={updateAppState}
-                analysisState={props.analysisState}
+            <div
+              style={{
+                position: 'absolute',
+                zIndex: 2,
+                right: 12,
+                top: 8,
+                transform: 'scale(1.5)',
+              }}
+            >
+              <FloatingButton
+                onPress={props.onClose}
+                text=""
+                icon={Close}
+                themeRole="primary"
               />
-            )}
+            </div>
+            <div
+              style={{
+                position: 'absolute',
+                zIndex: 1,
+                height: '100%',
+                width: '100%',
+              }}
+            >
+              {loading ? null : (
+                <plugin.fullScreenComponent
+                  appState={appState}
+                  persistAppState={updateAppState}
+                  analysisState={props.analysisState}
+                />
+              )}
+            </div>
           </div>
-        </div>,
+        </SnackbarProvider>,
         nodeRef
       )
     : null;

--- a/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
+++ b/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
@@ -186,7 +186,11 @@ function FullScreenMap(props: FullScreenComponentProps) {
 
   const setSelectedVariables = useCallback(
     (selectedVariables: VariablesByInputName) => {
-      setAppState({ overlayVariable: selectedVariables.overlay });
+      setAppState({
+        overlayVariable: selectedVariables.overlay,
+        ...// reset marker type to pie if no overlay var
+        (selectedVariables.overlay == null ? { markerType: 'pie' } : {}),
+      });
     },
     [setAppState]
   );

--- a/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
+++ b/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
@@ -140,7 +140,7 @@ function FullScreenMap(props: FullScreenComponentProps) {
         conttable: vizWithOptions(contTableVisualization),
         scatterplot: vizWithOptions(scatterplotVisualization),
         lineplot: vizWithOptions(lineplotVisualization),
-        'map-markers': vizWithOptions(mapVisualization),
+        // 'map-markers': vizWithOptions(mapVisualization), // disabling because of potential confusion between marker colors
         barplot: vizWithOptions(barplotVisualization),
         boxplot: vizWithOptions(boxplotVisualization),
       },

--- a/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
+++ b/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
@@ -122,6 +122,8 @@ function FullScreenMap(props: FullScreenComponentProps) {
         hideFacetInputs: true,
         layoutComponent: FloatingLayout,
         getOverlayVariable: (_) => appState.overlayVariable,
+        getOverlayVariableHelp: () =>
+          'None. Select an overlay variable in the top-right panel.',
       });
     }
 

--- a/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
+++ b/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
@@ -123,7 +123,7 @@ function FullScreenMap(props: FullScreenComponentProps) {
         layoutComponent: FloatingLayout,
         getOverlayVariable: (_) => appState.overlayVariable,
         getOverlayVariableHelp: () =>
-          'None. Select an overlay variable in the top-right panel.',
+          'The overlay variable can be selected via the top-right panel.',
       });
     }
 

--- a/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
+++ b/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
@@ -422,6 +422,8 @@ function FullScreenMap(props: FullScreenComponentProps) {
         onBoundsChanged={setBoundsZoomLevel}
         onViewportChanged={onViewportChanged}
         onMouseModeChange={onMouseModeChange}
+        showGrid={geoConfig?.zoomLevelToAggregationLevel != null}
+        zoomLevelToGeohashLevel={geoConfig?.zoomLevelToAggregationLevel}
       />
       {/* </div> */}
       <div

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -4,19 +4,17 @@ import { VariableDescriptor } from '../../types/variable';
 import {
   DataElementConstraintRecord,
   disabledVariablesForInput,
-  excludedVariables,
   flattenConstraints,
   VariablesByInputName,
 } from '../../utils/data-element-constraints';
 
 import VariableTreeDropdown from '../variableTrees/VariableTreeDropdown';
-import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import Toggle from '@veupathdb/coreui/dist/components/widgets/Toggle';
 import { makeEntityDisplayName } from '../../utils/study-metadata';
 import { useInputStyles } from './inputStyles';
 import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
-import useSnackbar from '@veupathdb/coreui/dist/components/notifications/useSnackbar';
+import { isEqual } from 'lodash';
 
 export interface InputSpec {
   name: string;
@@ -176,8 +174,6 @@ export function InputVariables(props: Props) {
     ]
   );
 
-  const { enqueueSnackbar } = useSnackbar();
-
   return (
     <div className={classes.inputs}>
       {[undefined, 'axis', 'stratification'].map(
@@ -240,13 +236,11 @@ export function InputVariables(props: Props) {
                       // and disable radio input if needed
                       <RadioButtonGroup
                         disabledList={
-                          disabledVariablesByInputName[input.name].filter(
-                            (variable) =>
-                              variable.entityId ===
-                                input.providedOptionalVariable?.entityId &&
-                              variable.variableId ===
-                                input.providedOptionalVariable?.variableId
-                          ).length
+                          disabledVariablesByInputName[
+                            input.name
+                          ].find((variable) =>
+                            isEqual(variable, input.providedOptionalVariable)
+                          )
                             ? ['provided']
                             : []
                         }
@@ -266,13 +260,13 @@ export function InputVariables(props: Props) {
                               : input.providedOptionalVariable
                           )
                         }
-                        onSelectedOptionDisabled={(_) => {
-                          handleChange(input.name, undefined);
-                          enqueueSnackbar(
-                            `The newly chosen ${input.label} variable has been disabled because is not compatible with this visualization as currently configured.`,
-                            { preventDuplicate: true } // nasty hack to workaround double calls to this callback which I tried for more than an hour to fix (and when I did fix it, the radio button was not switched to "none"...)
-                          );
-                        }}
+                        //                        onSelectedOptionDisabled={(_) => {
+                        //                          handleChange(input.name, undefined);
+                        //                          enqueueSnackbar(
+                        //                            `The newly chosen ${input.label} variable has been disabled because is not compatible with this visualization as currently configured.`,
+                        //                            { preventDuplicate: true } // nasty hack to workaround double calls to this callback which I tried for more than an hour to fix (and when I did fix it, the radio button was not switched to "none"...)
+                        //                          );
+                        //                        }}
                       />
                     ) : input.readonlyValue ? (
                       <span style={{ height: '32px', lineHeight: '32px' }}>

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -15,6 +15,8 @@ import { makeEntityDisplayName } from '../../utils/study-metadata';
 import { useInputStyles } from './inputStyles';
 import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
+import { enqueueSnackbar } from '@veupathdb/wdk-client/lib/Actions/NotificationActions';
+import useSnackbar from '@veupathdb/coreui/dist/components/notifications/useSnackbar';
 
 export interface InputSpec {
   name: string;
@@ -238,6 +240,8 @@ export function InputVariables(props: Props) {
     ]
   );
 
+  const { enqueueSnackbar } = useSnackbar();
+
   return (
     <div className={classes.inputs}>
       {[undefined, 'axis', 'stratification'].map(
@@ -326,9 +330,12 @@ export function InputVariables(props: Props) {
                               : input.providedOptionalVariable
                           )
                         }
-                        onSelectedOptionDisabled={(_) =>
-                          handleChange(input.name, undefined)
-                        }
+                        onSelectedOptionDisabled={(_) => {
+                          handleChange(input.name, undefined);
+                          enqueueSnackbar(
+                            `The newly chosen ${input.label} variable has been disabled because is not compatible with this visualization as currently configured.`
+                          );
+                        }}
                       />
                     ) : input.readonlyValue ? (
                       <span style={{ height: '32px', lineHeight: '32px' }}>

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -15,7 +15,6 @@ import { makeEntityDisplayName } from '../../utils/study-metadata';
 import { useInputStyles } from './inputStyles';
 import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
-import { enqueueSnackbar } from '@veupathdb/wdk-client/lib/Actions/NotificationActions';
 import useSnackbar from '@veupathdb/coreui/dist/components/notifications/useSnackbar';
 
 export interface InputSpec {
@@ -333,7 +332,8 @@ export function InputVariables(props: Props) {
                         onSelectedOptionDisabled={(_) => {
                           handleChange(input.name, undefined);
                           enqueueSnackbar(
-                            `The newly chosen ${input.label} variable has been disabled because is not compatible with this visualization as currently configured.`
+                            `The newly chosen ${input.label} variable has been disabled because is not compatible with this visualization as currently configured.`,
+                            { preventDuplicate: true } // nasty hack to workaround double calls to this callback which I tried for more than an hour to fix (and when I did fix it, the radio button was not switched to "none"...)
                           );
                         }}
                       />

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -14,6 +14,7 @@ import Toggle from '@veupathdb/coreui/dist/components/widgets/Toggle';
 import { makeEntityDisplayName } from '../../utils/study-metadata';
 import { useInputStyles } from './inputStyles';
 import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
+import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
 
 export interface InputSpec {
   name: string;
@@ -23,6 +24,11 @@ export interface InputSpec {
    */
   readonlyValue?: string;
   role?: 'axis' | 'stratification';
+  /**
+   * Instead of just providing a string, as above, provide the only
+   * allowed variable for this input (though it can also be cleared with "Clear selection")
+   */
+  providedOptionalVariable?: VariableDescriptor;
 }
 
 interface SectionSpec {
@@ -277,7 +283,41 @@ export function InputVariables(props: Props) {
                         )}
                       </div>
                     </Tooltip>
-                    {!input.readonlyValue ? (
+                    {input.readonlyValue ? (
+                      <span style={{ height: '32px', lineHeight: '32px' }}>
+                        {input.readonlyValue}
+                      </span>
+                    ) : input.providedOptionalVariable ? (
+                      // render a radio button to choose between provided and nothing
+                      // check if provided var is in disabledVariablesByInputName[input.name]
+                      // and disable radio input if needed
+                      <RadioButtonGroup
+                        disabledList={
+                          disabledVariablesByInputName[input.name].filter(
+                            (variable) =>
+                              variable.entityId ===
+                                input.providedOptionalVariable?.entityId &&
+                              variable.variableId ===
+                                input.providedOptionalVariable?.variableId
+                          ).length
+                            ? ['provided']
+                            : []
+                        }
+                        options={['none', 'provided']}
+                        optionLabels={['None', 'Some message here']}
+                        selectedOption={
+                          selectedVariables[input.name] ? 'provided' : 'none'
+                        }
+                        onOptionSelected={(selection) =>
+                          handleChange(
+                            input.name,
+                            selection === 'none'
+                              ? undefined
+                              : input.providedOptionalVariable
+                          )
+                        }
+                      />
+                    ) : (
                       <VariableTreeDropdown
                         scope="variableTree"
                         showMultiFilterDescendants
@@ -295,10 +335,6 @@ export function InputVariables(props: Props) {
                           handleChange(input.name, variable);
                         }}
                       />
-                    ) : (
-                      <span style={{ height: '32px', lineHeight: '32px' }}>
-                        {input.readonlyValue}
-                      </span>
                     )}
                   </div>
                 ))}

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -25,9 +25,15 @@ export interface InputSpec {
   readonlyValue?: string;
   role?: 'axis' | 'stratification';
   /**
-   * Instead of just providing a string, as above, provide the only
-   * allowed variable for this input (though it can also be cleared with "Clear selection").
-   * However, you can use the `readonlyValue` as a label to display when the provided variable is null
+   * Instead of just providing a string, as above, provide a variable that the
+   * user will be able to choose with a radio button group (the other option is "no variable").
+   *
+   * However, you should additionaly use the `readonlyValue` prop as a label to display
+   * when the provided variable is null.
+   *
+   * The variable will only be selected/selectable if the constraints are met.
+   * (Meaning that if you pass a new provided variable that isn't compatible, the radio button
+   * will switch to "no variable")
    */
   providedOptionalVariable?: VariableDescriptor;
 }
@@ -274,7 +280,11 @@ export function InputVariables(props: Props) {
                         className={classes.label}
                         style={{ cursor: 'default' }}
                       >
-                        {input.label + (input.readonlyValue ? ' (fixed)' : '')}
+                        {input.label +
+                          (input.readonlyValue &&
+                          !input.providedOptionalVariable
+                            ? ' (fixed)'
+                            : '')}
                         {!input.readonlyValue &&
                         flattenedConstraints &&
                         flattenedConstraints[input.name].isRequired ? (
@@ -301,7 +311,10 @@ export function InputVariables(props: Props) {
                             : []
                         }
                         options={['none', 'provided']}
-                        optionLabels={['None', 'Some message here']}
+                        optionLabels={[
+                          'None',
+                          input.readonlyValue ?? 'Provided',
+                        ]}
                         selectedOption={
                           selectedVariables[input.name] ? 'provided' : 'none'
                         }

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -26,7 +26,8 @@ export interface InputSpec {
   role?: 'axis' | 'stratification';
   /**
    * Instead of just providing a string, as above, provide the only
-   * allowed variable for this input (though it can also be cleared with "Clear selection")
+   * allowed variable for this input (though it can also be cleared with "Clear selection").
+   * However, you can use the `readonlyValue` as a label to display when the provided variable is null
    */
   providedOptionalVariable?: VariableDescriptor;
 }
@@ -283,11 +284,7 @@ export function InputVariables(props: Props) {
                         )}
                       </div>
                     </Tooltip>
-                    {input.readonlyValue ? (
-                      <span style={{ height: '32px', lineHeight: '32px' }}>
-                        {input.readonlyValue}
-                      </span>
-                    ) : input.providedOptionalVariable ? (
+                    {input.providedOptionalVariable ? (
                       // render a radio button to choose between provided and nothing
                       // check if provided var is in disabledVariablesByInputName[input.name]
                       // and disable radio input if needed
@@ -316,7 +313,14 @@ export function InputVariables(props: Props) {
                               : input.providedOptionalVariable
                           )
                         }
+                        onSelectedOptionDisabled={(_) =>
+                          handleChange(input.name, undefined)
+                        }
                       />
+                    ) : input.readonlyValue ? (
+                      <span style={{ height: '32px', lineHeight: '32px' }}>
+                        {input.readonlyValue}
+                      </span>
                     ) : (
                       <VariableTreeDropdown
                         scope="variableTree"

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -259,6 +259,21 @@ function BarplotViz(props: VisualizationProps<Options>) {
     [options?.getOverlayVariable, computation.descriptor.configuration]
   );
 
+  useEffect(() => {
+    if (
+      vizConfig.overlayVariable == null ||
+      isEqual(providedOverlayVariableDescriptor, vizConfig.overlayVariable)
+    )
+      return;
+    updateVizConfig({
+      overlayVariable: providedOverlayVariableDescriptor,
+    });
+  }, [
+    providedOverlayVariableDescriptor,
+    vizConfig.overlayVariable,
+    updateVizConfig,
+  ]);
+
   const findEntityAndVariable = useFindEntityAndVariable();
   const {
     variable,
@@ -718,9 +733,8 @@ function BarplotViz(props: VisualizationProps<Options>) {
                 options?.getOverlayVariable != null
                   ? providedOverlayVariableDescriptor
                     ? variableDisplayWithUnit(providedOverlayVariable)
-                    : options?.getOverlayVariableHelp?.() ?? 'none'
+                    : 'None. ' + options?.getOverlayVariableHelp?.() ?? ''
                   : undefined,
-              // TO DO: verbiage for 'none'
             },
             ...(options?.hideFacetInputs
               ? []

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -77,6 +77,7 @@ import Button from '@veupathdb/components/lib/components/widgets/Button';
 import { useDefaultAxisRange } from '../../../hooks/computeDefaultAxisRange';
 import {
   useFlattenedConstraints,
+  useNeutralPaletteProps,
   useProvidedOptionalVariable,
   useVizConfig,
 } from '../../../hooks/visualizations';
@@ -526,6 +527,10 @@ function BarplotViz(props: VisualizationProps<Options>) {
   );
 
   const overlayLabel = variableDisplayWithUnit(overlayVariable);
+  const neutralPaletteProps = useNeutralPaletteProps(
+    vizConfig.overlayVariable,
+    providedOverlayVariableDescriptor
+  );
 
   // these props are passed to either a single plot
   // or by FacetedPlot to each individual facet plot (where some will be overridden)
@@ -558,6 +563,7 @@ function BarplotViz(props: VisualizationProps<Options>) {
         max: truncationConfigDependentAxisMax,
       },
     },
+    ...neutralPaletteProps,
   };
 
   const plotNode = (

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -715,7 +715,9 @@ function BarplotViz(props: VisualizationProps<Options>) {
               label: 'Overlay',
               role: 'stratification',
               providedOptionalVariable: providedOverlayVariable,
-              //              readonlyValue:
+              readonlyValue: options?.getOverlayVariable
+                ? 'none (select one top right)'
+                : undefined,
               //                options?.getOverlayVariable != null
               //                  ? providedOverlayVariable
               //                    ? overlayLabel

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -254,34 +254,32 @@ function BarplotViz(props: VisualizationProps<Options>) {
     'checkedLegendItems'
   );
 
-  const providedOverlayVariable = useMemo(
+  const providedOverlayVariableDescriptor = useMemo(
     () => options?.getOverlayVariable?.(computation.descriptor.configuration),
     [options?.getOverlayVariable, computation.descriptor.configuration]
   );
-
-  //  useEffect(() => {
-  //    if (isEqual(vizConfig.overlayVariable, providedOverlayVariable))
-  //      return;
-  //    // TO DO: check constraints here
-  //    updateVizConfig({ overlayVariable: providedOverlayVariable });
-  //  }, [ vizConfig.overlayVariable, providedOverlayVariable, updateVizConfig ])
 
   const findEntityAndVariable = useFindEntityAndVariable();
   const {
     variable,
     entity,
     overlayVariable,
+    providedOverlayVariable,
     overlayEntity,
     facetVariable,
     facetEntity,
   } = useMemo(() => {
     const xAxisVariable = findEntityAndVariable(vizConfig.xAxisVariable);
     const overlayVariable = findEntityAndVariable(vizConfig.overlayVariable);
+    const providedOverlayVariable = findEntityAndVariable(
+      providedOverlayVariableDescriptor
+    );
     const facetVariable = findEntityAndVariable(vizConfig.facetVariable);
     return {
       variable: xAxisVariable?.variable,
       entity: xAxisVariable?.entity,
       overlayVariable: overlayVariable?.variable,
+      providedOverlayVariable: providedOverlayVariable?.variable,
       overlayEntity: overlayVariable?.entity,
       facetVariable: facetVariable?.variable,
       facetEntity: facetVariable?.entity,
@@ -291,6 +289,7 @@ function BarplotViz(props: VisualizationProps<Options>) {
     vizConfig.xAxisVariable,
     vizConfig.overlayVariable,
     vizConfig.facetVariable,
+    providedOverlayVariableDescriptor,
   ]);
 
   const data = usePromise(
@@ -714,15 +713,13 @@ function BarplotViz(props: VisualizationProps<Options>) {
               name: 'overlayVariable',
               label: 'Overlay',
               role: 'stratification',
-              providedOptionalVariable: providedOverlayVariable,
-              readonlyValue: options?.getOverlayVariable
-                ? 'none (select one top right)'
-                : undefined,
-              //                options?.getOverlayVariable != null
-              //                  ? providedOverlayVariable
-              //                    ? overlayLabel
-              //                    : 'none'
-              //                  : undefined,
+              providedOptionalVariable: providedOverlayVariableDescriptor,
+              readonlyValue:
+                options?.getOverlayVariable != null
+                  ? providedOverlayVariableDescriptor
+                    ? variableDisplayWithUnit(providedOverlayVariable)
+                    : options?.getOverlayVariableHelp?.() ?? 'none'
+                  : undefined,
               // TO DO: verbiage for 'none'
             },
             ...(options?.hideFacetInputs

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -269,6 +269,7 @@ function BarplotViz(props: VisualizationProps<Options>) {
   );
 
   useProvidedOptionalVariable<BarplotConfig>(
+    options?.getOverlayVariable,
     'overlayVariable',
     providedOverlayVariableDescriptor,
     vizConfig.overlayVariable,

--- a/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -450,11 +450,14 @@ function BarplotViz(props: VisualizationProps<Options>) {
       : [];
   }, [data]);
 
-  // set checkedLegendItems
+  // set checkedLegendItems to either the config-stored items, or all items if nothing stored (or if no overlay locally configured)
   const checkedLegendItems = useCheckedLegendItemsStatus(
     legendItems,
-    options?.getCheckedLegendItems?.(computation.descriptor.configuration) ??
-      vizConfig.checkedLegendItems
+    vizConfig.overlayVariable
+      ? options?.getCheckedLegendItems?.(
+          computation.descriptor.configuration
+        ) ?? vizConfig.checkedLegendItems
+      : undefined
   );
 
   const minPos = useMemo(() => barplotDefaultDependentAxisMinPos(data), [data]);

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -814,7 +814,7 @@ function Plot({
   const plotRef = useUpdateThumbnailEffect(
     updateThumbnail,
     plotContainerStyles,
-    [data, checkedLegendItems, vizConfig.dependentAxisRange]
+    [data, vizConfig.checkedLegendItems, vizConfig.dependentAxisRange]
   );
   // set truncation flags: will see if this is reusable with other application
   const {

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -513,11 +513,14 @@ function BoxplotViz(props: VisualizationProps<Options>) {
       : [];
   }, [data]);
 
-  // set checkedLegendItems
+  // set checkedLegendItems to either the config-stored items, or all items if nothing stored (or if no overlay locally configured)
   const checkedLegendItems = useCheckedLegendItemsStatus(
     legendItems,
-    options?.getCheckedLegendItems?.(computation.descriptor.configuration) ??
-      vizConfig.checkedLegendItems
+    vizConfig.overlayVariable
+      ? options?.getCheckedLegendItems?.(
+          computation.descriptor.configuration
+        ) ?? vizConfig.checkedLegendItems
+      : undefined
   );
 
   // alphadiv abundance findEntityAndVariable does not work properly for collection variable
@@ -699,8 +702,6 @@ function BoxplotViz(props: VisualizationProps<Options>) {
   ]);
 
   const LayoutComponent = options?.layoutComponent ?? PlotLayout;
-
-  console.log('Viz component');
 
   // for handling alphadiv abundance
   return (

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -238,6 +238,7 @@ function BoxplotViz(props: VisualizationProps<Options>) {
   );
 
   useProvidedOptionalVariable<BoxplotConfig>(
+    options?.getOverlayVariable,
     'overlayVariable',
     providedOverlayVariableDescriptor,
     vizConfig.overlayVariable,

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -519,11 +519,14 @@ function HistogramViz(props: VisualizationProps<Options>) {
       : [];
   }, [data]);
 
-  // set checkedLegendItems
+  // set checkedLegendItems to either the config-stored items, or all items if nothing stored (or if no overlay locally configured)
   const checkedLegendItems = useCheckedLegendItemsStatus(
     legendItems,
-    options?.getCheckedLegendItems?.(computation.descriptor.configuration) ??
-      vizConfig.checkedLegendItems
+    vizConfig.overlayVariable
+      ? options?.getCheckedLegendItems?.(
+          computation.descriptor.configuration
+        ) ?? vizConfig.checkedLegendItems
+      : undefined
   );
 
   // axis range control

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -92,11 +92,17 @@ import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/
 import { UIState } from '../../filter/HistogramFilter';
 // change defaultIndependentAxisRange to hook
 import { useDefaultAxisRange } from '../../../hooks/computeDefaultAxisRange';
-import { useVizConfig } from '../../../hooks/visualizations';
+import {
+  useFlattenedConstraints,
+  useNeutralPaletteProps,
+  useProvidedOptionalVariable,
+  useVizConfig,
+} from '../../../hooks/visualizations';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
 import { histogramDefaultDependentAxisMinMax } from '../../../utils/axis-range-calculations';
 import { LayoutOptions } from '../../layouts/types';
 import { OverlayOptions } from '../options/types';
+import { useDeepValue } from '../../../hooks/immutability';
 
 export type HistogramDataWithCoverageStatistics = (
   | HistogramData
@@ -298,24 +304,52 @@ function HistogramViz(props: VisualizationProps<Options>) {
     };
   }, [findEntityAndVariable, vizConfig.xAxisVariable]);
 
-  const providedOverlayVariable = options?.getOverlayVariable?.(
-    computation.descriptor.configuration
+  const providedOverlayVariableDescriptor = useMemo(
+    () => options?.getOverlayVariable?.(computation.descriptor.configuration),
+    [options?.getOverlayVariable, computation.descriptor.configuration]
+  );
+
+  const selectedVariables = useDeepValue({
+    xAxisVariable: vizConfig.xAxisVariable,
+    overlayVariable: vizConfig.overlayVariable,
+    facetVariable: vizConfig.facetVariable,
+  });
+
+  const flattenedConstraints = useFlattenedConstraints(
+    dataElementConstraints,
+    selectedVariables,
+    entities
+  );
+
+  useProvidedOptionalVariable<HistogramConfig>(
+    'overlayVariable',
+    providedOverlayVariableDescriptor,
+    vizConfig.overlayVariable,
+    entities,
+    flattenedConstraints,
+    dataElementDependencyOrder,
+    selectedVariables,
+    updateVizConfig,
+    /** snackbar message */
+    'The new overlay variable is not compatible with this visualization and has been disabled.'
   );
 
   const {
     overlayVariable,
+    providedOverlayVariable,
     overlayEntity,
     facetVariable,
     facetEntity,
   } = useMemo(() => {
     const { variable: overlayVariable, entity: overlayEntity } =
-      findEntityAndVariable(
-        providedOverlayVariable ?? vizConfig.overlayVariable
-      ) ?? {};
+      findEntityAndVariable(vizConfig.overlayVariable) ?? {};
+    const { variable: providedOverlayVariable } =
+      findEntityAndVariable(providedOverlayVariableDescriptor) ?? {};
     const { variable: facetVariable, entity: facetEntity } =
       findEntityAndVariable(vizConfig.facetVariable) ?? {};
     return {
       overlayVariable,
+      providedOverlayVariable,
       overlayEntity,
       facetVariable,
       facetEntity,
@@ -324,7 +358,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
     findEntityAndVariable,
     vizConfig.overlayVariable,
     vizConfig.facetVariable,
-    providedOverlayVariable,
+    providedOverlayVariableDescriptor,
   ]);
 
   const data = usePromise(
@@ -348,8 +382,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
         filters ?? [],
         valueType,
         vizConfig,
-        xAxisVariable,
-        providedOverlayVariable
+        xAxisVariable
       );
       const response = await dataClient.getHistogram(
         computation.descriptor.type,
@@ -419,7 +452,6 @@ function HistogramViz(props: VisualizationProps<Options>) {
       valueType,
       // get data when changing independentAxisRange
       vizConfig.independentAxisRange,
-      providedOverlayVariable,
     ])
   );
 
@@ -679,6 +711,10 @@ function HistogramViz(props: VisualizationProps<Options>) {
   );
 
   const overlayLabel = variableDisplayWithUnit(overlayVariable);
+  const neutralPaletteProps = useNeutralPaletteProps(
+    vizConfig.overlayVariable,
+    providedOverlayVariableDescriptor
+  );
 
   const histogramProps: HistogramProps = {
     dependentAxisLogScale: vizConfig.dependentAxisLogScale,
@@ -709,6 +745,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
         max: truncationConfigDependentAxisMax,
       },
     },
+    ...neutralPaletteProps,
   };
 
   const plotNode = (
@@ -976,13 +1013,13 @@ function HistogramViz(props: VisualizationProps<Options>) {
               name: 'overlayVariable',
               label: 'Overlay',
               role: 'stratification',
+              providedOptionalVariable: providedOverlayVariableDescriptor,
               readonlyValue:
                 options?.getOverlayVariable != null
-                  ? providedOverlayVariable
-                    ? overlayLabel
-                    : 'none'
+                  ? providedOverlayVariableDescriptor
+                    ? variableDisplayWithUnit(providedOverlayVariable)
+                    : 'None. ' + options?.getOverlayVariableHelp?.() ?? ''
                   : undefined,
-              // TO DO: verbiage for 'none'
             },
             ...(options?.hideFacetInputs
               ? []
@@ -995,11 +1032,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
                 ]),
           ]}
           entities={entities}
-          selectedVariables={{
-            xAxisVariable: vizConfig.xAxisVariable,
-            overlayVariable: vizConfig.overlayVariable,
-            facetVariable: vizConfig.facetVariable,
-          }}
+          selectedVariables={selectedVariables}
           onChange={handleInputVariableChange}
           constraints={dataElementConstraints}
           dataElementDependencyOrder={dataElementDependencyOrder}
@@ -1144,8 +1177,7 @@ function getRequestParams(
   filters: Filter[],
   valueType: 'number' | 'date',
   vizConfig: HistogramConfig,
-  variable?: Variable,
-  providedOverlayVariable?: VariableDescriptor
+  variable?: Variable
 ): HistogramRequestParams {
   const {
     binWidth = NumberVariable.is(variable) || DateVariable.is(variable)
@@ -1188,7 +1220,7 @@ function getRequestParams(
       outputEntityId: xAxisVariable!.entityId,
       xAxisVariable,
       barMode: 'stack',
-      overlayVariable: providedOverlayVariable ?? overlayVariable,
+      overlayVariable: overlayVariable,
       facetVariable: facetVariable ? [facetVariable] : [],
       valueSpec,
       ...binSpec,

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -713,7 +713,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
     plotContainerStyles,
     [
       data,
-      checkedLegendItems,
+      vizConfig.checkedLegendItems,
       vizConfig.dependentAxisLogScale,
       vizConfig.dependentAxisRange,
     ]

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -322,6 +322,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
   );
 
   useProvidedOptionalVariable<HistogramConfig>(
+    options?.getOverlayVariable,
     'overlayVariable',
     providedOverlayVariableDescriptor,
     vizConfig.overlayVariable,

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -817,7 +817,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
     plotContainerStyles,
     [
       data,
-      checkedLegendItems,
+      vizConfig.checkedLegendItems,
       // considering axis range control too
       vizConfig.independentAxisRange,
       vizConfig.dependentAxisRange,

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -93,7 +93,12 @@ import { isFaceted, isTimeDelta } from '@veupathdb/components/lib/types/guards';
 import FacetedLinePlot from '@veupathdb/components/lib/plots/facetedPlots/FacetedLinePlot';
 import { useCheckedLegendItemsStatus } from '../../../hooks/checkedLegendItemsStatus';
 import { BinSpec, BinWidthSlider, TimeUnit } from '../../../types/general';
-import { useVizConfig } from '../../../hooks/visualizations';
+import {
+  useFlattenedConstraints,
+  useNeutralPaletteProps,
+  useProvidedOptionalVariable,
+  useVizConfig,
+} from '../../../hooks/visualizations';
 import { useInputStyles } from '../inputStyles';
 import { ValuePicker } from './ValuePicker';
 import HelpIcon from '@veupathdb/wdk-client/lib/Components/Icon/HelpIcon';
@@ -113,6 +118,7 @@ import { useDefaultAxisRange } from '../../../hooks/computeDefaultAxisRange';
 import useSnackbar from '@veupathdb/coreui/dist/components/notifications/useSnackbar';
 import { LayoutOptions } from '../../layouts/types';
 import { OverlayOptions } from '../options/types';
+import { useDeepValue } from '../../../hooks/immutability';
 
 const plotContainerStyles = {
   width: 750,
@@ -234,17 +240,49 @@ function LineplotViz(props: VisualizationProps<Options>) {
     updateConfiguration
   );
 
-  const providedOverlayVariable = options?.getOverlayVariable?.(
-    computation.descriptor.configuration
+  const providedOverlayVariableDescriptor = useMemo(
+    () => options?.getOverlayVariable?.(computation.descriptor.configuration),
+    [options?.getOverlayVariable, computation.descriptor.configuration]
   );
 
-  // moved the location of this findEntityAndVariable
+  const selectedVariables = useDeepValue({
+    xAxisVariable: vizConfig.xAxisVariable,
+    yAxisVariable: vizConfig.yAxisVariable,
+    overlayVariable: vizConfig.overlayVariable,
+    facetVariable: vizConfig.facetVariable,
+  });
+
+  const flattenedConstraints = useFlattenedConstraints(
+    dataElementConstraints,
+    selectedVariables,
+    entities
+  );
+
+  useProvidedOptionalVariable<LineplotConfig>(
+    'overlayVariable',
+    providedOverlayVariableDescriptor,
+    vizConfig.overlayVariable,
+    entities,
+    flattenedConstraints,
+    dataElementDependencyOrder,
+    selectedVariables,
+    updateVizConfig,
+    /** snackbar message */
+    'The new overlay variable is not compatible with this visualization and has been disabled.'
+  );
+
+  const neutralPaletteProps = useNeutralPaletteProps(
+    vizConfig.overlayVariable,
+    providedOverlayVariableDescriptor
+  );
+
   const findEntityAndVariable = useFindEntityAndVariable();
 
   const {
     xAxisVariable,
     yAxisVariable,
     overlayVariable,
+    providedOverlayVariable,
     overlayEntity,
     facetVariable,
     facetEntity,
@@ -254,15 +292,16 @@ function LineplotViz(props: VisualizationProps<Options>) {
     const { variable: yAxisVariable } =
       findEntityAndVariable(vizConfig.yAxisVariable) ?? {};
     const { variable: overlayVariable, entity: overlayEntity } =
-      findEntityAndVariable(
-        providedOverlayVariable ?? vizConfig.overlayVariable
-      ) ?? {};
+      findEntityAndVariable(vizConfig.overlayVariable) ?? {};
+    const { variable: providedOverlayVariable } =
+      findEntityAndVariable(providedOverlayVariableDescriptor) ?? {};
     const { variable: facetVariable, entity: facetEntity } =
       findEntityAndVariable(vizConfig.facetVariable) ?? {};
     return {
       xAxisVariable,
       yAxisVariable,
       overlayVariable,
+      providedOverlayVariable,
       overlayEntity,
       facetVariable,
       facetEntity,
@@ -273,7 +312,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
     vizConfig.yAxisVariable,
     vizConfig.overlayVariable,
     vizConfig.facetVariable,
-    providedOverlayVariable,
+    providedOverlayVariableDescriptor,
   ]);
 
   const categoricalMode = isSuitableCategoricalVariable(yAxisVariable);
@@ -515,8 +554,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
         vizConfig,
         xAxisVariable,
         yAxisVariable,
-        outputEntity,
-        providedOverlayVariable
+        outputEntity
       );
 
       const response = await dataClient.getLineplot(
@@ -568,7 +606,8 @@ function LineplotViz(props: VisualizationProps<Options>) {
         overlayVariable,
         showMissingFacet,
         facetVocabulary,
-        facetVariable
+        facetVariable,
+        neutralPaletteProps.colorPalette
       );
     }, [
       studyId,
@@ -659,6 +698,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
   // custom legend list
   const legendItems: LegendItemsProps[] = useMemo(() => {
     const allData = data.value?.dataSetProcess;
+    const palette = neutralPaletteProps.colorPalette ?? ColorPaletteDefault;
 
     const legendData = !isFaceted(allData)
       ? allData?.series
@@ -675,9 +715,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
             marker: 'line',
             // set marker colors appropriately
             markerColor:
-              dataItem?.name === 'No data'
-                ? '#E8E8E8'
-                : ColorPaletteDefault[index], // set first color for no overlay variable selected
+              dataItem?.name === 'No data' ? '#E8E8E8' : palette[index], // set first color for no overlay variable selected
             // simplifying the check with the presence of data: be carefule of y:[null] case in Scatter plot
             hasData: !isFaceted(allData)
               ? dataItem.y != null &&
@@ -700,7 +738,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
           };
         })
       : [];
-  }, [data]);
+  }, [data, neutralPaletteProps]);
 
   // set checkedLegendItems: not working well with plot options
   const checkedLegendItems = useCheckedLegendItemsStatus(
@@ -804,6 +842,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
       ? plotSpacingOptions
       : undefined,
     interactive: !isFaceted(data.value?.dataSetProcess) ? true : false,
+    showSpinner: filteredCounts.pending || data.pending,
 
     independentValueType: DateVariable.is(xAxisVariable)
       ? 'date'
@@ -1441,13 +1480,13 @@ function LineplotViz(props: VisualizationProps<Options>) {
               name: 'overlayVariable',
               label: 'Overlay',
               role: 'stratification',
+              providedOptionalVariable: providedOverlayVariableDescriptor,
               readonlyValue:
                 options?.getOverlayVariable != null
-                  ? providedOverlayVariable
-                    ? legendTitle
-                    : 'none'
+                  ? providedOverlayVariableDescriptor
+                    ? variableDisplayWithUnit(providedOverlayVariable)
+                    : 'None. ' + options?.getOverlayVariableHelp?.() ?? ''
                   : undefined,
-              // TO DO: verbiage for 'none'
             },
             ...(options?.hideFacetInputs
               ? []
@@ -1474,12 +1513,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
             },
           ]}
           entities={entities}
-          selectedVariables={{
-            xAxisVariable: vizConfig.xAxisVariable,
-            yAxisVariable: vizConfig.yAxisVariable,
-            overlayVariable: vizConfig.overlayVariable,
-            facetVariable: vizConfig.facetVariable,
-          }}
+          selectedVariables={selectedVariables}
           onChange={handleInputVariableChange}
           constraints={dataElementConstraints}
           dataElementDependencyOrder={dataElementDependencyOrder}
@@ -1533,7 +1567,8 @@ export function lineplotResponseToData(
   overlayVariable?: Variable,
   showMissingFacet: boolean = false,
   facetVocabulary: string[] = [],
-  facetVariable?: Variable
+  facetVariable?: Variable,
+  colorPaletteOverride?: string[]
 ): LinePlotDataWithCoverage {
   const modeValue: LinePlotDataSeries['mode'] = 'lines+markers';
 
@@ -1577,7 +1612,8 @@ export function lineplotResponseToData(
       hasMissingData,
       response.lineplot.config.binSpec,
       response.lineplot.config.binSlider,
-      overlayVariable
+      overlayVariable,
+      colorPaletteOverride
     );
 
     return {
@@ -1725,8 +1761,7 @@ function getRequestParams(
   vizConfig: Omit<LineplotConfig, 'dependentAxisRange' | 'checkedLegendItems'>,
   xAxisVariableMetadata: Variable,
   yAxisVariableMetadata: Variable,
-  outputEntity: StudyEntity,
-  providedOverlayVariable: VariableDescriptor | undefined
+  outputEntity: StudyEntity
 ): LineplotRequestParams {
   const {
     xAxisVariable,
@@ -1787,7 +1822,7 @@ function getRequestParams(
       xAxisVariable: xAxisVariable!, // these will never be undefined because
       yAxisVariable: yAxisVariable!, // data requests are only made when they have been chosen by user
       ...binSpec,
-      overlayVariable: providedOverlayVariable ?? overlayVariable,
+      overlayVariable: overlayVariable,
       facetVariable: facetVariable ? [facetVariable] : [],
       showMissingness: showMissingness ? 'TRUE' : 'FALSE',
       // no error bars for date variables (error bar toggle switch is also disabled)
@@ -1820,7 +1855,8 @@ function processInputData(
   hasMissingData: boolean,
   binSpec?: BinSpec,
   binWidthSlider?: BinWidthSlider,
-  overlayVariable?: Variable
+  overlayVariable?: Variable,
+  colorPaletteOverride?: string[]
 ) {
   // set fillAreaValue for densityplot
   const fillAreaValue: LinePlotDataSeries['fill'] =
@@ -1839,10 +1875,11 @@ function processInputData(
 
   // function to return color or gray where needed if showMissingness == true
   const markerColor = (index: number) => {
+    const palette = colorPaletteOverride ?? ColorPaletteDefault;
     if (showMissingness && index === responseLineplotData.length - 1) {
       return gray;
     } else {
-      return ColorPaletteDefault[index] ?? 'black'; // TO DO: decide on overflow behaviour
+      return palette[index] ?? 'black'; // TO DO: decide on overflow behaviour
     }
   };
 

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -259,6 +259,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
   );
 
   useProvidedOptionalVariable<LineplotConfig>(
+    options?.getOverlayVariable,
     'overlayVariable',
     providedOverlayVariableDescriptor,
     vizConfig.overlayVariable,

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -740,11 +740,14 @@ function LineplotViz(props: VisualizationProps<Options>) {
       : [];
   }, [data, neutralPaletteProps]);
 
-  // set checkedLegendItems: not working well with plot options
+  // set checkedLegendItems to either the config-stored items, or all items if nothing stored (or if no overlay locally configured)
   const checkedLegendItems = useCheckedLegendItemsStatus(
     legendItems,
-    options?.getCheckedLegendItems?.(computation.descriptor.configuration) ??
-      vizConfig.checkedLegendItems
+    vizConfig.overlayVariable
+      ? options?.getCheckedLegendItems?.(
+          computation.descriptor.configuration
+        ) ?? vizConfig.checkedLegendItems
+      : undefined
   );
 
   const areRequiredInputsSelected = useMemo(() => {

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -525,11 +525,15 @@ function MosaicViz(props: Props<Options>) {
               label: 'Y-axis',
               role: 'axis',
             },
-            {
-              name: 'facetVariable',
-              label: 'Facet',
-              role: 'stratification',
-            },
+            ...(options?.hideFacetInputs
+              ? []
+              : [
+                  {
+                    name: 'facetVariable',
+                    label: 'Facet',
+                    role: 'stratification',
+                  } as const,
+                ]),
           ]}
           entities={entities}
           selectedVariables={{

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -108,7 +108,12 @@ import Button from '@veupathdb/components/lib/components/widgets/Button';
 import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
 import { useDefaultAxisRange } from '../../../hooks/computeDefaultAxisRange';
 import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
-import { useVizConfig } from '../../../hooks/visualizations';
+import {
+  useFlattenedConstraints,
+  useNeutralPaletteProps,
+  useProvidedOptionalVariable,
+  useVizConfig,
+} from '../../../hooks/visualizations';
 // typing computedVariableMetadata for computation apps such as alphadiv and abundance
 import { ComputedVariableMetadata } from '../../../api/DataClient/types';
 // use Banner from CoreUI for showing message for no smoothing
@@ -119,6 +124,7 @@ import { useFindOutputEntity } from '../../../hooks/findOutputEntity';
 import useSnackbar from '@veupathdb/coreui/dist/components/notifications/useSnackbar';
 import { LayoutOptions, TitleOptions } from '../../layouts/types';
 import { OverlayOptions } from '../options/types';
+import { useDeepValue } from '../../../hooks/immutability';
 
 const MAXALLOWEDDATAPOINTS = 100000;
 const SMOOTHEDMEANTEXT = 'Smoothed mean';
@@ -239,16 +245,49 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     computation.descriptor.configuration
   );
 
-  const providedOverlayVariable = options?.getOverlayVariable?.(
-    computation.descriptor.configuration
+  const providedOverlayVariableDescriptor = useMemo(
+    () => options?.getOverlayVariable?.(computation.descriptor.configuration),
+    [options?.getOverlayVariable, computation.descriptor.configuration]
   );
-  // moved the location of this findEntityAndVariable
+
+  const selectedVariables = useDeepValue({
+    xAxisVariable: vizConfig.xAxisVariable,
+    yAxisVariable: vizConfig.yAxisVariable,
+    overlayVariable: vizConfig.overlayVariable,
+    facetVariable: vizConfig.facetVariable,
+  });
+
+  const flattenedConstraints = useFlattenedConstraints(
+    dataElementConstraints,
+    selectedVariables,
+    entities
+  );
+
+  useProvidedOptionalVariable<ScatterplotConfig>(
+    'overlayVariable',
+    providedOverlayVariableDescriptor,
+    vizConfig.overlayVariable,
+    entities,
+    flattenedConstraints,
+    dataElementDependencyOrder,
+    selectedVariables,
+    updateVizConfig,
+    /** snackbar message */
+    'The new overlay variable is not compatible with this visualization and has been disabled.'
+  );
+
+  const neutralPaletteProps = useNeutralPaletteProps(
+    vizConfig.overlayVariable,
+    providedOverlayVariableDescriptor
+  );
+
   const findEntityAndVariable = useFindEntityAndVariable();
 
   const {
     xAxisVariable,
     yAxisVariable,
     overlayVariable,
+    providedOverlayVariable,
     overlayEntity,
     facetVariable,
     facetEntity,
@@ -258,15 +297,16 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     const { variable: yAxisVariable } =
       findEntityAndVariable(vizConfig.yAxisVariable) ?? {};
     const { variable: overlayVariable, entity: overlayEntity } =
-      findEntityAndVariable(
-        providedOverlayVariable ?? vizConfig.overlayVariable
-      ) ?? {};
+      findEntityAndVariable(vizConfig.overlayVariable) ?? {};
+    const { variable: providedOverlayVariable } =
+      findEntityAndVariable(providedOverlayVariableDescriptor) ?? {};
     const { variable: facetVariable, entity: facetEntity } =
       findEntityAndVariable(vizConfig.facetVariable) ?? {};
     return {
       xAxisVariable,
       yAxisVariable,
       overlayVariable,
+      providedOverlayVariable,
       overlayEntity,
       facetVariable,
       facetEntity,
@@ -277,7 +317,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     vizConfig.yAxisVariable,
     vizConfig.overlayVariable,
     vizConfig.facetVariable,
-    providedOverlayVariable,
+    providedOverlayVariableDescriptor,
   ]);
 
   // set the state of truncation warning message
@@ -450,7 +490,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
           valueSpec: valueSpecValue,
           xAxisVariable: vizConfig.xAxisVariable,
           yAxisVariable: vizConfig.yAxisVariable,
-          overlayVariable: providedOverlayVariable ?? vizConfig.overlayVariable,
+          overlayVariable: vizConfig.overlayVariable,
           facetVariable: vizConfig.facetVariable
             ? [vizConfig.facetVariable]
             : [],
@@ -510,7 +550,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
         facetVariable,
         // pass computation
         computation,
-        entities
+        entities,
+        neutralPaletteProps.colorPalette
       );
     }, [
       vizConfig.xAxisVariable,
@@ -582,6 +623,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
 
   // custom legend list
   const legendItems: LegendItemsProps[] = useMemo(() => {
+    const palette = neutralPaletteProps.colorPalette ?? ColorPaletteDefault;
+
     const allData = data.value?.dataSetProcess;
 
     /**
@@ -623,7 +666,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     const legendLabelColor = legendLabel?.map((label, index) => {
       return {
         label: label,
-        color: ColorPaletteDefault[index],
+        color: palette[index],
       };
     });
 
@@ -783,7 +826,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
                         .filter((n: string) => n !== '')
                         .toString()
                     : '#ffffff' // just set not to be empty
-                  : ColorPaletteDefault[0], // set first color for no overlay variable selected
+                  : palette[0], // set first color for no overlay variable selected
               // simplifying the check with the presence of data: be carefule of y:[null] case in Scatter plot
               hasData: !isFaceted(allData)
                 ? dataItem.y != null &&
@@ -812,6 +855,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     vizConfig.overlayVariable,
     vizConfig.showMissingness,
     vizConfig.valueSpecConfig,
+    neutralPaletteProps,
   ]);
 
   const checkedLegendItems = useCheckedLegendItemsStatus(
@@ -1004,6 +1048,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     spacingOptions: !isFaceted(data.value?.dataSetProcess)
       ? plotSpacingOptions
       : undefined,
+    // ...neutralPaletteProps, // no-op. we have to handle colours here.
   };
 
   const plotNode = (
@@ -1468,13 +1513,13 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
                     name: 'overlayVariable',
                     label: 'Overlay',
                     role: 'stratification',
+                    providedOptionalVariable: providedOverlayVariableDescriptor,
                     readonlyValue:
                       options?.getOverlayVariable != null
-                        ? providedOverlayVariable
-                          ? legendTitle
-                          : 'none'
+                        ? providedOverlayVariableDescriptor
+                          ? variableDisplayWithUnit(providedOverlayVariable)
+                          : 'None. ' + options?.getOverlayVariableHelp?.() ?? ''
                         : undefined,
-                    // TO DO: verbiage for 'none'
                   } as const,
                 ]),
             ...(options?.hideFacetInputs
@@ -1488,12 +1533,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
                 ]),
           ]}
           entities={entities}
-          selectedVariables={{
-            xAxisVariable: vizConfig.xAxisVariable,
-            yAxisVariable: vizConfig.yAxisVariable,
-            overlayVariable: vizConfig.overlayVariable,
-            facetVariable: vizConfig.facetVariable,
-          }}
+          selectedVariables={selectedVariables}
           onChange={handleInputVariableChange}
           constraints={dataElementConstraints}
           dataElementDependencyOrder={dataElementDependencyOrder}
@@ -1583,7 +1623,8 @@ export function scatterplotResponseToData(
   facetVocabulary: string[] = [],
   facetVariable?: Variable,
   computation?: Computation,
-  entities?: StudyEntity[]
+  entities?: StudyEntity[],
+  colorPaletteOverride?: string[]
 ): ScatterPlotDataWithCoverage {
   const modeValue = 'markers';
 
@@ -1631,7 +1672,8 @@ export function scatterplotResponseToData(
       // pass computation here to add conditions for apps
       computation,
       response.scatterplot.config.computedVariableMetadata,
-      entities
+      entities,
+      colorPaletteOverride
     );
 
     return {
@@ -1701,7 +1743,8 @@ function processInputData<T extends number | string>(
   facetVariable?: Variable,
   computation?: Computation,
   computedVariableMetadata?: ComputedVariableMetadata,
-  entities?: StudyEntity[]
+  entities?: StudyEntity[],
+  colorPaletteOverride?: string[]
 ) {
   // set variables for x- and yaxis ranges: no default values are set
   let xMin: number | string | undefined;
@@ -1731,19 +1774,21 @@ function processInputData<T extends number | string>(
 
   // function to return color or gray where needed if showMissingness == true
   const markerColor = (index: number) => {
+    const palette = colorPaletteOverride ?? ColorPaletteDefault;
     if (showMissingness && index === responseScatterplotData.length - 1) {
       return gray;
     } else {
-      return ColorPaletteDefault[index] ?? 'black'; // TO DO: decide on overflow behaviour
+      return palette[index] ?? 'black'; // TO DO: decide on overflow behaviour
     }
   };
 
   // using dark color: function to return color or gray where needed if showMissingness == true
   const markerColorDark = (index: number) => {
+    const palette = colorPaletteOverride ?? ColorPaletteDark;
     if (showMissingness && index === responseScatterplotData.length - 1) {
       return gray;
     } else {
-      return ColorPaletteDark[index] ?? 'black'; // TO DO: decide on overflow behaviour
+      return palette[index] ?? 'black'; // TO DO: decide on overflow behaviour
     }
   };
 

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -858,10 +858,14 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     neutralPaletteProps,
   ]);
 
+  // set checkedLegendItems to either the config-stored items, or all items if nothing stored (or if no overlay locally configured)
   const checkedLegendItems = useCheckedLegendItemsStatus(
     legendItems,
-    options?.getCheckedLegendItems?.(computation.descriptor.configuration) ??
-      vizConfig.checkedLegendItems
+    vizConfig.overlayVariable
+      ? options?.getCheckedLegendItems?.(
+          computation.descriptor.configuration
+        ) ?? vizConfig.checkedLegendItems
+      : undefined
   );
 
   const legendTitle = useMemo(() => {

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -264,6 +264,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
   );
 
   useProvidedOptionalVariable<ScatterplotConfig>(
+    options?.getOverlayVariable,
     'overlayVariable',
     providedOverlayVariableDescriptor,
     vizConfig.overlayVariable,

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -934,7 +934,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     plotContainerStyles,
     [
       data,
-      checkedLegendItems,
+      vizConfig.checkedLegendItems,
       vizConfig.independentAxisRange,
       vizConfig.dependentAxisRange,
       vizConfig.independentAxisLogScale,

--- a/src/lib/core/components/visualizations/options/types.ts
+++ b/src/lib/core/components/visualizations/options/types.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { VariableDescriptor } from '../../../types/variable';
 
 export interface XAxisOptions {
@@ -8,4 +9,5 @@ export interface OverlayOptions {
   getOverlayVariable?: (
     computeConfig: unknown
   ) => VariableDescriptor | undefined;
+  getOverlayVariableHelp?: () => string;
 }

--- a/src/lib/core/hooks/visualizations.ts
+++ b/src/lib/core/hooks/visualizations.ts
@@ -69,6 +69,9 @@ export function useVizConfig<ConfigType>(
  * Doesn't return anything!
  */
 export function useProvidedOptionalVariable<ConfigType>(
+  optionGetter:
+    | ((config: unknown) => VariableDescriptor | undefined)
+    | undefined,
   inputName: keyof ConfigType,
   providedVariableDescriptor: VariableDescriptor | undefined,
   /* storedVariableDescriptor is basically vizConfig.overlayVariable */
@@ -88,6 +91,7 @@ export function useProvidedOptionalVariable<ConfigType>(
   // if the new variable is compatible with variable constraints
   useEffect(() => {
     if (
+      optionGetter == null ||
       storedVariableDescriptor == null ||
       isEqual(providedVariableDescriptor, storedVariableDescriptor)
     )

--- a/src/lib/core/hooks/visualizations.ts
+++ b/src/lib/core/hooks/visualizations.ts
@@ -12,6 +12,7 @@ import {
   VariablesByInputName,
 } from '../utils/data-element-constraints';
 import { isEqual } from 'lodash';
+import { ColorPaletteAddon } from '@veupathdb/components/lib/types/plots';
 
 /**
  * Decodes config from back end or uses default config if there's an error (including no config at all)
@@ -134,5 +135,25 @@ export function useFlattenedConstraints(
       dataElementConstraints &&
       flattenConstraints(selectedVariables, entities, dataElementConstraints),
     [dataElementConstraints, selectedVariables, entities]
+  );
+}
+
+/**
+ * Simple hook to create the appropriate PlotlyPlotProps to make the plot markers grey
+ * when there's an externally provided overlay variable that is currently not enabled
+ * as an overlay.
+ */
+
+export function useNeutralPaletteProps(
+  overlayVariableDescriptor: VariableDescriptor | undefined,
+  providedOverlayVariableDescriptor: VariableDescriptor | undefined
+): ColorPaletteAddon {
+  return useMemo(
+    () =>
+      overlayVariableDescriptor == null &&
+      providedOverlayVariableDescriptor != null
+        ? { colorPalette: ['#333'] }
+        : {},
+    [overlayVariableDescriptor, providedOverlayVariableDescriptor]
   );
 }

--- a/src/lib/core/hooks/visualizations.ts
+++ b/src/lib/core/hooks/visualizations.ts
@@ -152,7 +152,7 @@ export function useNeutralPaletteProps(
     () =>
       overlayVariableDescriptor == null &&
       providedOverlayVariableDescriptor != null
-        ? { colorPalette: ['#333'] }
+        ? { colorPalette: Array(8).fill('#333') }
         : {},
     [overlayVariableDescriptor, providedOverlayVariableDescriptor]
   );

--- a/src/lib/core/hooks/visualizations.ts
+++ b/src/lib/core/hooks/visualizations.ts
@@ -1,7 +1,17 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useEffect, ReactNode } from 'react';
 import { getOrElse } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/function';
 import * as t from 'io-ts';
+import { VariableDescriptor } from '../types/variable';
+import useSnackbar from '@veupathdb/coreui/dist/components/notifications/useSnackbar';
+import { StudyEntity } from '../types/study';
+import {
+  DataElementConstraintRecord,
+  disabledVariablesForInput,
+  flattenConstraints,
+  VariablesByInputName,
+} from '../utils/data-element-constraints';
+import { isEqual } from 'lodash';
 
 /**
  * Decodes config from back end or uses default config if there's an error (including no config at all)
@@ -38,4 +48,91 @@ export function useVizConfig<ConfigType>(
   );
 
   return [vizConfig, updateVizConfig];
+}
+
+/**
+ * To be used in conjunction with InputVariables.providedOptionalVariable
+ *
+ * Sets up a "listener" to monitor changes in providedVariableDescriptor
+ * and if the existing vizConfig[inputName] variable is not null
+ * (when the user has "None" selected in the radio buttons),
+ * and if the new variable is compatible with the constraints, then
+ * update the vizConfig[inputName] to the provided variable.
+ *
+ * If vizConfig[inputName] is not null and the variable does not meet the
+ * constraints, then set vizConfig[inputName] to undefined (which has
+ * the effect of moving the radio button to "None".
+ *
+ * Also enqueues a snackbar. Make sure you are in a child of a SnackbarProvider.
+ *
+ * Doesn't return anything!
+ */
+export function useProvidedOptionalVariable<ConfigType>(
+  inputName: keyof ConfigType,
+  providedVariableDescriptor: VariableDescriptor | undefined,
+  /* storedVariableDescriptor is basically vizConfig.overlayVariable */
+  storedVariableDescriptor: VariableDescriptor | undefined,
+  entities: StudyEntity[],
+  flattenedConstraints: DataElementConstraintRecord | undefined,
+  dataElementDependencyOrder: string[] | undefined,
+  selectedVariables: VariablesByInputName,
+  updateVizConfig: (newConfig: VariablesByInputName) => void,
+  /* optional message to display in snackbar: ReactNode | string */
+  snackbarMessage?: ReactNode | string // can't import SnackbarMessage type from notistack
+): void {
+  const { enqueueSnackbar } = useSnackbar();
+
+  // watch the providedOverlayVariable and update vizConfig.overlayVariable
+  // only if there is currently an overlay variable selected by the user and
+  // if the new variable is compatible with variable constraints
+  useEffect(() => {
+    if (
+      storedVariableDescriptor == null ||
+      isEqual(providedVariableDescriptor, storedVariableDescriptor)
+    )
+      return;
+
+    if (
+      disabledVariablesForInput(
+        inputName as string,
+        entities,
+        flattenedConstraints,
+        dataElementDependencyOrder,
+        selectedVariables
+      ).find((variable) => isEqual(variable, providedVariableDescriptor))
+    ) {
+      if (snackbarMessage) enqueueSnackbar(snackbarMessage);
+      updateVizConfig({ [inputName]: undefined });
+    } else {
+      updateVizConfig({
+        [inputName]: providedVariableDescriptor,
+      });
+    }
+  }, [
+    providedVariableDescriptor,
+    storedVariableDescriptor,
+    entities,
+    flattenedConstraints,
+    dataElementDependencyOrder,
+    selectedVariables,
+    enqueueSnackbar,
+    updateVizConfig,
+  ]);
+}
+
+/**
+ * simple memo hook for flattenedConstraints, used in several places
+ */
+
+export function useFlattenedConstraints(
+  dataElementConstraints: DataElementConstraintRecord[] | undefined,
+  selectedVariables: VariablesByInputName,
+  entities: StudyEntity[]
+) {
+  return useMemo(
+    () =>
+      dataElementConstraints &&
+      flattenConstraints(selectedVariables, entities, dataElementConstraints),
+    [dataElementConstraints, selectedVariables, entities]
+  );
 }

--- a/src/lib/core/hooks/visualizations.ts
+++ b/src/lib/core/hooks/visualizations.ts
@@ -106,7 +106,8 @@ export function useProvidedOptionalVariable<ConfigType>(
         selectedVariables
       ).find((variable) => isEqual(variable, providedVariableDescriptor))
     ) {
-      if (snackbarMessage) enqueueSnackbar(snackbarMessage);
+      if (snackbarMessage)
+        enqueueSnackbar(snackbarMessage, { preventDuplicate: true });
       updateVizConfig({ [inputName]: undefined });
     } else {
       updateVizConfig({

--- a/src/lib/core/utils/data-element-constraints.ts
+++ b/src/lib/core/utils/data-element-constraints.ts
@@ -14,8 +14,8 @@ import { findEntityAndVariable } from './study-metadata';
  * current selectedVariables
  *
  */
-export function disabledVariablesForInput(
-  inputName: string,
+export function disabledVariablesForInput<ConfigType>(
+  inputName: keyof ConfigType,
   entities: StudyEntity[],
   flattenedConstraints: DataElementConstraintRecord | undefined,
   dataElementDependencyOrder: string[] | undefined,
@@ -23,12 +23,12 @@ export function disabledVariablesForInput(
 ): VariableDescriptor[] {
   const disabledVariables = excludedVariables(
     entities[0],
-    flattenedConstraints && flattenedConstraints[inputName]
+    flattenedConstraints && flattenedConstraints[inputName as string] // not ideal...
   );
   if (dataElementDependencyOrder == null) {
     return disabledVariables;
   }
-  const index = dataElementDependencyOrder.indexOf(inputName);
+  const index = dataElementDependencyOrder.indexOf(inputName as string); // ditto
   // no change if dependencyOrder is not declared
   if (index === -1) {
     return disabledVariables;


### PR DESCRIPTION
Fixes https://github.com/VEuPathDB/web-eda/issues/1368

No longer requires web-components PR.

- [x] add snackbar when the overlay variable is automatically disabled by the new hook
- [x] unstratified plots should NOT use maroon. Use black (very dark grey?) until Ann is back!
- [x] barplot
- [x] histogram
- [x] lineplot
- [x] scatterplot
- [x] boxplot


