### PR TITLE
Add assertion check that study entities do not have empty variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.10.8",
+  "version": "3.10.9",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",


### PR DESCRIPTION
closes #943

This PR adds a check that the study object we received from the backend does not include any entities with an empty array of variables.