### PR TITLE
check if a computed overlay var is present in birds eye

### DIFF
--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1807,7 +1807,9 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
           data.pending ? undefined : data.value?.completeCasesAxesVars
         }
         outputEntity={outputEntity}
-        stratificationIsActive={overlayVariable != null}
+        stratificationIsActive={
+          overlayVariable != null || computedOverlayVariableDescriptor != null
+        }
         enableSpinner={
           xAxisVariable != null && yAxisVariable != null && !data.error
         }


### PR DESCRIPTION
Resolves #1547 

Ranked abundance scatter has a computed overlay var, which means it has an overlay var but `overlayVariable` is undefined. This PR adds a check for a computed overlay var in the birds eye plot. 

