### PR TITLE
remove marker for missing data at Lineplot Viz

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.13.6",
+  "version": "3.13.7",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -2226,7 +2226,8 @@ function processInputData(
 
   return {
     dataSetProcess: {
-      series: nullZeroHack(dataSetProcess, dependentValueType),
+      // Let's not show no data: nullZeroHack is not used
+      series: dataSetProcess,
       ...binWidthSliderData,
     },
     xMin: min(xValues),


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1411. 

After extensive tests and check codes, I found that Bob (I guess) nicely implemented nullZeroHack() function not to connect lines for missing data and the processed data was passed through the function. The request by the ticket is to remove those data points, thus the simplest solution is not to use the function.

Here is the screenshot for the same example in the ticket. Clearly, data points for Year 3 and Year 4 are now gone as compared to the screenshot in the ticket (https://github.com/VEuPathDB/web-eda/issues/1411#issue-1409463546).

 ![lineplot-no-data1](https://user-images.githubusercontent.com/12802305/206624618-a0bd2504-7720-4bee-9407-14e0cbf58ef7.png)
