### PR TITLE
Handle case where a dataset record's is_public attribute value is "NA"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -197,7 +197,7 @@ export function AnalysisPanel({
     );
   if (analysis == null || approvalStatus === 'loading') return <Loading />;
   if (
-    (studyRecord.attributes.is_public !== 'true' && !showUnreleasedData) ||
+    (studyRecord.attributes.is_public === 'false' && !showUnreleasedData) ||
     approvalStatus === 'not-approved' ||
     isStubEntity(studyMetadata.rootEntity)
   )

--- a/src/lib/workspace/StandaloneStudyPage.tsx
+++ b/src/lib/workspace/StandaloneStudyPage.tsx
@@ -21,7 +21,7 @@ export function StandaloneStudyPage(props: Props) {
   const approvalStatus: ApprovalStatus = permissionsValue.loading
     ? 'loading'
     : permissionsValue.permissions.perDataset[studyId] == null ||
-      (!showUnreleasedData && studyRecord.attributes.is_public !== 'true')
+      (!showUnreleasedData && studyRecord.attributes.is_public === 'false')
     ? 'study-not-found'
     : permissionsValue.permissions.perDataset[studyId]?.actionAuthorization
         .studyMetadata


### PR DESCRIPTION
Fixes #1387.

Since the `is_public` attribute of a dataset can have the value "NA", it's better to check if the value is "false", rather than is not "true", when determining if the dataset is unreleased.

A value of "NA" does strictly mean the dataset has been released, but for the context in which the value is being checked, we can assume the user has access to the dataset, since only user datasets have this value, and a user will only see such datasets if they are owned by the user making the request.

When this PR is merged, we should also make a PR for branch `v3.8.20-patch` and cherry-pick the commit.