### PR TITLE
address type issue for Lineplot Viz

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.13.5",
+  "version": "3.13.6",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/api/DataClient/types.ts
+++ b/src/lib/core/api/DataClient/types.ts
@@ -424,7 +424,7 @@ const LineplotResponseData = array(
 export type LineplotConfig = TypeOf<typeof lineplotConfig>;
 const lineplotConfig = intersection([
   plotConfig,
-  type({
+  partial({
     binSlider: BinWidthSlider,
     binSpec: BinSpec,
     viewport: numericViewport,


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1506.

After extensive tests, I realized that the backend did not return binSlider, binSpec, and viewport anymore for ordinal variables, which caused the error in the ticket. Changed type({}) to partial({}) for relevant type definition and the error is gone.

Here is the screenshot for the same Study and variables (the presence of the filter does not matter):
![lineplot-bug0](https://user-images.githubusercontent.com/12802305/206558034-bfff9388-fa82-4be6-930b-94fd866f6756.png)


