### PR TITLE
Prevent access to unreleased studies if client is not configured for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ _The `yarn start` script makes use of environment variables when running in deve
 The following environment variables are used by the `yarn start` script:
 
 | Variable name                         | Description                                                             |
-| ------------------------------------- | ----------------------------------------------------------------------- | -------- |
+| ------------------------------------- | ----------------------------------------------------------------------- |
 | `VEUPATHDB_LOGIN_USER`                | VEuPathDB BRC prerelease user name                                      |
 | `VEUPATHDB_LOGIN_PASS`                | VEuPathDB BRC prerelease user password                                  |
 | `WDK_SERVICE_URL`                     | Full url to a running WDK REST Service                                  |
@@ -66,7 +66,7 @@ The following environment variables are used by the `yarn start` script:
 | `REACT_APP_DISABLE_DATA_RESTRICTIONS` | If present and `true`, disables data restrictions                       |
 | `REACT_APP_EXAMPLE_ANALYSES_AUTHOR`   | The ID of the WDK user who maintains "example strategies" (optional)    |
 | `REACT_APP_SINGLE_APP_MODE`           | Name of one app. If defined, runs the eda with one instance of that app |
-| `REACT_APP_SHOW_UNRELEASED_DATA`      | Indicates if unreleased data should be accessible (optional             | "false") |
+| `REACT_APP_SHOW_UNRELEASED_DATA`      | Indicates if unreleased data should be accessible (optional - "false")  |
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ _The `yarn start` script makes use of environment variables when running in deve
 The following environment variables are used by the `yarn start` script:
 
 | Variable name                         | Description                                                             |
-| ------------------------------------- | ----------------------------------------------------------------------- |
+| ------------------------------------- | ----------------------------------------------------------------------- | -------- |
 | `VEUPATHDB_LOGIN_USER`                | VEuPathDB BRC prerelease user name                                      |
 | `VEUPATHDB_LOGIN_PASS`                | VEuPathDB BRC prerelease user password                                  |
 | `WDK_SERVICE_URL`                     | Full url to a running WDK REST Service                                  |
@@ -66,6 +66,7 @@ The following environment variables are used by the `yarn start` script:
 | `REACT_APP_DISABLE_DATA_RESTRICTIONS` | If present and `true`, disables data restrictions                       |
 | `REACT_APP_EXAMPLE_ANALYSES_AUTHOR`   | The ID of the WDK user who maintains "example strategies" (optional)    |
 | `REACT_APP_SINGLE_APP_MODE`           | Name of one app. If defined, runs the eda with one instance of that app |
+| `REACT_APP_SHOW_UNRELEASED_DATA`      | Indicates if unreleased data should be accessible (optional             | "false") |
 
 ## Learn More
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.8.26",
+  "version": "3.8.27",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,7 +53,6 @@ import { useCoreUIFonts } from '@veupathdb/coreui/dist/hooks';
 import { colors, H3 } from '@veupathdb/coreui';
 
 import './index.css';
-import { StoreModule } from '@veupathdb/wdk-client/lib/Core/Store';
 
 // snackbar
 import makeSnackbarProvider from '@veupathdb/coreui/dist/components/notifications/SnackbarProvider';
@@ -66,6 +65,9 @@ const downloadServiceUrl = '/eda-user-service';
 // Set singleAppMode to the name of one app, if the eda should use one instance of one app only.
 // Otherwise, let singleAppMode remain undefined or set it to '' to allow multiple app instances.
 const singleAppMode = process.env.REACT_APP_SINGLE_APP_MODE;
+
+const showUnreleasedData =
+  process.env.REACT_APP_SHOW_UNRELEASED_DATA === 'true';
 
 const exampleAnalysesAuthor = process.env.REACT_APP_EXAMPLE_ANALYSES_AUTHOR
   ? Number(process.env.REACT_APP_EXAMPLE_ANALYSES_AUTHOR)
@@ -175,6 +177,7 @@ initialize({
             sharingUrlPrefix={window.location.href}
             showLoginForm={showLoginForm}
             singleAppMode={singleAppMode}
+            showUnreleasedData={showUnreleasedData}
           />
         );
       },

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -87,6 +87,7 @@ interface Props {
   /** API client that will be used in the Download Tab */
   downloadClient: DownloadClient;
   singleAppMode?: string;
+  showUnreleasedData: boolean;
 }
 
 /**
@@ -105,6 +106,7 @@ export function AnalysisPanel({
   showLoginForm,
   downloadClient,
   singleAppMode,
+  showUnreleasedData,
 }: Props) {
   const studyRecord = useStudyRecord();
   const analysisState = useAnalysis(analysisId, singleAppMode);
@@ -187,6 +189,7 @@ export function AnalysisPanel({
     );
   if (analysis == null || approvalStatus === 'loading') return <Loading />;
   if (
+    (studyRecord.attributes.is_public !== 'true' && !showUnreleasedData) ||
     approvalStatus === 'not-approved' ||
     isStubEntity(studyMetadata.rootEntity)
   )

--- a/src/lib/workspace/StandaloneStudyPage.tsx
+++ b/src/lib/workspace/StandaloneStudyPage.tsx
@@ -1,0 +1,36 @@
+import { ApprovalStatus } from '@veupathdb/study-data-access/lib/data-restriction/dataRestrictionHooks';
+import { usePermissions } from '@veupathdb/study-data-access/lib/data-restriction/permissionsHooks';
+import { RestrictedPage } from '@veupathdb/study-data-access/lib/data-restriction/RestrictedPage';
+import { RecordController } from '@veupathdb/wdk-client/lib/Controllers';
+import { useStudyRecord } from '../core';
+import { EDAWorkspaceHeading } from './EDAWorkspaceHeading';
+
+interface Props {
+  studyId: string;
+  showUnreleasedData: boolean;
+}
+
+/**
+ * Determine if a user is allow to access a study. If not, then
+ * @param props
+ */
+export function StandaloneStudyPage(props: Props) {
+  const { studyId, showUnreleasedData } = props;
+  const studyRecord = useStudyRecord();
+  const permissionsValue = usePermissions();
+  const approvalStatus: ApprovalStatus = permissionsValue.loading
+    ? 'loading'
+    : permissionsValue.permissions.perDataset[studyId] == null ||
+      (!showUnreleasedData && studyRecord.attributes.is_public !== 'true')
+    ? 'study-not-found'
+    : permissionsValue.permissions.perDataset[studyId]?.actionAuthorization
+        .studyMetadata
+    ? 'approved'
+    : 'not-approved';
+  return (
+    <RestrictedPage approvalStatus={approvalStatus}>
+      <EDAWorkspaceHeading />
+      <RecordController recordClass="dataset" primaryKey={studyId} />
+    </RestrictedPage>
+  );
+}

--- a/src/lib/workspace/WorkspaceRouter.tsx
+++ b/src/lib/workspace/WorkspaceRouter.tsx
@@ -24,8 +24,7 @@ import { PublicAnalysesRoute } from './PublicAnalysesRoute';
 import { StudyList } from './StudyList';
 import { WorkspaceContainer } from './WorkspaceContainer';
 import { AnalysisPanel } from './AnalysisPanel';
-import { RecordController } from '@veupathdb/wdk-client/lib/Controllers';
-import { EDAWorkspaceHeading } from './EDAWorkspaceHeading';
+import { StandaloneStudyPage } from './StandaloneStudyPage';
 
 const theme = createTheme(workspaceTheme);
 
@@ -35,6 +34,7 @@ type Props = {
   userServiceUrl: string;
   downloadServiceUrl: string;
   exampleAnalysesAuthor?: number;
+  showUnreleasedData?: boolean;
   /**
    * The base of the URL from which to being sharing links.
    * This is passed down through several component layers. */
@@ -62,6 +62,7 @@ export function WorkspaceRouter({
   sharingUrlPrefix,
   showLoginForm,
   singleAppMode,
+  showUnreleasedData = false,
 }: Props) {
   const { path, url } = useRouteMatch();
 
@@ -203,10 +204,9 @@ export function WorkspaceRouter({
                 userServiceUrl={userServiceUrl}
                 downloadServiceUrl={downloadServiceUrl}
               >
-                <EDAWorkspaceHeading />
-                <RecordController
-                  recordClass="dataset"
-                  primaryKey={props.match.params.studyId}
+                <StandaloneStudyPage
+                  studyId={props.match.params.studyId}
+                  showUnreleasedData={showUnreleasedData}
                 />
               </WorkspaceContainer>
             )}
@@ -228,6 +228,7 @@ export function WorkspaceRouter({
                   hideSavedAnalysisButtons
                   downloadClient={downloadClient}
                   singleAppMode={singleAppMode}
+                  showUnreleasedData={showUnreleasedData}
                 />
               </WorkspaceContainer>
             )}
@@ -293,6 +294,7 @@ export function WorkspaceRouter({
                   showLoginForm={showLoginForm}
                   downloadClient={downloadClient}
                   singleAppMode={singleAppMode}
+                  showUnreleasedData={showUnreleasedData}
                 />
               </WorkspaceContainer>
             )}


### PR DESCRIPTION
Addresses https://github.com/VEuPathDB/ClinEpiWebsite/issues/60

This PR add protection against accessing datasets that are unreleased, from websites that are not configured to include such datasets.