### PR TITLE
Handle minNumValues var constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.11.11",
+  "version": "3.11.12",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/types/visualization.ts
+++ b/src/lib/core/types/visualization.ts
@@ -100,6 +100,7 @@ export const DataElementConstraint = intersection([
     isTemporal: boolean,
     allowedTypes: array(VariableType),
     allowedShapes: array(VariableDataShape),
+    minNumValues: number,
     maxNumValues: number,
     allowMultiValued: boolean,
     // description isn't yet present for the records visualization

--- a/src/lib/core/utils/data-element-constraints.ts
+++ b/src/lib/core/utils/data-element-constraints.ts
@@ -365,7 +365,7 @@ export function mergeMinNumValues(
   constraintA: DataElementConstraint,
   constraintB: DataElementConstraint
 ) {
-  const mergedMinNumValues = Math.min(
+  const mergedMinNumValues = Math.max(
     constraintA.minNumValues === undefined
       ? -Infinity
       : constraintA.minNumValues,


### PR DESCRIPTION
Closes #1453

This depends on some backend changes (https://github.com/VEuPathDB/EdaCommon/pull/21, and https://github.com/VEuPathDB/EdaDataService/pull/219) to be able to fully test. They have not yet been merged.

In the mean time, these changes should not break any thing, since it is a new constraint. So, it is possible to test for regressions, if any one wants to take that on.

@d-callan if you can add a message here when the backend changes are merged, that would be great.