### PR TITLE
Use variable's field.term instead of name for SelectTree key

### DIFF
--- a/src/lib/core/components/variableTrees/VariableList.tsx
+++ b/src/lib/core/components/variableTrees/VariableList.tsx
@@ -722,7 +722,7 @@ export default function VariableList({
       }}
     >
       <SelectTree
-        key={dropdownLabel}
+        key={activeField?.term}
         {...sharedProps}
         buttonDisplayContent={dropdownLabel}
         wrapPopover={(treeSection) => (


### PR DESCRIPTION
Closes #1414 