### PR TITLE
Only request attributes that are defined for dataset records.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.11.8",
+  "version": "3.11.9",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",


### PR DESCRIPTION
This PR adds some logic to filter out attributes that are not defined for the WDK dataset record class. This is required to support https://github.com/VEuPathDB/EbrcModelCommon/pull/28