### PR TITLE
independent axis range control btw x and y, no origin for auto-zoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -261,16 +261,24 @@ function HistogramViz(props: VisualizationProps<Options>) {
   // prettier-ignore
   // allow 2nd parameter of resetCheckedLegendItems for checking legend status
   const onChangeHandlerFactory = useCallback(
-    < ValueType,>(key: keyof HistogramConfig, resetCheckedLegendItems?: boolean, resetAxisRanges?: boolean) => (newValue?: ValueType) => {
+    < ValueType,>(key: keyof HistogramConfig,
+      resetCheckedLegendItems?: boolean,
+      resetIndependentAxisRanges?: boolean,
+      resetDependentAxisRanges?: boolean,
+      ) => (newValue?: ValueType) => {
       const newPartialConfig = {
         [key]: newValue,
         ...(resetCheckedLegendItems ? { checkedLegendItems: undefined } : {}),
-      	...(resetAxisRanges ? { independentAxisRange: undefined, dependentAxisRange: undefined } : {}),
+        ...(resetIndependentAxisRanges ? { independentAxisRange: undefined } : {}),
+        ...(resetDependentAxisRanges ? { dependentAxisRange: undefined } : {}),
       };
       updateVizConfig(newPartialConfig);
-      if (resetAxisRanges)
+      if (resetIndependentAxisRanges) {
         setTruncatedIndependentAxisWarning('');
-	      setTruncatedDependentAxisWarning('');
+      }
+      if (resetDependentAxisRanges) {
+        setTruncatedDependentAxisWarning('');
+      }
     },
     [updateVizConfig]
   );
@@ -278,22 +286,26 @@ function HistogramViz(props: VisualizationProps<Options>) {
   const onDependentAxisLogScaleChange = onChangeHandlerFactory<boolean>(
     'dependentAxisLogScale',
     false,
+    false,
     true
   );
 
   const onValueSpecChange = onChangeHandlerFactory<ValueSpec>(
     'valueSpec',
     false,
+    true,
     true
   );
 
   const onIndependentAxisValueSpecChange = onChangeHandlerFactory<string>(
     'independentAxisValueSpec',
     false,
-    true
+    true,
+    false
   );
   const onDependentAxisValueSpecChange = onChangeHandlerFactory<string>(
     'dependentAxisValueSpec',
+    false,
     false,
     true
   );
@@ -301,6 +313,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
   // set checkedLegendItems: undefined for the change of showMissingness
   const onShowMissingnessChange = onChangeHandlerFactory<boolean>(
     'showMissingness',
+    true,
     true,
     true
   );

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -420,23 +420,28 @@ function LineplotViz(props: VisualizationProps<Options>) {
   const onChangeHandlerFactory = useCallback(
     < ValueType,>(key: keyof LineplotConfig,
 		  resetCheckedLegendItems?: boolean,
-		  resetAxisRanges?: boolean,
       resetIndependentAxisLogScale?: boolean,
       resetDependentAxisLogScale?: boolean,
       resetBinningControl?: boolean,
-      resetErrorBarControl?: boolean) => (newValue?: ValueType) => {
+      resetErrorBarControl?: boolean,
+      resetIndependentAxisRanges?: boolean,
+      resetDependentAxisRanges?: boolean,
+      ) => (newValue?: ValueType) => {
       const newPartialConfig = {
         [key]: newValue,
         ...(resetCheckedLegendItems ? { checkedLegendItems: undefined } : {}),
-      	...(resetAxisRanges ? { independentAxisRange: undefined, dependentAxisRange: undefined } : {}),
         ...(resetIndependentAxisLogScale ? { independentAxisLogScale: false } : {}),
         ...(resetDependentAxisLogScale ? { dependentAxisLogScale: false } : {}),
         ...(resetBinningControl ? { useBinning: false } : {}),
         ...(resetErrorBarControl ? { showErrorBars: false } : {}),
+        ...(resetIndependentAxisRanges ? { independentAxisRange: undefined } : {}),
+        ...(resetDependentAxisRanges ? { dependentAxisRange: undefined } : {}),
       };
       updateVizConfig(newPartialConfig);
-      if (resetAxisRanges) {
+      if (resetIndependentAxisRanges) {
         setTruncatedIndependentAxisWarning('');
+      }
+      if (resetDependentAxisRanges) {
         setTruncatedDependentAxisWarning('');
       }
     },
@@ -447,17 +452,31 @@ function LineplotViz(props: VisualizationProps<Options>) {
   const onValueSpecChange = onChangeHandlerFactory<string>(
     'valueSpecConfig',
     true,
-    // axis range control: resetAxisRange
+    false,
+    false,
+    false,
+    false,
+    true,
     true
   );
 
   const onIndependentAxisValueSpecChange = onChangeHandlerFactory<string>(
     'independentAxisValueSpec',
     false,
-    true
+    false,
+    false,
+    false,
+    false,
+    true,
+    false
   );
   const onDependentAxisValueSpecChange = onChangeHandlerFactory<string>(
     'dependentAxisValueSpec',
+    false,
+    false,
+    false,
+    false,
+    false,
     false,
     true
   );
@@ -465,17 +484,21 @@ function LineplotViz(props: VisualizationProps<Options>) {
   const onShowMissingnessChange = onChangeHandlerFactory<boolean>(
     'showMissingness',
     true,
-    // axis range control: resetAxisRange
+    false,
+    false,
+    false,
+    false,
+    true,
     true
   );
 
   const onShowErrorBarsChange = onChangeHandlerFactory<boolean>(
     'showErrorBars',
     true,
-    // need to consider axis range control: resetAxisRange? seems not
-    false,
     false,
     true, // reset dependentAxisLogScale
+    false,
+    false,
     false,
     false
   );
@@ -483,8 +506,9 @@ function LineplotViz(props: VisualizationProps<Options>) {
   const onUseBinningChange = onChangeHandlerFactory<boolean>(
     'useBinning',
     false,
-    false,
     true, // reset independentAxisLogScale
+    false,
+    false,
     false,
     false,
     false
@@ -500,21 +524,23 @@ function LineplotViz(props: VisualizationProps<Options>) {
   const onIndependentAxisLogScaleChange = onChangeHandlerFactory<boolean>(
     'independentAxisLogScale',
     false,
-    true,
     false,
     false,
     true, // reset useBinning
+    false,
+    true,
     false
   );
 
   const onDependentAxisLogScaleChange = onChangeHandlerFactory<boolean>(
     'dependentAxisLogScale',
     false,
-    true,
     false,
     false,
     false,
-    true // reset showErrorBars
+    true, // reset showErrorBars
+    false,
+    true
   );
 
   const outputEntity = useFindOutputEntity(

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -375,19 +375,24 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
   const onChangeHandlerFactory = useCallback(
     < ValueType,>(key: keyof ScatterplotConfig,
       resetCheckedLegendItems?: boolean,
-      resetAxisRanges?: boolean,
       resetAxisLogScale?: boolean,
-      resetValueSpecConfig?: boolean) => (newValue?: ValueType) => {
+      resetValueSpecConfig?: boolean,
+      resetIndependentAxisRanges?: boolean,
+      resetDependentAxisRanges?: boolean,
+      ) => (newValue?: ValueType) => {
       const newPartialConfig = {
         [key]: newValue,
         ...(resetCheckedLegendItems ? { checkedLegendItems: undefined } : {}),
-      	...(resetAxisRanges ? { independentAxisRange: undefined, dependentAxisRange: undefined } : {}),
         ...(resetAxisLogScale ? { independentAxisLogScale: false, dependentAxisLogScale: false } : {}),
         ...(resetValueSpecConfig ? { valueSpecConfig: 'Raw' } : {}),
+        ...(resetIndependentAxisRanges ? { independentAxisRange: undefined } : {}),
+        ...(resetDependentAxisRanges ? { dependentAxisRange: undefined } : {}),
       };
       updateVizConfig(newPartialConfig);
-      if (resetAxisRanges) {
+      if (resetIndependentAxisRanges) {
         setTruncatedIndependentAxisWarning('');
+      }
+      if (resetDependentAxisRanges) {
         setTruncatedDependentAxisWarning('');
       }
     },
@@ -398,18 +403,26 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
   const onValueSpecChange = onChangeHandlerFactory<string>(
     'valueSpecConfig',
     true,
-    true,
     true, // reset both axisLogScale to false
-    false
+    false,
+    true,
+    true
   );
 
   const onIndependentAxisValueSpecChange = onChangeHandlerFactory<string>(
     'independentAxisValueSpec',
     false,
-    true
+    false,
+    false,
+    true,
+    false
   );
+
   const onDependentAxisValueSpecChange = onChangeHandlerFactory<string>(
     'dependentAxisValueSpec',
+    false,
+    false,
+    false,
     false,
     true
   );
@@ -417,23 +430,28 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
   const onShowMissingnessChange = onChangeHandlerFactory<boolean>(
     'showMissingness',
     true,
+    true,
+    false,
+    true,
     true
   );
 
   const onIndependentAxisLogScaleChange = onChangeHandlerFactory<boolean>(
     'independentAxisLogScale',
     true,
-    true,
     false,
-    true // reset valueSpec to Raw
+    true, // reset valueSpec to Raw
+    true,
+    false
   );
 
   const onDependentAxisLogScaleChange = onChangeHandlerFactory<boolean>(
     'dependentAxisLogScale',
     true,
-    true,
     false,
-    true // reset valueSpec to Raw
+    true, // reset valueSpec to Raw
+    false,
+    true
   );
 
   // outputEntity for OutputEntityTitle's outputEntity prop and outputEntityId at getRequestParams

--- a/src/lib/core/utils/default-axis-range.ts
+++ b/src/lib/core/utils/default-axis-range.ts
@@ -65,9 +65,9 @@ export function numberDateDefaultAxisRange(
             min: logScale
               ? (observedMinPos as number)
               : observedMin != null
-              ? Math.min(0, observedMin as number)
+              ? Math.min(observedMin as number)
               : // just leave this or set to be undefined
-                Math.min(0, defaults.rangeMin),
+                Math.min(defaults.rangeMin),
             max:
               observedMax != null
                 ? (observedMax as number)


### PR DESCRIPTION
This will address two enhancements described in the ticket, https://github.com/VEuPathDB/web-eda/issues/1408

a) behavior of axis range controls between x and y are independent each other
b) for Auto-zoom option, origin (e.g., 0) is not included

As for b), below is the example case that Bob raised (https://github.com/VEuPathDB/web-eda/issues/1097#issuecomment-1265744498, https://github.com/VEuPathDB/web-eda/issues/1097#issuecomment-1273655548)
- X-axis Full
![histogram-india1](https://user-images.githubusercontent.com/12802305/194994309-6a63a914-e1e4-43f7-bb35-2704554f1aa8.png)

- X-axis Auto-zoom: now the X-axis range is based on data, not including 0.
![histogram-india2](https://user-images.githubusercontent.com/12802305/194994489-2a20f346-f0c8-4c94-9f0b-0b2f1b42f4ee.png)
