### PR TITLE
update compute status display text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.15.2",
+  "version": "3.15.3",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/RunComputeButton.tsx
+++ b/src/lib/core/components/computations/RunComputeButton.tsx
@@ -53,6 +53,18 @@ const colorMap: Record<JobStatus, string> = {
   failed: 'red',
 };
 
+// Replace internal job status with user-friendly status messages
+const jobStatusDisplay: Record<JobStatus, string> = {
+  'no-such-job': 'Not started.',
+  requesting: 'Requesting.',
+  queued: 'Queued.',
+  'in-progress':
+    'In progress. You may return later to use results in the visualization.',
+  complete: 'Complete, results saved in the system.',
+  expired: 'Results expired.',
+  failed: 'Failed. Contact the VEuPathDB team for support.',
+};
+
 interface StatusIconProps {
   status: JobStatus;
   showLabel?: boolean;
@@ -60,7 +72,7 @@ interface StatusIconProps {
 
 export function StatusIcon({ status, showLabel = false }: StatusIconProps) {
   const color = status ? colorMap[status] : '#808080cc';
-  const label = status ? capitalize(status?.replaceAll('-', ' ')) : 'Unknown';
+  const label = status ? jobStatusDisplay[status] : 'Unknown';
   return <Dot color={color} label={label} showLabel={showLabel} />;
 }
 

--- a/src/lib/core/components/computations/RunComputeButton.tsx
+++ b/src/lib/core/components/computations/RunComputeButton.tsx
@@ -54,7 +54,7 @@ const colorMap: Record<JobStatus, string> = {
 };
 
 // Replace internal job status with user-friendly status messages
-const jobStatusDisplay: Record<JobStatus, string> = {
+const jobStatusDisplay = {
   'no-such-job': 'Not started.',
   requesting: 'Requesting.',
   queued: 'Queued.',
@@ -63,7 +63,7 @@ const jobStatusDisplay: Record<JobStatus, string> = {
   complete: 'Complete, results saved in the system.',
   expired: 'Results expired.',
   failed: 'Failed. Contact the VEuPathDB team for support.',
-};
+} as const;
 
 interface StatusIconProps {
   status: JobStatus;

--- a/src/lib/core/components/computations/RunComputeButton.tsx
+++ b/src/lib/core/components/computations/RunComputeButton.tsx
@@ -60,7 +60,7 @@ const jobStatusDisplay = {
   queued: 'Queued.',
   'in-progress':
     'In progress. You may return later to use results in the visualization.',
-  complete: 'Complete, results saved in the system.',
+  complete: 'Complete. Results saved in the system.',
   expired: 'Results expired.',
   failed: 'Failed. Contact the VEuPathDB team for support.',
 } as const;


### PR DESCRIPTION
Resolves #1562 

Adds a new map between internal compute statuses and user-friendly statuses. 