### PR TITLE
Revive mapveu app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.15.12",
+  "version": "3.16.0",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -194,7 +194,7 @@ initialize({
     },
     {
       path: '/mapveu',
-      component: MapVeuContainer,
+      component: () => <MapVeuContainer singleAppMode={singleAppMode} />,
       exact: false,
       rootClassNameModifier: 'MapVEu',
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -157,6 +157,12 @@ initialize({
               <Link to="/eda/studies">All studies</Link>
             </li>
           </ul>
+          <H3>MapVEu Links</H3>
+          <ul>
+            <li>
+              <Link to="/mapveu">Mapveu</Link>
+            </li>
+          </ul>
         </div>
       ),
     },
@@ -190,6 +196,7 @@ initialize({
       path: '/mapveu',
       component: MapVeuContainer,
       exact: false,
+      rootClassNameModifier: 'MapVEu',
     },
     ...routes,
   ],

--- a/src/lib/core/components/EntityDiagram.tsx
+++ b/src/lib/core/components/EntityDiagram.tsx
@@ -4,13 +4,13 @@ import EntityDiagramComponent, {
   StudyData,
 } from '@veupathdb/components/lib/EntityDiagram/EntityDiagram';
 import { StudyEntity } from '../types/study';
-import { VariableLink } from './VariableLink';
 import {
   mapStructure,
   preorder,
 } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { reduce } from '@veupathdb/wdk-client/lib/Utils/IterableUtils';
 import { useEffect, useMemo, useState } from 'react';
+import { VariableLink, VariableLinkConfig } from './VariableLink';
 
 interface Props {
   expanded: boolean;
@@ -20,10 +20,11 @@ interface Props {
   entityCounts?: Record<string, number>;
   filteredEntities?: string[];
   filteredEntityCounts?: Record<string, number>;
+  variableLinkConfig: VariableLinkConfig;
 }
 
 export function EntityDiagram(props: Props) {
-  const { selectedEntity, selectedVariable } = props;
+  const { selectedEntity, selectedVariable, variableLinkConfig } = props;
   const studyMetadata = useStudyMetadata();
   const entityTree = useMemo((): StudyEntity => {
     return mapStructure(
@@ -64,6 +65,7 @@ export function EntityDiagram(props: Props) {
         children={children}
         replace={false}
         style={{ textDecoration: 'none' }}
+        linkConfig={variableLinkConfig}
       ></VariableLink>
     );
   };

--- a/src/lib/core/components/FilterChipList.tsx
+++ b/src/lib/core/components/FilterChipList.tsx
@@ -1,10 +1,10 @@
 import FilterChip from './FilterChip';
 import { StudyEntity } from '..';
-import { VariableLink } from './VariableLink';
 import { makeStyles } from '@material-ui/core/styles';
 import { Filter } from '../types/filter';
 import { findEntityAndVariable } from '../utils/study-metadata';
 import { ReactNode, Fragment } from 'react';
+import { VariableLink, VariableLinkConfig } from './VariableLink';
 
 // Material UI CSS declarations
 const useStyles = makeStyles((theme) => ({
@@ -24,6 +24,7 @@ interface Props {
   selectedEntityId?: string;
   selectedVariableId?: string;
   removeFilter: (filter: Filter) => void;
+  variableLinkConfig: VariableLinkConfig;
 }
 
 /**
@@ -32,7 +33,13 @@ interface Props {
  */
 export default function FilterChipList(props: Props) {
   const classes = useStyles();
-  const { filters, removeFilter, selectedEntityId, selectedVariableId } = props;
+  const {
+    filters,
+    removeFilter,
+    selectedEntityId,
+    selectedVariableId,
+    variableLinkConfig,
+  } = props;
 
   if (filters) {
     return (
@@ -113,6 +120,7 @@ export default function FilterChipList(props: Props) {
                   entityId={entity.id}
                   variableId={variable.id}
                   replace={true}
+                  linkConfig={variableLinkConfig}
                 >
                   {variable.displayName}
                 </VariableLink>

--- a/src/lib/core/components/GlobalFiltersDialog.tsx
+++ b/src/lib/core/components/GlobalFiltersDialog.tsx
@@ -8,6 +8,7 @@ import { Alert } from '@material-ui/lab';
 import _ from 'lodash';
 import 'react-resizable/css/styles.css';
 import './GlobalFiltersDialog.scss';
+import { VariableLinkConfig } from './VariableLink';
 
 interface Props {
   // Whether the dialog is open
@@ -22,6 +23,7 @@ interface Props {
   setFilters: (filters: Filter[]) => void;
   // A function to remove a given filter
   removeFilter: (filter: Filter) => void;
+  variableLinkConfig: VariableLinkConfig;
 }
 
 /**
@@ -51,6 +53,7 @@ export default function GlobalFiltersDialog(props: Props) {
               filters={matchingFilters}
               entities={props.entities}
               removeFilter={props.removeFilter}
+              variableLinkConfig={props.variableLinkConfig}
             />
           </div>
         );

--- a/src/lib/core/components/GlobalFiltersDialog.tsx
+++ b/src/lib/core/components/GlobalFiltersDialog.tsx
@@ -23,6 +23,7 @@ interface Props {
   setFilters: (filters: Filter[]) => void;
   // A function to remove a given filter
   removeFilter: (filter: Filter) => void;
+  // Determines if we render a link or a button.
   variableLinkConfig: VariableLinkConfig;
 }
 

--- a/src/lib/core/components/VariableLink.tsx
+++ b/src/lib/core/components/VariableLink.tsx
@@ -1,32 +1,66 @@
 /*
  * Link to the page for a variable
  */
-import { useMemo } from 'react';
+import { forwardRef, Ref } from 'react';
 import { Link, LinkProps } from 'react-router-dom';
-import { useMakeVariableLink } from '../hooks/workspace';
+
+type VariableValue = {
+  entityId?: string;
+  variableId?: string;
+};
+
+export type VariableLinkConfig =
+  | {
+      type: 'link';
+      makeVariableLink: (value?: VariableValue) => string;
+    }
+  | {
+      type: 'button';
+      onClick: (value?: VariableValue) => void;
+    };
 
 export interface Props<S = unknown> extends Omit<LinkProps<S>, 'to'> {
   entityId?: string;
   variableId?: string;
+  linkConfig: VariableLinkConfig;
 }
 
-export function VariableLink(props: Props) {
-  const { entityId, variableId, ...rest } = props;
-  const makeVariableLink = useMakeVariableLink();
-  const variableLink = useMemo(
-    () =>
-      makeVariableLink({
-        entityId,
-        variableId,
-      }),
-    [makeVariableLink, entityId, variableId]
-  );
+export const VariableLink = forwardRef(
+  (props: Props, ref: Ref<HTMLAnchorElement>) => {
+    const { entityId, variableId, linkConfig, ...rest } = props;
+    const value = { entityId, variableId };
 
-  return (
-    <Link
-      replace
-      {...rest}
-      to={{ pathname: variableLink, state: { scrollToTop: false } }}
-    />
-  );
-}
+    return linkConfig.type === 'link' ? (
+      <Link
+        replace
+        {...rest}
+        to={{
+          pathname: linkConfig.makeVariableLink(value),
+          state: { scrollToTop: false },
+        }}
+      />
+    ) : (
+      // Typically, we would just use a <button> for this case,
+      // but this needs to work in an SVG fragment, which does
+      // not support <button>, so this is a compromise
+      // eslint-disable-next-line jsx-a11y/anchor-has-content
+      <a
+        ref={ref}
+        role="button"
+        aria-pressed="false"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            linkConfig.onClick(value);
+          }
+        }}
+        onClick={(event) => {
+          event.preventDefault();
+          linkConfig.onClick(value);
+        }}
+        {...rest}
+      />
+    );
+  }
+);

--- a/src/lib/core/components/VariableLink.tsx
+++ b/src/lib/core/components/VariableLink.tsx
@@ -27,12 +27,14 @@ export interface Props<S = unknown> extends Omit<LinkProps<S>, 'to'> {
 
 export const VariableLink = forwardRef(
   (props: Props, ref: Ref<HTMLAnchorElement>) => {
-    const { entityId, variableId, linkConfig, ...rest } = props;
+    const { entityId, variableId, linkConfig, style, ...rest } = props;
     const value = { entityId, variableId };
 
     return linkConfig.type === 'link' ? (
       <Link
+        ref={ref}
         replace
+        style={style}
         {...rest}
         to={{
           pathname: linkConfig.makeVariableLink(value),
@@ -47,8 +49,8 @@ export const VariableLink = forwardRef(
       <a
         ref={ref}
         role="button"
-        aria-pressed="false"
         tabIndex={0}
+        style={{ cursor: 'pointer', ...style }}
         onKeyDown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();

--- a/src/lib/core/components/computations/Utils.ts
+++ b/src/lib/core/components/computations/Utils.ts
@@ -15,7 +15,8 @@ export function createComputation(
   configuration: unknown,
   computations: Computation[] = [],
   visualizations: Visualization[] = [],
-  computationId?: string
+  computationId?: string,
+  displayName?: string
 ): Computation {
   if (!computationId) {
     computationId = createNewId(
@@ -30,7 +31,7 @@ export function createComputation(
       configuration,
     },
     visualizations,
-    displayName: '',
+    displayName,
   };
 }
 

--- a/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
+++ b/src/lib/core/components/variableTrees/MultiSelectVariableTree.tsx
@@ -13,6 +13,7 @@ import {
   useValuesMap,
 } from './hooks';
 import { CustomCheckboxes } from '@veupathdb/wdk-client/lib/Components/CheckboxTree/CheckboxTreeNode';
+import { VariableLinkConfig } from '../VariableLink';
 
 export interface MultiSelectVariableTreeProps {
   /** The "scope" of variables which should be offered. */
@@ -79,7 +80,9 @@ export default function MultiSelectVariableTree({
     [onSelectedVariablesChange]
   );
 
-  const onActiveFieldChange = useCallback(() => undefined, []);
+  const variableLinkConfig = useMemo((): VariableLinkConfig => {
+    return { type: 'button', onClick: () => {} };
+  }, []);
 
   return (
     <VariableList
@@ -87,7 +90,7 @@ export default function MultiSelectVariableTree({
       showMultiFilterDescendants={true}
       selectedFields={selectedVariableFields}
       onSelectedFieldsChange={onSelectedVariableTermsChange}
-      onActiveFieldChange={onActiveFieldChange}
+      variableLinkConfig={variableLinkConfig}
       featuredFields={featuredFields}
       starredVariables={starredVariableDescriptors}
       valuesMap={valuesMap}

--- a/src/lib/core/components/variableTrees/VariableList.tsx
+++ b/src/lib/core/components/variableTrees/VariableList.tsx
@@ -10,7 +10,7 @@ import React, {
   useContext,
   ReactNode,
 } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 
 //correct paths as this is a copy of FieldList component at @veupathdb/
 import { scrollIntoViewIfNeeded } from '@veupathdb/wdk-client/lib/Utils/DomUtils';
@@ -52,6 +52,7 @@ import { useActiveDocument } from '../docs/DocumentationContainer';
 import { CustomCheckboxes } from '@veupathdb/wdk-client/lib/Components/CheckboxTree/CheckboxTreeNode';
 import { Toggle } from '@veupathdb/coreui';
 import useUITheme from '@veupathdb/coreui/dist/components/theming/useUITheme';
+import { VariableLink, VariableLinkConfig } from '../VariableLink';
 
 const baseFieldNodeLinkStyle = {
   padding: '0.25em 0.5em',
@@ -145,7 +146,6 @@ interface FieldNodeProps {
   isMultiFilterDescendant: boolean;
   showMultiFilterDescendants: boolean;
   customDisabledVariableMessage?: string;
-  handleFieldSelect: (field: VariableField) => void;
   activeFieldEntity?: string;
   isStarred: boolean;
   starredVariablesLoading: boolean;
@@ -153,6 +153,7 @@ interface FieldNodeProps {
   scrollIntoView: boolean;
   asDropdown?: boolean;
   isFeaturedField?: boolean;
+  variableLinkConfig: VariableLinkConfig;
 }
 
 interface getNodeSearchStringType {
@@ -185,7 +186,7 @@ type ValuesMap = Record<string, string>;
 interface VariableListProps {
   mode: 'singleSelection' | 'multiSelection';
   activeField?: VariableField;
-  onActiveFieldChange: (term: string) => void;
+  variableLinkConfig: VariableLinkConfig;
   selectedFields?: Array<VariableField>;
   onSelectedFieldsChange?: (terms: Array<string>) => void;
   valuesMap: ValuesMap;
@@ -215,7 +216,7 @@ interface VariableListProps {
 export default function VariableList({
   mode,
   activeField,
-  onActiveFieldChange,
+  variableLinkConfig,
   selectedFields = [],
   onSelectedFieldsChange,
   disabledFieldIds,
@@ -267,6 +268,24 @@ export default function VariableList({
 
   const activeFieldEntity = activeField?.term.split('/')[0];
 
+  const history = useHistory();
+
+  const onActiveFieldChange = useCallback(
+    (field: Field) => {
+      const [entityId, variableId] = field.term.split('/');
+      const variableDescriptor = { entityId, variableId };
+      if (variableLinkConfig.type === 'button') {
+        variableLinkConfig.onClick(variableDescriptor);
+      } else {
+        history.replace(
+          variableLinkConfig.makeVariableLink(variableDescriptor),
+          { scrollToTop: false }
+        );
+      }
+    },
+    [history, variableLinkConfig]
+  );
+
   // When active field changes, we want to collapse entity nodes that are not an ancestor
   // of the active field. We also want to retain the expanded state of internal nodes, so
   // we will only remove entity nodes from the list of expanded nodes.
@@ -305,7 +324,7 @@ export default function VariableList({
         else selectedFieldTerms.splice(indexOfField, 1);
         onSelectedFieldsChange(selectedFieldTerms);
       } else {
-        onActiveFieldChange(field.term);
+        onActiveFieldChange(field);
       }
     },
     [isMultiPick, onSelectedFieldsChange, selectedFields, onActiveFieldChange]
@@ -419,7 +438,7 @@ export default function VariableList({
           isActive={node.field.term === activeField?.term}
           isDisabled={disabledFields.has(node.field.term)}
           customDisabledVariableMessage={customDisabledVariableMessage}
-          handleFieldSelect={handleFieldSelect}
+          variableLinkConfig={variableLinkConfig}
           //add activefieldEntity prop (parent entity obtained from activeField)
           //alternatively, send activeField and isActive is directly checked at FieldNode
           activeFieldEntity={activeFieldEntity}
@@ -439,10 +458,11 @@ export default function VariableList({
       activeField?.term,
       disabledFields,
       customDisabledVariableMessage,
-      handleFieldSelect,
+      variableLinkConfig,
       activeFieldEntity,
       starredVariableTermsSet,
       starredVariablesLoading,
+      asDropdown,
       toggleStarredVariable,
     ]
   );
@@ -733,7 +753,7 @@ export default function VariableList({
                         customDisabledVariableMessage
                       }
                       searchTerm=""
-                      handleFieldSelect={handleFieldSelect}
+                      variableLinkConfig={variableLinkConfig}
                       isStarred={starredVariableTermsSet.has(field.term)}
                       starredVariablesLoading={starredVariablesLoading}
                       onClickStar={() =>
@@ -876,7 +896,7 @@ const FieldNode = ({
   isDisabled,
   isMultiPick,
   customDisabledVariableMessage,
-  handleFieldSelect,
+  variableLinkConfig,
   activeFieldEntity,
   isStarred,
   starredVariablesLoading,
@@ -887,7 +907,9 @@ const FieldNode = ({
   asDropdown,
   isFeaturedField,
 }: FieldNodeProps) => {
-  const nodeRef = useRef<HTMLButtonElement>(null);
+  const nodeRef = useRef<HTMLAnchorElement>(null);
+
+  const [entityId, variableId] = field.term.split('/');
 
   const nodeColorSelector = asDropdown
     ? 'dropdown-node-color'
@@ -926,8 +948,11 @@ const FieldNode = ({
     //       : 'Select this variable.'
     //   }
     // >
-    <button
+    <VariableLink
       ref={nodeRef}
+      entityId={entityId}
+      variableId={variableId}
+      linkConfig={variableLinkConfig}
       title={
         isMultiPick
           ? ''
@@ -937,21 +962,15 @@ const FieldNode = ({
           : 'Select this variable.'
       }
       className={
-        'link ' +
-        (isActive
+        isActive
           ? `active-field-node ${nodeColorSelector} ${anchorNodeLinkSelector}`
           : isDisabled
           ? `disabled-field-node ${nodeColorSelector} ${anchorNodeLinkSelector}`
-          : `base-field-node ${nodeColorSelector} ${anchorNodeLinkSelector}`)
+          : `base-field-node ${nodeColorSelector} ${anchorNodeLinkSelector}`
       }
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        if (!isDisabled) handleFieldSelect(field);
-      }}
     >
       <Icon fa={getIcon(field)} /> {safeHtml(field.display)}
-    </button>
+    </VariableLink>
   ) : (
     // </Tooltip>
     //add condition for identifying entity parent and entity parent of activeField

--- a/src/lib/core/components/variableTrees/VariableList.tsx
+++ b/src/lib/core/components/variableTrees/VariableList.tsx
@@ -887,7 +887,7 @@ const FieldNode = ({
   asDropdown,
   isFeaturedField,
 }: FieldNodeProps) => {
-  const nodeRef = useRef<HTMLAnchorElement>(null);
+  const nodeRef = useRef<HTMLButtonElement>(null);
 
   const nodeColorSelector = asDropdown
     ? 'dropdown-node-color'
@@ -926,7 +926,7 @@ const FieldNode = ({
     //       : 'Select this variable.'
     //   }
     // >
-    <a
+    <button
       ref={nodeRef}
       title={
         isMultiPick
@@ -937,13 +937,13 @@ const FieldNode = ({
           : 'Select this variable.'
       }
       className={
-        isActive
+        'link ' +
+        (isActive
           ? `active-field-node ${nodeColorSelector} ${anchorNodeLinkSelector}`
           : isDisabled
           ? `disabled-field-node ${nodeColorSelector} ${anchorNodeLinkSelector}`
-          : `base-field-node ${nodeColorSelector} ${anchorNodeLinkSelector}`
+          : `base-field-node ${nodeColorSelector} ${anchorNodeLinkSelector}`)
       }
-      href={'#' + field.term}
       onClick={(e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -951,7 +951,7 @@ const FieldNode = ({
       }}
     >
       <Icon fa={getIcon(field)} /> {safeHtml(field.display)}
-    </a>
+    </button>
   ) : (
     // </Tooltip>
     //add condition for identifying entity parent and entity parent of activeField

--- a/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/src/lib/core/components/visualizations/InputVariables.tsx
@@ -302,8 +302,13 @@ export function InputVariables(props: Props) {
                         toggleStarredVariable={toggleStarredVariable}
                         entityId={selectedVariables[input.name]?.entityId}
                         variableId={selectedVariables[input.name]?.variableId}
-                        onChange={(variable) => {
-                          handleChange(input.name, variable);
+                        variableLinkConfig={{
+                          type: 'button',
+                          onClick: (variable) =>
+                            handleChange(
+                              input.name,
+                              variable as VariableDescriptor
+                            ),
                         }}
                       />
                     )}

--- a/src/lib/core/hooks/analysis.ts
+++ b/src/lib/core/hooks/analysis.ts
@@ -152,7 +152,9 @@ export function useAnalysis(
 
     if (!isSavedAnalysis(analysis)) {
       createAnalysis(analysis);
-    } else {
+    }
+    // Only save if the analysis has changed
+    else if (analysis !== analysisCache.get(analysis.analysisId)) {
       await analysisClient.updateAnalysis(analysis.analysisId, analysis);
       analysisCache.set(analysis.analysisId, analysis);
     }
@@ -479,10 +481,14 @@ function updateAnalysis<T>(
   nestedValueLens: Lens<NewAnalysis | Analysis, T>,
   nestedValue: T | ((nestedValue: T) => T)
 ) {
+  const oldNestedValue = nestedValueLens.get(analysis);
   const newNestedValue =
     typeof nestedValue === 'function'
-      ? (nestedValue as (nestedValue: T) => T)(nestedValueLens.get(analysis))
+      ? (nestedValue as (nestedValue: T) => T)(oldNestedValue)
       : nestedValue;
 
-  return nestedValueLens.set(newNestedValue)(analysis);
+  if (oldNestedValue !== newNestedValue) {
+    return nestedValueLens.set(newNestedValue)(analysis);
+  }
+  return analysis;
 }

--- a/src/lib/core/hooks/study.ts
+++ b/src/lib/core/hooks/study.ts
@@ -134,7 +134,7 @@ export function useWdkStudyRecords(
       );
     },
     [attributes, tables]
-  )?.records;
+  )?.records.filter((record) => record.attributes.eda_study_id != null);
 }
 
 /**

--- a/src/lib/core/utils/data-element-constraints.ts
+++ b/src/lib/core/utils/data-element-constraints.ts
@@ -218,7 +218,9 @@ function variableConstraintPredicate(
   );
 }
 
-export type VariablesByInputName = Partial<Record<string, VariableDescriptor>>;
+export type VariablesByInputName<T extends string = string> = Partial<
+  Record<T, VariableDescriptor>
+>;
 export type DataElementConstraintRecord = Partial<
   Record<string, DataElementConstraint>
 >;

--- a/src/lib/mapveu/MapVEu.scss
+++ b/src/lib/mapveu/MapVEu.scss
@@ -1,0 +1,14 @@
+.wdk-RootContainer__MapVEu {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+
+  .wdk-PageContent {
+    flex-grow: 2;
+    padding: 0;
+  }
+
+  .MapVEu {
+    height: 100%;
+  }
+}

--- a/src/lib/mapveu/MapVeuAnalysis.tsx
+++ b/src/lib/mapveu/MapVeuAnalysis.tsx
@@ -1,10 +1,15 @@
 import { useCallback, useMemo, useState } from 'react';
+import { v4 as uuid } from 'uuid';
+import * as t from 'io-ts';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 
 import {
   makeNewAnalysis,
+  PromiseResult,
   useAnalysis,
+  useDataClient,
   useFindEntityAndVariable,
+  usePromise,
   useStudyEntities,
   useStudyMetadata,
   useStudyRecord,
@@ -20,29 +25,78 @@ import { useToggleStarredVariable } from '../core/hooks/starredVariables';
 import { DocumentationContainer } from '../core/components/docs/DocumentationContainer';
 import { VariableDescriptor } from '../core/types/variable';
 import PlotLegend from '@veupathdb/components/lib/components/plotControls/PlotLegend';
+import {
+  FullScreenVisualization,
+  NewVisualizationPickerModal,
+} from '../core/components/visualizations/VisualizationsContainer';
+import { FilledButton } from '@veupathdb/coreui';
+import { Visualization } from '../core/types/visualization';
+import { useEntityCounts } from '../core/hooks/entityCounts';
+import { Tooltip } from '@material-ui/core';
+import { Link } from 'react-router-dom';
+import { ComputationPlugin } from '../core/components/computations/Types';
+import { ZeroConfigWithButton } from '../core/components/computations/ZeroConfiguration';
+import { histogramVisualization } from '../core/components/visualizations/implementations/HistogramVisualization';
+import { VisualizationPlugin } from '../core/components/visualizations/VisualizationPlugin';
+import { LayoutOptions } from '../core/components/layouts/types';
+import { OverlayOptions } from '../core/components/visualizations/options/types';
+import { FloatingLayout } from '../core/components/layouts/FloatingLayout';
+import {
+  contTableVisualization,
+  twoByTwoVisualization,
+} from '../core/components/visualizations/implementations/MosaicVisualization';
+import { scatterplotVisualization } from '../core/components/visualizations/implementations/ScatterplotVisualization';
+import { lineplotVisualization } from '../core/components/visualizations/implementations/LineplotVisualization';
+import { barplotVisualization } from '../core/components/visualizations/implementations/BarplotVisualization';
+import { boxplotVisualization } from '../core/components/visualizations/implementations/BoxplotVisualization';
+import ShowHideVariableContextProvider from '../core/utils/show-hide-variable-context';
 
 const mapStyle: React.CSSProperties = {
   zIndex: 1,
 };
 
-interface AppState {
-  viewport: Viewport;
-  boundsZoomLevel?: BoundsViewport;
-  mouseMode: MouseMode;
-  selectedOverlayVariable?: VariableDescriptor;
+function vizPluginWithOptions(
+  vizPlugin: VisualizationPlugin<LayoutOptions & OverlayOptions>
+) {
+  return vizPlugin.withOptions({
+    hideFacetInputs: true,
+    layoutComponent: FloatingLayout,
+  });
 }
+
+const plugin: ComputationPlugin = {
+  configurationComponent: ZeroConfigWithButton,
+  isConfigurationValid: t.undefined.is,
+  createDefaultConfiguration: () => undefined,
+  visualizationPlugins: {
+    histogram: vizPluginWithOptions(histogramVisualization),
+    twobytwo: vizPluginWithOptions(twoByTwoVisualization),
+    conttable: vizPluginWithOptions(contTableVisualization),
+    scatterplot: vizPluginWithOptions(scatterplotVisualization),
+    lineplot: vizPluginWithOptions(lineplotVisualization),
+    barplot: vizPluginWithOptions(barplotVisualization),
+    _boxplot: vizPluginWithOptions(boxplotVisualization),
+    get boxplot() {
+      return this._boxplot;
+    },
+    set boxplot(value) {
+      this._boxplot = value;
+    },
+  },
+};
 
 interface Props {
   analysisId: string;
   studyId: string;
 }
+
 export function MapVeuAnalysis(props: Props) {
   const { analysisId } = props;
   const studyRecord = useStudyRecord();
   const studyMetadata = useStudyMetadata();
   const studyEntities = useStudyEntities();
   const geoConfigs = useGeoConfig(studyEntities);
-  const analysisState = useAnalysis(analysisId);
+  const analysisState = useAnalysis(analysisId, 'pass-through');
 
   const {
     appState,
@@ -50,6 +104,8 @@ export function MapVeuAnalysis(props: Props) {
     setMouseMode,
     setSelectedVariables,
     setViewport,
+    setIsVizSelectorVisible,
+    setActiveVisualizationId,
   } = useAppState();
 
   const geoConfig = geoConfigs[0];
@@ -90,91 +146,303 @@ export function MapVeuAnalysis(props: Props) {
 
   const finalMarkers = useMemo(() => markers || [], [markers]);
 
+  const dataClient = useDataClient();
+
+  const appPromiseState = usePromise(
+    useCallback(async () => {
+      const { apps } = await dataClient.getApps();
+      const app = apps.find((a) => a.name === 'pass');
+      if (app == null) throw new Error('Could not find pass app.');
+      return app;
+    }, [dataClient])
+  );
+
+  const computation = analysisState.analysis?.descriptor.computations[0];
+
+  const updateVisualizations = useCallback(
+    (
+      visualizations:
+        | Visualization[]
+        | ((visualizations: Visualization[]) => Visualization[])
+    ) => {
+      analysisState.setComputations((computations) =>
+        computations.map((c) =>
+          c.computationId !== computation?.computationId
+            ? c
+            : {
+                ...c,
+                visualizations:
+                  typeof visualizations === 'function'
+                    ? visualizations(c.visualizations)
+                    : visualizations,
+              }
+        )
+      );
+    },
+    [analysisState, computation?.computationId]
+  );
+
+  const onVisualizationCreated = useCallback(
+    (visualizationId: string) => {
+      setActiveVisualizationId(visualizationId);
+      setIsVizSelectorVisible(false);
+    },
+    [setActiveVisualizationId, setIsVizSelectorVisible]
+  );
+
+  const activeViz = analysisState.analysis?.descriptor.computations
+    .flatMap((c) => c.visualizations)
+    .find((v) => v.visualizationId === appState.activeVisualizationId);
+
+  const totalCounts = useEntityCounts();
+  const filteredCounts = useEntityCounts(
+    analysisState.analysis?.descriptor.subset.descriptor
+  );
+
+  const fullScreenActions = (
+    <>
+      <div>
+        <Tooltip title="Delete visualization">
+          <button
+            type="button"
+            className="link"
+            onClick={() => {
+              if (activeViz == null) return;
+              updateVisualizations((visualizations) =>
+                visualizations.filter(
+                  (v) => v.visualizationId !== appState.activeVisualizationId
+                )
+              );
+              setActiveVisualizationId(undefined);
+            }}
+          >
+            <i className="fa fa-trash"></i>
+          </button>
+        </Tooltip>
+      </div>
+      <div>
+        <Tooltip title="Copy visualization">
+          <button
+            type="button"
+            className="link"
+            onClick={() => {
+              if (activeViz == null) return;
+              const vizCopyId = uuid();
+              updateVisualizations((visualizations) =>
+                visualizations.concat({
+                  ...activeViz,
+                  visualizationId: vizCopyId,
+                  displayName:
+                    'Copy of ' +
+                    (activeViz.displayName || 'unnamed visualization'),
+                })
+              );
+              setActiveVisualizationId(vizCopyId);
+            }}
+          >
+            <i className="fa fa-clone"></i>
+          </button>
+        </Tooltip>
+      </div>
+      <Tooltip title="Minimize visualization">
+        <Link
+          to=""
+          onClick={(e) => {
+            e.preventDefault();
+            setActiveVisualizationId(undefined);
+          }}
+        >
+          <i className="fa fa-window-minimize" />
+        </Link>
+      </Tooltip>
+    </>
+  );
+
   return (
-    <DocumentationContainer>
-      <div
-        style={{
-          height: '100%',
-          position: 'relative',
-        }}
-      >
-        <MapVEuMap
-          height="100%"
-          width="100%"
-          style={mapStyle}
-          showMouseToolbar
-          showSpinner={pending}
-          animation={null}
-          viewport={appState.viewport}
-          markers={finalMarkers}
-          mouseMode={appState.mouseMode}
-          flyToMarkers={false}
-          flyToMarkersDelay={500}
-          onBoundsChanged={setBoundsZoomLevel}
-          onViewportChanged={setViewport}
-          onMouseModeChange={setMouseMode}
-          showGrid={geoConfig?.zoomLevelToAggregationLevel !== null}
-          zoomLevelToGeohashLevel={geoConfig?.zoomLevelToAggregationLevel}
-        />
-        {legendItems.length > 0 && (
+    <ShowHideVariableContextProvider>
+      <DocumentationContainer>
+        <div
+          style={{
+            height: '100%',
+            position: 'relative',
+          }}
+        >
+          <MapVEuMap
+            height="100%"
+            width="100%"
+            style={mapStyle}
+            showMouseToolbar
+            showSpinner={pending}
+            animation={null}
+            viewport={appState.viewport}
+            markers={finalMarkers}
+            mouseMode={appState.mouseMode}
+            flyToMarkers={false}
+            flyToMarkersDelay={500}
+            onBoundsChanged={setBoundsZoomLevel}
+            onViewportChanged={setViewport}
+            onMouseModeChange={setMouseMode}
+            showGrid={geoConfig?.zoomLevelToAggregationLevel !== null}
+            zoomLevelToGeohashLevel={geoConfig?.zoomLevelToAggregationLevel}
+          />
+          {legendItems.length > 0 && (
+            <FloatingDiv
+              style={{
+                top: 50,
+                right: 50,
+              }}
+            >
+              <div>
+                <strong>{variable?.displayName}</strong>
+              </div>
+              <PlotLegend
+                type="list"
+                legendItems={legendItems}
+                showOverlayLegend
+                checkedLegendItems={legendItems.map((item) => item.label)}
+                containerStyles={{
+                  border: 'none',
+                  boxShadow: 'none',
+                  padding: 0,
+                  width: 'auto',
+                }}
+              />
+            </FloatingDiv>
+          )}
           <FloatingDiv
             style={{
-              top: 50,
-              right: 50,
+              top: 10,
+              left: 100,
             }}
           >
             <div>
-              <strong>{variable?.displayName}</strong>
+              {safeHtml(studyRecord.displayName)} ({totalEntityCount})
             </div>
-            <PlotLegend
-              type="list"
-              legendItems={legendItems}
-              showOverlayLegend
-              checkedLegendItems={legendItems.map((item) => item.label)}
-              containerStyles={{
-                border: 'none',
-                boxShadow: 'none',
-                padding: 0,
-                width: 'auto',
-              }}
+            <div>
+              Showing {entity?.displayName} variable {variable?.displayName}
+            </div>
+            <div>
+              <InputVariables
+                inputs={[{ name: 'overlay', label: 'Overlay' }]}
+                entities={studyEntities}
+                selectedVariables={selectedVariables}
+                onChange={setSelectedVariables}
+                starredVariables={
+                  analysisState.analysis?.descriptor.starredVariables ?? []
+                }
+                toggleStarredVariable={toggleStarredVariable}
+              />
+            </div>
+            <FilledButton
+              text="Add a plot"
+              onPress={() => setIsVizSelectorVisible(true)}
             />
+            <ul>
+              {analysisState.analysis?.descriptor.computations.map(
+                (computation) => (
+                  <li>
+                    <strong>
+                      {computation.displayName} ({computation.descriptor.type})
+                    </strong>
+                    <ul>
+                      {computation.visualizations.map((viz) => (
+                        <li>
+                          <button
+                            type="button"
+                            className="link"
+                            onClick={() => {
+                              setActiveVisualizationId(viz.visualizationId);
+                            }}
+                          >
+                            {viz.displayName} ({viz.descriptor.type})
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </li>
+                )
+              )}
+            </ul>
           </FloatingDiv>
-        )}
-        <FloatingDiv
-          style={{
-            top: 10,
-            left: 100,
-          }}
-        >
-          <div>
-            {safeHtml(studyRecord.displayName)} ({totalEntityCount})
-          </div>
-          <div>
-            Showing {entity?.displayName} variable {variable?.displayName}
-          </div>
-          <div>
-            <InputVariables
-              inputs={[{ name: 'overlay', label: 'Overlay' }]}
-              entities={studyEntities}
-              selectedVariables={selectedVariables}
-              onChange={setSelectedVariables}
-              starredVariables={
-                analysisState.analysis?.descriptor.starredVariables ?? []
-              }
-              toggleStarredVariable={toggleStarredVariable}
-            />
-          </div>
-        </FloatingDiv>
-        {(basicMarkerError || overlayError) && (
           <FloatingDiv
-            style={{ top: undefined, bottom: 50, left: 100, right: 100 }}
+            style={{
+              bottom: 10,
+              left: 100,
+            }}
           >
-            {basicMarkerError && <div>{String(basicMarkerError)}</div>}
-            {overlayError && <div>{String(overlayError)}</div>}
+            {activeViz && (
+              <div
+                style={{
+                  transform: 'scale(0.9)',
+                  background: 'white',
+                  minHeight: '10em',
+                  minWidth: '12em',
+                  width: '65em',
+                  position: 'fixed',
+                  right: 0,
+                  bottom: 0,
+                  zIndex: 2000,
+                  padding: '0 1em',
+                }}
+              >
+                <PromiseResult state={appPromiseState}>
+                  {(app) => (
+                    <FullScreenVisualization
+                      analysisState={analysisState}
+                      computation={computation!}
+                      updateVisualizations={updateVisualizations}
+                      visualizationPlugins={plugin.visualizationPlugins}
+                      visualizationsOverview={app.visualizations}
+                      geoConfigs={[geoConfig]}
+                      computationAppOverview={app}
+                      filters={
+                        analysisState.analysis?.descriptor.subset.descriptor ??
+                        []
+                      }
+                      starredVariables={
+                        analysisState.analysis?.descriptor.starredVariables ??
+                        []
+                      }
+                      toggleStarredVariable={toggleStarredVariable}
+                      totalCounts={totalCounts}
+                      filteredCounts={filteredCounts}
+                      isSingleAppMode
+                      disableThumbnailCreation
+                      id={activeViz.visualizationId}
+                      actions={fullScreenActions}
+                    />
+                  )}
+                </PromiseResult>
+              </div>
+            )}
           </FloatingDiv>
-        )}
-      </div>
-    </DocumentationContainer>
+          {(basicMarkerError || overlayError) && (
+            <FloatingDiv
+              style={{ top: undefined, bottom: 50, left: 100, right: 100 }}
+            >
+              {basicMarkerError && <div>{String(basicMarkerError)}</div>}
+              {overlayError && <div>{String(overlayError)}</div>}
+            </FloatingDiv>
+          )}
+        </div>
+        <PromiseResult state={appPromiseState}>
+          {(app) => {
+            return (
+              <NewVisualizationPickerModal
+                visible={appState.isVizSelectorVisible}
+                onVisibleChange={setIsVizSelectorVisible}
+                computation={computation!}
+                updateVisualizations={updateVisualizations}
+                visualizationPlugins={plugin.visualizationPlugins}
+                visualizationsOverview={app.visualizations}
+                geoConfigs={[geoConfig]}
+                onVisualizationCreated={onVisualizationCreated}
+              />
+            );
+          }}
+        </PromiseResult>
+      </DocumentationContainer>
+    </ShowHideVariableContextProvider>
   );
 }
 
@@ -198,6 +466,15 @@ function FloatingDiv(props: {
   );
 }
 
+interface AppState {
+  viewport: Viewport;
+  boundsZoomLevel?: BoundsViewport;
+  mouseMode: MouseMode;
+  selectedOverlayVariable?: VariableDescriptor;
+  isVizSelectorVisible: boolean;
+  activeVisualizationId?: string;
+}
+
 function useAppState() {
   const [appState, setAppState] = useState<AppState>(() => ({
     viewport: {
@@ -205,6 +482,7 @@ function useAppState() {
       zoom: 4,
     },
     mouseMode: 'default',
+    isVizSelectorVisible: false,
   }));
 
   const setViewport = useCallback((viewport: Viewport) => {
@@ -229,11 +507,27 @@ function useAppState() {
     []
   );
 
+  const setIsVizSelectorVisible = useCallback(
+    (isVizSelectorVisible: boolean) => {
+      setAppState((prevState) => ({ ...prevState, isVizSelectorVisible }));
+    },
+    []
+  );
+
+  const setActiveVisualizationId = useCallback(
+    (activeVisualizationId?: string) => {
+      setAppState((prevState) => ({ ...prevState, activeVisualizationId }));
+    },
+    []
+  );
+
   return {
     appState,
     setViewport,
     setMouseMode,
     setBoundsZoomLevel,
     setSelectedVariables,
+    setIsVizSelectorVisible,
+    setActiveVisualizationId,
   };
 }

--- a/src/lib/mapveu/MapVeuAnalysis.tsx
+++ b/src/lib/mapveu/MapVeuAnalysis.tsx
@@ -1,13 +1,27 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
-import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 
 import {
   makeNewAnalysis,
   useAnalysis,
+  useFindEntityAndVariable,
+  useStudyEntities,
   useStudyMetadata,
   useStudyRecord,
 } from '../core';
+import MapVEuMap from '@veupathdb/components/lib/map/MapVEuMap';
+import { BoundsViewport, Viewport } from '@veupathdb/components/lib/map/Types';
+import { MouseMode } from '@veupathdb/components/lib/map/MouseTools';
+import { useGeoConfig } from '../core/hooks/geoConfig';
+import { useMapMarkers } from '../core/hooks/mapMarkers';
+import { InputVariables } from '../core/components/visualizations/InputVariables';
+import { VariablesByInputName } from '../core/utils/data-element-constraints';
+import { useToggleStarredVariable } from '../core/hooks/starredVariables';
+import { DocumentationContainer } from '../core/components/docs/DocumentationContainer';
+
+const mapStyle: React.CSSProperties = {
+  zIndex: 1,
+};
 
 interface Props {
   analysisId: string;
@@ -17,33 +31,136 @@ export function MapVeuAnalysis(props: Props) {
   const { analysisId } = props;
   const studyRecord = useStudyRecord();
   const studyMetadata = useStudyMetadata();
-  const { analysis } = useAnalysis(analysisId);
-  if (analysis == null) return <div>No analysis found</div>;
-  const entities = Array.from(
-    preorder(studyMetadata.rootEntity, (e) => e.children ?? [])
-  );
+  const studyEntities = useStudyEntities();
+  const geoConfigs = useGeoConfig(studyEntities);
+  const analysisState = useAnalysis(analysisId);
+  const [viewport, setViewport] = useState<Viewport>(() => ({
+    center: [0, 0],
+    zoom: 4,
+  }));
+  const [boundsZoomLevel, setBoundsZoomLevel] = useState<BoundsViewport>();
+  const [mouseMode, setMouseMode] = useState<MouseMode>('default');
+  const geoConfig = geoConfigs[0];
+
+  const [
+    selectedVariables,
+    setSelectedVariables,
+  ] = useState<VariablesByInputName>({
+    overlay: undefined,
+  });
+
+  const findEntityAndVariable = useFindEntityAndVariable();
+  const { entity, variable } =
+    findEntityAndVariable(selectedVariables.overlayVariable) ?? {};
+
+  const toggleStarredVariable = useToggleStarredVariable(analysisState);
+
+  const {
+    markers,
+    pending,
+    legendItems,
+    vocabulary,
+    basicMarkerError,
+    overlayError,
+    totalEntityCount,
+  } = useMapMarkers({
+    requireOverlay: false,
+    boundsZoomLevel,
+    geoConfig: geoConfig,
+    studyId: studyMetadata.id,
+    filters: analysisState.analysis?.descriptor.subset.descriptor,
+    // xAxisVariable: appState.overlayVariable,
+    xAxisVariable: selectedVariables.overlay,
+    computationType: 'pass',
+    markerType: 'pie',
+    checkedLegendItems: undefined,
+    //TO DO: maybe dependentAxisLogScale
+  });
+
+  const finalMarkers = useMemo(() => markers || [], [markers]);
+
   return (
-    <>
-      <h2>Study: {studyRecord.displayName}</h2>
-      <h3>Study details</h3>
-      <dl>
-        <dt>Entities</dt>
-        <dd>
-          <ul>
-            {entities.map((e) => (
-              <li>{safeHtml(e.displayName)}</li>
-            ))}
-          </ul>
-        </dd>
-      </dl>
-      <h3>Analysis details</h3>
-      <dl>
-        {' '}
-        <dt>Name</dt>
-        <dd>{analysis?.displayName}</dd>
-        {/* <dt>Created</dt>
-        <dd>{analysis.created}</dd> */}
-      </dl>
-    </>
+    <DocumentationContainer>
+      <div
+        style={{
+          height: '100%',
+          position: 'relative',
+        }}
+      >
+        <MapVEuMap
+          height="100%"
+          width="100%"
+          style={mapStyle}
+          showMouseToolbar
+          showSpinner={pending}
+          animation={null}
+          viewport={viewport}
+          markers={finalMarkers}
+          mouseMode={mouseMode}
+          flyToMarkers={false}
+          flyToMarkersDelay={500}
+          onBoundsChanged={setBoundsZoomLevel}
+          onViewportChanged={setViewport}
+          onMouseModeChange={setMouseMode}
+          showGrid={geoConfig?.zoomLevelToAggregationLevel !== null}
+          zoomLevelToGeohashLevel={geoConfig?.zoomLevelToAggregationLevel}
+        />
+        <FloatingDiv
+          style={{
+            top: 10,
+            left: 100,
+          }}
+        >
+          <div>
+            {safeHtml(studyRecord.displayName)} ({totalEntityCount})
+          </div>
+          <div>
+            Showing {entity?.displayName} variable {variable?.displayName}
+          </div>
+          <div>
+            <InputVariables
+              inputs={[{ name: 'overlay', label: 'Overlay' }]}
+              entities={studyEntities}
+              selectedVariables={selectedVariables}
+              onChange={setSelectedVariables}
+              starredVariables={
+                analysisState.analysis?.descriptor.starredVariables ?? []
+              }
+              toggleStarredVariable={toggleStarredVariable}
+            />
+          </div>
+        </FloatingDiv>
+        {(basicMarkerError || overlayError) && (
+          <FloatingDiv
+            style={{ top: undefined, bottom: 50, left: 100, right: 100 }}
+          >
+            {basicMarkerError && <div>{String(basicMarkerError)}</div>}
+            {overlayError && <div>{String(overlayError)}</div>}
+          </FloatingDiv>
+        )}
+      </div>
+    </DocumentationContainer>
+  );
+}
+
+function FloatingDiv(props: {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        zIndex: 1,
+        padding: '1em',
+        backgroundColor: 'white',
+        border: '1px solid black',
+        ...props.style,
+      }}
+    >
+      {props.children}
+    </div>
   );
 }

--- a/src/lib/mapveu/MapVeuAnalysis.tsx
+++ b/src/lib/mapveu/MapVeuAnalysis.tsx
@@ -107,11 +107,11 @@ export function MapVeuAnalysis(props: Props) {
     setMouseMode,
     setSelectedOverlayVariable,
     setViewport,
-    setIsVizSelectorVisible,
     setActiveVisualizationId,
   } = useAppState('@@mapApp@@', analysisState);
 
   const [boundsZoomLevel, setBoundsZoomLevel] = useState<BoundsViewport>();
+  const [isVizSelectorVisible, setIsVizSelectorVisible] = useState(false);
 
   const selectedVariables = useMemo(
     () => ({
@@ -434,7 +434,7 @@ export function MapVeuAnalysis(props: Props) {
           {(app) => {
             return (
               <NewVisualizationPickerModal
-                visible={appState.isVizSelectorVisible}
+                visible={isVizSelectorVisible}
                 onVisibleChange={setIsVizSelectorVisible}
                 computation={computation!}
                 updateVisualizations={updateVisualizations}
@@ -481,7 +481,6 @@ const AppState = t.intersection([
       default: null,
       magnification: null,
     }),
-    isVizSelectorVisible: t.boolean,
   }),
   t.partial({
     selectedOverlayVariable: VariableDescriptor,
@@ -498,7 +497,6 @@ const defaultAppState: AppState = {
     zoom: 4,
   },
   mouseMode: 'default',
-  isVizSelectorVisible: false,
 };
 
 function useAppState(uiStateKey: string, analysisState: AnalysisState) {
@@ -515,33 +513,28 @@ function useAppState(uiStateKey: string, analysisState: AnalysisState) {
     setAppState(savedState);
   }, [savedState]);
 
-  function useStateUpdater<T extends keyof AppState>(key: T) {
-    return useCallback(
-      (value: AppState[T]) => {
-        setVariableUISettings((prev) => ({
-          ...prev,
-          [uiStateKey]: {
-            ...appState,
-            [key]: value,
-          },
-        }));
-      },
-      [key]
-    );
+  function makeSetter<T extends keyof AppState>(key: T) {
+    return function setter(value: AppState[T]) {
+      setVariableUISettings((prev) => ({
+        ...prev,
+        [uiStateKey]: {
+          ...appState,
+          [key]: value,
+        },
+      }));
+    };
   }
 
-  const setViewport = useStateUpdater('viewport');
-  const setMouseMode = useStateUpdater('mouseMode');
-  const setSelectedOverlayVariable = useStateUpdater('selectedOverlayVariable');
-  const setIsVizSelectorVisible = useStateUpdater('isVizSelectorVisible');
-  const setActiveVisualizationId = useStateUpdater('activeVisualizationId');
+  const setViewport = makeSetter('viewport');
+  const setMouseMode = makeSetter('mouseMode');
+  const setSelectedOverlayVariable = makeSetter('selectedOverlayVariable');
+  const setActiveVisualizationId = makeSetter('activeVisualizationId');
 
   return {
     appState,
     setViewport,
     setMouseMode,
     setSelectedOverlayVariable,
-    setIsVizSelectorVisible,
     setActiveVisualizationId,
   };
 }

--- a/src/lib/mapveu/MapVeuAnalysis.tsx
+++ b/src/lib/mapveu/MapVeuAnalysis.tsx
@@ -5,7 +5,6 @@ import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 
 import {
   AnalysisState,
-  makeNewAnalysis,
   PromiseResult,
   useAnalysis,
   useDataClient,
@@ -16,12 +15,10 @@ import {
   useStudyRecord,
 } from '../core';
 import MapVEuMap from '@veupathdb/components/lib/map/MapVEuMap';
-import { BoundsViewport, Viewport } from '@veupathdb/components/lib/map/Types';
-import { MouseMode } from '@veupathdb/components/lib/map/MouseTools';
+import { BoundsViewport } from '@veupathdb/components/lib/map/Types';
 import { useGeoConfig } from '../core/hooks/geoConfig';
 import { useMapMarkers } from '../core/hooks/mapMarkers';
 import { InputVariables } from '../core/components/visualizations/InputVariables';
-import { VariablesByInputName } from '../core/utils/data-element-constraints';
 import { useToggleStarredVariable } from '../core/hooks/starredVariables';
 import { DocumentationContainer } from '../core/components/docs/DocumentationContainer';
 import { VariableDescriptor } from '../core/types/variable';
@@ -130,7 +127,6 @@ export function MapVeuAnalysis(props: Props) {
     markers,
     pending,
     legendItems,
-    vocabulary,
     basicMarkerError,
     overlayError,
     totalEntityCount,

--- a/src/lib/mapveu/MapVeuAnalysisList.tsx
+++ b/src/lib/mapveu/MapVeuAnalysisList.tsx
@@ -5,14 +5,16 @@ import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { AnalysisClient } from '../core/api/AnalysisClient';
 import { usePromise } from '../core/hooks/promise';
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
+import { createComputation } from '../core/components/computations/Utils';
 
 interface Props {
   studyId: string;
   analysisStore: AnalysisClient;
+  singleAppMode?: string;
 }
 
 export function AnalysisList(props: Props) {
-  const { analysisStore, studyId } = props;
+  const { analysisStore, studyId, singleAppMode } = props;
   const studyRecord = useStudyRecord();
   const list = usePromise(
     useCallback(async () => {
@@ -23,11 +25,23 @@ export function AnalysisList(props: Props) {
   const { url } = useRouteMatch();
   const history = useHistory();
   const createAnalysis = useCallback(async () => {
+    // FIXME Only create computation if singleAppMode is defined
+    // If using singleAppMode, create a computation object that will be used in our default analysis.
+    const computation = singleAppMode
+      ? createComputation(
+          singleAppMode,
+          undefined,
+          [],
+          [],
+          undefined,
+          'Unnamed computation'
+        )
+      : undefined;
     const { analysisId } = await analysisStore.createAnalysis(
-      makeNewAnalysis(studyId)
+      makeNewAnalysis(studyId, computation)
     );
     history.push(`${url}/${analysisId}`);
-  }, [analysisStore, history, studyId, url]);
+  }, [analysisStore, history, singleAppMode, studyId, url]);
   return (
     <>
       <h2>Study: {safeHtml(studyRecord.displayName)}</h2>

--- a/src/lib/mapveu/MapVeuAnalysisList.tsx
+++ b/src/lib/mapveu/MapVeuAnalysisList.tsx
@@ -58,7 +58,7 @@ export function AnalysisList(props: Props) {
       ) : (
         <ul>
           {list.value?.map((analysis) => (
-            <li>
+            <li key={analysis.analysisId}>
               <Link to={`${url}/${analysis.analysisId}`}>
                 {safeHtml(analysis.displayName)}
               </Link>

--- a/src/lib/mapveu/MapVeuAnalysisList.tsx
+++ b/src/lib/mapveu/MapVeuAnalysisList.tsx
@@ -16,8 +16,8 @@ export function AnalysisList(props: Props) {
   const studyRecord = useStudyRecord();
   const list = usePromise(
     useCallback(async () => {
-      const studies = await analysisStore.getAnalyses();
-      return studies.filter((study) => study.analysisId === studyId);
+      const analyses = await analysisStore.getAnalyses();
+      return analyses.filter((analysis) => analysis.studyId === studyId);
     }, [studyId, analysisStore])
   );
   const { url } = useRouteMatch();
@@ -30,7 +30,7 @@ export function AnalysisList(props: Props) {
   }, [analysisStore, history, studyId, url]);
   return (
     <>
-      <h2>Study: {studyRecord.displayName}</h2>
+      <h2>Study: {safeHtml(studyRecord.displayName)}</h2>
       <h3>Saved Analyses</h3>
       <div>
         <button className="btn" type="button" onClick={createAnalysis}>

--- a/src/lib/mapveu/MapVeuContainer.tsx
+++ b/src/lib/mapveu/MapVeuContainer.tsx
@@ -8,7 +8,7 @@ import {
 import { EDAAnalysisListContainer, EDAWorkspaceContainer } from '../core';
 
 import { AnalysisList } from './MapVeuAnalysisList';
-import { MapVeuAnalysis } from './MapVeuAnalysis';
+import { MapVeuAnalysis } from './analysis/MapVeuAnalysis';
 
 import { StudyList } from './StudyList';
 import {

--- a/src/lib/mapveu/MapVeuContainer.tsx
+++ b/src/lib/mapveu/MapVeuContainer.tsx
@@ -8,7 +8,7 @@ import {
 import { EDAAnalysisListContainer, EDAWorkspaceContainer } from '../core';
 
 import { AnalysisList } from './MapVeuAnalysisList';
-import { MapVeuAnalysis } from './analysis/MapVeuAnalysis';
+import { MapAnalysis } from './analysis/MapAnalysis';
 
 import { StudyList } from './StudyList';
 import {
@@ -53,7 +53,7 @@ export function MapVeuContainer(props: Props) {
               computeClient={computeClient}
               className="MapVEu"
             >
-              <MapVeuAnalysis
+              <MapAnalysis
                 analysisId={props.match.params.analysisId}
                 studyId={props.match.params.studyId}
               />

--- a/src/lib/mapveu/MapVeuContainer.tsx
+++ b/src/lib/mapveu/MapVeuContainer.tsx
@@ -21,7 +21,12 @@ import {
 
 import './MapVEu.scss';
 
-export function MapVeuContainer() {
+interface Props {
+  singleAppMode?: string;
+}
+
+export function MapVeuContainer(props: Props) {
+  const { singleAppMode } = props;
   const edaClient = useConfiguredSubsettingClient('/eda-subsetting-service');
   const dataClient = useConfiguredDataClient('/eda-data-service');
   const computeClient = useConfiguredComputeClient('/eda-data-service');
@@ -70,6 +75,7 @@ export function MapVeuContainer() {
               <AnalysisList
                 studyId={props.match.params.studyId}
                 analysisStore={analysisClient}
+                singleAppMode={singleAppMode}
               />
             </EDAAnalysisListContainer>
           )}

--- a/src/lib/mapveu/MapVeuContainer.tsx
+++ b/src/lib/mapveu/MapVeuContainer.tsx
@@ -19,6 +19,8 @@ import {
   useConfiguredComputeClient,
 } from '../core/hooks/client';
 
+import './MapVEu.scss';
+
 export function MapVeuContainer() {
   const edaClient = useConfiguredSubsettingClient('/eda-subsetting-service');
   const dataClient = useConfiguredDataClient('/eda-data-service');
@@ -31,7 +33,6 @@ export function MapVeuContainer() {
   const { path } = useRouteMatch();
   return (
     <>
-      <h1>MapVEu</h1>
       <Switch>
         <Route
           path={`${path}/:studyId/:analysisId`}
@@ -45,6 +46,7 @@ export function MapVeuContainer() {
               dataClient={dataClient}
               downloadClient={downloadClient}
               computeClient={computeClient}
+              className="MapVEu"
             >
               <MapVeuAnalysis
                 analysisId={props.match.params.analysisId}
@@ -63,6 +65,7 @@ export function MapVeuContainer() {
               dataClient={dataClient}
               downloadClient={downloadClient}
               computeClient={computeClient}
+              className="MapVEu"
             >
               <AnalysisList
                 studyId={props.match.params.studyId}

--- a/src/lib/mapveu/analysis/FloatingDiv.tsx
+++ b/src/lib/mapveu/analysis/FloatingDiv.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export function FloatingDiv(props: {
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+}) {
+  if (!props.children) return null;
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        zIndex: 1,
+        padding: '1em',
+        backgroundColor: 'white',
+        border: '1px solid black',
+        ...props.style,
+      }}
+    >
+      {props.children}
+    </div>
+  );
+}

--- a/src/lib/mapveu/analysis/MapAnalysis.tsx
+++ b/src/lib/mapveu/analysis/MapAnalysis.tsx
@@ -243,6 +243,7 @@ export function MapAnalysisImpl(props: Props & CompleteAppState) {
       <div>
         <Tooltip title="Delete visualization">
           <button
+            aria-label={`Delete ${activeViz?.displayName || 'visualization.'}`}
             type="button"
             className="link"
             onClick={() => {
@@ -255,13 +256,16 @@ export function MapAnalysisImpl(props: Props & CompleteAppState) {
               setActiveVisualizationId(undefined);
             }}
           >
-            <i className="fa fa-trash"></i>
+            <i aria-hidden className="fa fa-trash"></i>
           </button>
         </Tooltip>
       </div>
       <div>
         <Tooltip title="Copy visualization">
           <button
+            aria-label={`Create a copy of ${
+              activeViz?.displayName || 'visualization.'
+            }`}
             type="button"
             className="link"
             onClick={() => {
@@ -279,7 +283,7 @@ export function MapAnalysisImpl(props: Props & CompleteAppState) {
               setActiveVisualizationId(vizCopyId);
             }}
           >
-            <i className="fa fa-clone"></i>
+            <i aria-hidden className="fa fa-clone"></i>
           </button>
         </Tooltip>
       </div>
@@ -291,7 +295,7 @@ export function MapAnalysisImpl(props: Props & CompleteAppState) {
             setActiveVisualizationId(undefined);
           }}
         >
-          <i className="fa fa-window-minimize" />
+          <i aria-hidden className="fa fa-window-minimize" />
         </Link>
       </Tooltip>
     </>

--- a/src/lib/mapveu/analysis/MapAnalysis.tsx
+++ b/src/lib/mapveu/analysis/MapAnalysis.tsx
@@ -90,7 +90,7 @@ interface Props {
   studyId: string;
 }
 
-export function MapVeuAnalysis(props: Props) {
+export function MapAnalysis(props: Props) {
   const { analysisId } = props;
   const studyRecord = useStudyRecord();
   const studyMetadata = useStudyMetadata();

--- a/src/lib/mapveu/analysis/MapAnalysis.tsx
+++ b/src/lib/mapveu/analysis/MapAnalysis.tsx
@@ -378,14 +378,14 @@ export function MapAnalysisImpl(props: Props & CompleteAppState) {
                 <ul>
                   {analysisState.analysis?.descriptor.computations.map(
                     (computation) => (
-                      <li>
+                      <li key={computation.computationId}>
                         <strong>
                           {computation.displayName} (
                           {computation.descriptor.type})
                         </strong>
                         <ul>
                           {computation.visualizations.map((viz) => (
-                            <li>
+                            <li key={viz.visualizationId}>
                               <button
                                 type="button"
                                 className="link"

--- a/src/lib/mapveu/analysis/MapLegend.tsx
+++ b/src/lib/mapveu/analysis/MapLegend.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PlotLegend from '@veupathdb/components/lib/components/plotControls/PlotLegend';
+import { LegendItemsProps } from '@veupathdb/components/lib/components/plotControls/PlotListLegend';
+
+interface Props {
+  legendItems: LegendItemsProps[];
+  title?: string;
+}
+
+export function MapLegend(props: Props) {
+  const { legendItems, title = 'Legend' } = props;
+  return (
+    <>
+      <div>
+        <strong>{title}</strong>
+      </div>
+      <PlotLegend
+        type="list"
+        legendItems={legendItems}
+        showOverlayLegend
+        checkedLegendItems={legendItems.map((item) => item.label)}
+        containerStyles={{
+          border: 'none',
+          boxShadow: 'none',
+          padding: 0,
+          width: 'auto',
+        }}
+      />
+    </>
+  );
+}

--- a/src/lib/mapveu/analysis/MapVeuAnalysis.tsx
+++ b/src/lib/mapveu/analysis/MapVeuAnalysis.tsx
@@ -13,41 +13,41 @@ import {
   useStudyEntities,
   useStudyMetadata,
   useStudyRecord,
-} from '../core';
+} from '../../core';
 import MapVEuMap from '@veupathdb/components/lib/map/MapVEuMap';
 import { BoundsViewport } from '@veupathdb/components/lib/map/Types';
-import { useGeoConfig } from '../core/hooks/geoConfig';
-import { useMapMarkers } from '../core/hooks/mapMarkers';
-import { InputVariables } from '../core/components/visualizations/InputVariables';
-import { useToggleStarredVariable } from '../core/hooks/starredVariables';
-import { DocumentationContainer } from '../core/components/docs/DocumentationContainer';
-import { VariableDescriptor } from '../core/types/variable';
+import { useGeoConfig } from '../../core/hooks/geoConfig';
+import { useMapMarkers } from '../../core/hooks/mapMarkers';
+import { InputVariables } from '../../core/components/visualizations/InputVariables';
+import { useToggleStarredVariable } from '../../core/hooks/starredVariables';
+import { DocumentationContainer } from '../../core/components/docs/DocumentationContainer';
+import { VariableDescriptor } from '../../core/types/variable';
 import PlotLegend from '@veupathdb/components/lib/components/plotControls/PlotLegend';
 import {
   FullScreenVisualization,
   NewVisualizationPickerModal,
-} from '../core/components/visualizations/VisualizationsContainer';
+} from '../../core/components/visualizations/VisualizationsContainer';
 import { FilledButton } from '@veupathdb/coreui';
-import { Visualization } from '../core/types/visualization';
-import { useEntityCounts } from '../core/hooks/entityCounts';
+import { Visualization } from '../../core/types/visualization';
+import { useEntityCounts } from '../../core/hooks/entityCounts';
 import { Tooltip } from '@material-ui/core';
 import { Link } from 'react-router-dom';
-import { ComputationPlugin } from '../core/components/computations/Types';
-import { ZeroConfigWithButton } from '../core/components/computations/ZeroConfiguration';
-import { histogramVisualization } from '../core/components/visualizations/implementations/HistogramVisualization';
-import { VisualizationPlugin } from '../core/components/visualizations/VisualizationPlugin';
-import { LayoutOptions } from '../core/components/layouts/types';
-import { OverlayOptions } from '../core/components/visualizations/options/types';
-import { FloatingLayout } from '../core/components/layouts/FloatingLayout';
+import { ComputationPlugin } from '../../core/components/computations/Types';
+import { ZeroConfigWithButton } from '../../core/components/computations/ZeroConfiguration';
+import { histogramVisualization } from '../../core/components/visualizations/implementations/HistogramVisualization';
+import { VisualizationPlugin } from '../../core/components/visualizations/VisualizationPlugin';
+import { LayoutOptions } from '../../core/components/layouts/types';
+import { OverlayOptions } from '../../core/components/visualizations/options/types';
+import { FloatingLayout } from '../../core/components/layouts/FloatingLayout';
 import {
   contTableVisualization,
   twoByTwoVisualization,
-} from '../core/components/visualizations/implementations/MosaicVisualization';
-import { scatterplotVisualization } from '../core/components/visualizations/implementations/ScatterplotVisualization';
-import { lineplotVisualization } from '../core/components/visualizations/implementations/LineplotVisualization';
-import { barplotVisualization } from '../core/components/visualizations/implementations/BarplotVisualization';
-import { boxplotVisualization } from '../core/components/visualizations/implementations/BoxplotVisualization';
-import ShowHideVariableContextProvider from '../core/utils/show-hide-variable-context';
+} from '../../core/components/visualizations/implementations/MosaicVisualization';
+import { scatterplotVisualization } from '../../core/components/visualizations/implementations/ScatterplotVisualization';
+import { lineplotVisualization } from '../../core/components/visualizations/implementations/LineplotVisualization';
+import { barplotVisualization } from '../../core/components/visualizations/implementations/BarplotVisualization';
+import { boxplotVisualization } from '../../core/components/visualizations/implementations/BoxplotVisualization';
+import ShowHideVariableContextProvider from '../../core/utils/show-hide-variable-context';
 import { getOrElse } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/function';
 

--- a/src/lib/mapveu/analysis/appState.ts
+++ b/src/lib/mapveu/analysis/appState.ts
@@ -1,0 +1,74 @@
+import { getOrElse } from 'fp-ts/lib/Either';
+import { pipe } from 'fp-ts/lib/function';
+import * as t from 'io-ts';
+import { useEffect, useState } from 'react';
+import { AnalysisState } from '../../core';
+import { VariableDescriptor } from '../../core/types/variable';
+
+export const AppState = t.intersection([
+  t.type({
+    viewport: t.type({
+      center: t.tuple([t.number, t.number]),
+      zoom: t.number,
+    }),
+    mouseMode: t.keyof({
+      default: null,
+      magnification: null,
+    }),
+  }),
+  t.partial({
+    selectedOverlayVariable: VariableDescriptor,
+    activeVisualizationId: t.string,
+  }),
+]);
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type AppState = t.TypeOf<typeof AppState>;
+
+const defaultAppState: AppState = {
+  viewport: {
+    center: [0, 0],
+    zoom: 4,
+  },
+  mouseMode: 'default',
+};
+
+export function useAppState(uiStateKey: string, analysisState: AnalysisState) {
+  const { setVariableUISettings } = analysisState;
+  const savedState = pipe(
+    AppState.decode(
+      analysisState.analysis?.descriptor.subset.uiSettings[uiStateKey]
+    ),
+    getOrElse(() => defaultAppState)
+  );
+  const [appState, setAppState] = useState<AppState>(savedState);
+
+  useEffect(() => {
+    setAppState(savedState);
+  }, [savedState]);
+
+  function makeSetter<T extends keyof AppState>(key: T) {
+    return function setter(value: AppState[T]) {
+      setVariableUISettings((prev) => ({
+        ...prev,
+        [uiStateKey]: {
+          ...appState,
+          [key]: value,
+        },
+      }));
+    };
+  }
+
+  const setViewport = makeSetter('viewport');
+  const setMouseMode = makeSetter('mouseMode');
+  const setSelectedOverlayVariable = makeSetter('selectedOverlayVariable');
+  const setActiveVisualizationId = makeSetter('activeVisualizationId');
+
+  return {
+    appState,
+    setViewport,
+    setMouseMode,
+    setSelectedOverlayVariable,
+    setActiveVisualizationId,
+  };
+}

--- a/src/lib/workspace/AnalysisPanel.tsx
+++ b/src/lib/workspace/AnalysisPanel.tsx
@@ -54,6 +54,7 @@ import { fullScreenAppPlugins } from '../core/components/fullScreenApps';
 import { FullScreenAppPlugin } from '../core/types/fullScreenApp';
 import FullScreenContainer from '../core/components/fullScreenApps/FullScreenContainer';
 import useUITheme from '@veupathdb/coreui/dist/components/theming/useUITheme';
+import { VariableLinkConfig } from '../core/components/VariableLink';
 
 const AnalysisTabErrorBoundary = ({
   children,
@@ -190,6 +191,21 @@ export function AnalysisPanel({
       : 'Analysis'
   );
 
+  const variableLinkConfig: VariableLinkConfig = {
+    type: 'link',
+    makeVariableLink: (value) => {
+      const { entityId, variableId } = value ?? {};
+      const linkBase = `${routeBase}/variables`;
+      if (entityId) {
+        if (variableId) {
+          return `${linkBase}/${entityId}/${variableId}`;
+        }
+        return `${linkBase}/${entityId}`;
+      }
+      return linkBase;
+    },
+  };
+
   if (status === Status.Error)
     return (
       <div>
@@ -261,6 +277,7 @@ export function AnalysisPanel({
                 )
               )
             }
+            variableLinkConfig={variableLinkConfig}
           />
           <Route
             path={[
@@ -291,6 +308,7 @@ export function AnalysisPanel({
                   entityCounts={totalCounts.value}
                   filteredEntityCounts={filteredCounts.value}
                   filteredEntities={filteredEntities}
+                  variableLinkConfig={variableLinkConfig}
                 />
               </div>
             )}
@@ -368,6 +386,7 @@ export function AnalysisPanel({
               <AnalysisTabErrorBoundary>
                 <Subsetting
                   {...props.match.params}
+                  variableLinkConfig={variableLinkConfig}
                   analysisState={analysisState}
                   totalCounts={totalCounts.value}
                   filteredCounts={filteredCounts.value}

--- a/src/lib/workspace/Subsetting/index.tsx
+++ b/src/lib/workspace/Subsetting/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
-import { Redirect, useHistory } from 'react-router';
+import { Redirect } from 'react-router';
 
-import { MultiFilterVariable, useMakeVariableLink, Variable } from '../../core';
+import { MultiFilterVariable, Variable } from '../../core';
 
 // Components
 import { VariableDetails } from '../Variable';
@@ -19,6 +19,7 @@ import { AnalysisState } from '../../core/hooks/analysis';
 // Functions
 import { cx } from '../Utils';
 import { findMultiFilterParent } from '../../core/utils/study-metadata';
+import { VariableLinkConfig } from '../../core/components/VariableLink';
 
 interface SubsettingProps {
   analysisState: AnalysisState;
@@ -31,6 +32,7 @@ interface SubsettingProps {
   variableId: string;
   totalCounts: EntityCounts | undefined;
   filteredCounts: EntityCounts | undefined;
+  variableLinkConfig: VariableLinkConfig;
 }
 
 /** Allow user to filter study data based on the value(s) of any available variable. */
@@ -40,6 +42,7 @@ export default function Subsetting({
   analysisState,
   totalCounts,
   filteredCounts,
+  variableLinkConfig,
 }: SubsettingProps) {
   // Obtain all entities and associated variables.
   const entities = useStudyEntities();
@@ -50,9 +53,7 @@ export default function Subsetting({
   // What is the current variable?
   const variable = entity?.variables.find((v) => v.id === variableId);
 
-  const history = useHistory();
   const filters = analysisState.analysis?.descriptor.subset.descriptor;
-  const makeVariableLink = useMakeVariableLink();
 
   const toggleStarredVariable = useToggleStarredVariable(analysisState);
 
@@ -89,14 +90,7 @@ export default function Subsetting({
           starredVariables={starredVariables}
           toggleStarredVariable={toggleStarredVariable}
           variableId={variable.id}
-          onChange={(variable) => {
-            if (variable) {
-              const { entityId, variableId } = variable;
-              const scrollPosition = [window.scrollX, window.scrollY];
-              history.push(makeVariableLink({ entityId, variableId }));
-              window.scrollTo(scrollPosition[0], scrollPosition[1]);
-            } else history.push('..');
-          }}
+          variableLinkConfig={variableLinkConfig}
         />
       </div>
       <div className="FilterChips">
@@ -110,6 +104,7 @@ export default function Subsetting({
               )
             )
           }
+          variableLinkConfig={variableLinkConfig}
           entities={entities}
           selectedEntityId={entity.id}
           selectedVariableId={variable.id}


### PR DESCRIPTION
fixes #1549
fixes #1546

This PRs revives the mapveu application. It is a starting point for further development and refinement. The goal is to provide the basic wiring and implemention of core features (state management, filtering, and visualizing).

### The following is included:

- [x] Added a link on the homepage to the mapveu app. When this is added to a website, the `MapVEuContainer` component will need to be integrated with that site's router.
- [x] Implemented basic map-based analysis in `MapVEuAnalysis` component, including "full screen" styling and crude overlay panels.
- [x] Persist state as a part of the analysis
- [x] Implement visualizations
- [x] (?) Implement crude subsetting panel
- [ ] Remove website header from view (or make it optional), in preparation for map-specific header drawer. This may require some work in WDKClient so that the header can be hidden **(Will be a follow-up)**
- [ ] ~Implement "viewport" filter~ Decided not to do this
- [ ] Rename "MapVEu" to something else. Perhaps just "Map". **(Partially done)**
