### PR TITLE
fix scatterplot Viz legend for single data

### DIFF
--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -903,7 +903,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
       ? options?.getCheckedLegendItems?.(
           computation.descriptor.configuration
         ) ?? vizConfig.checkedLegendItems
-      : undefined,
+      : vizConfig.checkedLegendItems,
     updateVizConfig
   );
 

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -896,7 +896,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
   ]);
 
   // set checkedLegendItems to either the config-stored items, or all items if
-  // nothing stored (or if no overlay locally configured)
+  // nothing stored
   const [checkedLegendItems, setCheckedLegendItems] = useCheckedLegendItems(
     legendItems,
     vizConfig.overlayVariable


### PR DESCRIPTION
This addresses https://github.com/VEuPathDB/web-eda/issues/1413

After carefully checking the issue, I realized that an argument for useCheckedLegendItems hook was not correctly set, which was modified to cope with full screen map (FSM) before. Checked both Scatterplot Viz and FSM to work fine.

Here is a screenshot to disable data for the same example used in the ticket.
![scatter-legend-bug-fix2](https://user-images.githubusercontent.com/12802305/197575103-9c0998e9-4d93-495d-b613-0471cb5f6587.png)
