### PR TITLE
Add navbar to EDA dev workspace and improve link names

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -11,7 +11,13 @@ const buttonLinkStyle = {
   background: 'transparent',
   border: 'none',
   fontWeight: 500,
-  padding: '.5em 0',
+};
+
+const navBarLinkStyle = {
+  color: 'whitesmoke',
+  fontWeight: 500,
+  fontSize: '1rem',
+  margin: '0 1em',
 };
 
 export default function Header() {
@@ -62,110 +68,129 @@ export default function Header() {
       <code>||| VEUPATHDB DEVELOPMENT SITE |||</code>
       <br />
       <code>\\\ ========================== ///</code>
-      <div
-        style={{ fontSize: '1rem', padding: '1em 1em 0', position: 'relative' }}
-      >
-        {user == null ? (
-          <>Loading user...</>
-        ) : user.isGuest ? (
-          <>
+      <div style={{ display: 'flex', marginTop: '0.5em' }}>
+        <nav style={{ display: 'flex', alignItems: 'center' }}>
+          <Link to="/eda" style={navBarLinkStyle}>
+            My analyses
+          </Link>
+          <Link to="/eda/public" style={navBarLinkStyle}>
+            Public analyses
+          </Link>
+          <Link to="/eda/studies" style={navBarLinkStyle}>
+            All studies
+          </Link>
+        </nav>
+        <div
+          style={{
+            fontSize: '1rem',
+            position: 'relative',
+            flexGrow: 1,
+            textAlign: 'end',
+            paddingRight: '1em',
+          }}
+        >
+          {user == null ? (
+            <>Loading user...</>
+          ) : user.isGuest ? (
+            <>
+              <button
+                type="button"
+                style={buttonLinkStyle}
+                onClick={() => setLoginFormVisible(true)}
+              >
+                Log In
+              </button>
+            </>
+          ) : (
             <button
               type="button"
               style={buttonLinkStyle}
-              onClick={() => setLoginFormVisible(true)}
+              onClick={() => logout()}
             >
-              Log In
+              Log Out ({user.email})
             </button>
-          </>
-        ) : (
-          <button
-            type="button"
-            style={buttonLinkStyle}
-            onClick={() => logout()}
-          >
-            Log Out ({user.email})
-          </button>
-        )}
-        {loginFormVisible && (
-          <div
-            style={{
-              position: 'absolute',
-              background: 'black',
-              zIndex: 100,
-              padding: '1em',
-              left: 0,
-            }}
-          >
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                login();
+          )}
+          {loginFormVisible && (
+            <div
+              style={{
+                position: 'absolute',
+                background: 'black',
+                zIndex: 100,
+                padding: '1em',
+                right: 0,
               }}
             >
-              <div>
-                <label>
-                  Username:{' '}
-                  <input
-                    autoFocus
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    style={{ color: 'black', width: '100%' }}
-                    type="text"
-                  />
-                </label>
-              </div>
-              <div>
-                <label>
-                  Password:{' '}
-                  <input
-                    value={pwd}
-                    onChange={(e) => setPwd(e.target.value)}
-                    style={{ color: 'black', width: '100%' }}
-                    type="password"
-                  />
-                </label>
-              </div>
-              <div
-                style={{
-                  paddingTop: '1em',
-                  fontSize: '.85em',
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'end',
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  login();
                 }}
               >
                 <div>
-                  <button
-                    style={{ fontSize: '1em', color: 'black' }}
-                    type="submit"
-                  >
-                    Submit
-                  </button>{' '}
-                  &nbsp;
-                  <button
-                    style={{ fontSize: '1em', color: 'black' }}
-                    type="button"
+                  <label>
+                    Username:{' '}
+                    <input
+                      autoFocus
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      style={{ color: 'black', width: '100%' }}
+                      type="text"
+                    />
+                  </label>
+                </div>
+                <div>
+                  <label>
+                    Password:{' '}
+                    <input
+                      value={pwd}
+                      onChange={(e) => setPwd(e.target.value)}
+                      style={{ color: 'black', width: '100%' }}
+                      type="password"
+                    />
+                  </label>
+                </div>
+                <div
+                  style={{
+                    paddingTop: '1em',
+                    fontSize: '.85em',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'end',
+                  }}
+                >
+                  <div>
+                    <button
+                      style={{ fontSize: '1em', color: 'black' }}
+                      type="submit"
+                    >
+                      Submit
+                    </button>{' '}
+                    &nbsp;
+                    <button
+                      style={{ fontSize: '1em', color: 'black' }}
+                      type="button"
+                      onClick={() => setLoginFormVisible(false)}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                  <Link
+                    to="/user/registration"
+                    style={{ color: 'whitesmoke' }}
                     onClick={() => setLoginFormVisible(false)}
                   >
-                    Cancel
-                  </button>
+                    Register
+                  </Link>
                 </div>
-                <Link
-                  to="/user/registration"
-                  style={{ color: 'whitesmoke' }}
-                  onClick={() => setLoginFormVisible(false)}
+                <div
+                  style={{ color: 'red', fontSize: '.8em', paddingTop: '.5em' }}
                 >
-                  Register
-                </Link>
-              </div>
-              <div
-                style={{ color: 'red', fontSize: '.8em', paddingTop: '.5em' }}
-              >
-                {errorMsg}
-              </div>
-            </form>
-          </div>
-        )}
+                  {errorMsg}
+                </div>
+              </form>
+            </div>
+          )}
+        </div>
       </div>
     </h1>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -143,7 +143,7 @@ initialize({
           <H3>EDA Links</H3>
           <ul>
             <li>
-              <Link to="/eda">EDA Workspace</Link>
+              <Link to="/eda">My analyses</Link>
             </li>
             <li>
               <Link to="/eda/public">Public analyses</Link>


### PR DESCRIPTION
This is a trivial enhancement to `web-eda`'s dev environment. I often find it inconvenient to switch between studies or analyses. Thus, I added a navbar to the dev server's heading. Also note that I changed the first link's name from `EDA Workspace` to `My analyses`.

![image](https://user-images.githubusercontent.com/69446567/190475326-3d3d9040-df81-4b55-92fb-f5d8957e22a4.png)
