### PR TITLE
fix type error for Mosaic 2x2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/api/DataClient/types.ts
+++ b/src/lib/core/api/DataClient/types.ts
@@ -468,7 +468,7 @@ export const TwoByTwoResponse = intersection([
         pvalue: union([number, string]),
         orInterval: string,
         rrInterval: string,
-        relativerisk: number,
+        relativerisk: NumberOrNull,
         facetVariableDetails: union([
           tuple([StringVariableValue]),
           tuple([StringVariableValue, StringVariableValue]),


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1474

Checked the type definition for `statsTable` parameters. The example in the ticket responds two null values for `oddsratio` and `relativerisk`. The former already defined as `NumberOrNull` type, while the latter was `number` which caused the error. Thus, the latter was redefined as `NumberOrNull`.

Here is the screenshot after the fix (no error is thrown):

![ICEMR mosaic 2x2](https://user-images.githubusercontent.com/12802305/201967971-f85fd3a2-7c38-41d6-8efd-ce8bef853ccb.png)
