### PR TITLE
Rework marker tooltips to stack and assign n to denominator of y-axis proportion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.15.8",
+  "version": "3.15.9",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",
@@ -78,7 +78,7 @@
     "@types/react-table": "^7.7.12",
     "@types/uuid": "^8.3.4",
     "@veupathdb/browserslist-config": "^1.1.0",
-    "@veupathdb/components": "^0.19.17",
+    "@veupathdb/components": "^0.19.18",
     "@veupathdb/coreui": "^0.18.18",
     "@veupathdb/eslint-config": "^2.0.0",
     "@veupathdb/http-utils": "^1.1.0",

--- a/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -2273,9 +2273,7 @@ function processInputData(
               extraTooltipText: categoricalMode
                 ? el.binSampleSize.map(
                     (bss) =>
-                      `n: ${(bss as { numeratorN: number }).numeratorN}/${
-                        (bss as { denominatorN: number }).denominatorN
-                      }`
+                      `n: ${(bss as { denominatorN: number }).denominatorN}`
                   )
                 : el.binSampleSize.map(
                     (bss) => `n: ${(bss as { N: number }).N}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3554,10 +3554,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/browserslist-config/-/browserslist-config-1.1.0.tgz#5c7eecc048a91195404411d8729393197af0128c"
   integrity sha512-TQ58MbCy7UZN/h11HZ31CSJfywG17oDNHQzQJysj65Fvv2gAM1w7CjwCvV0bG3sRESKUDORSA7sJrVVv27GHBw==
 
-"@veupathdb/components@^0.19.17":
-  version "0.19.17"
-  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.19.17.tgz#82f6bf86fa4817062c1b97372954eac2cc630ee8"
-  integrity sha512-grFUE69YbBMSaLMAT05PmnorULxnte8aAsqIZfbuiHFTiC8Ylya4LJWI2c5wOlTwN50G9PbRrzAAO9gS7qFAYQ==
+"@veupathdb/components@^0.19.18":
+  version "0.19.18"
+  resolved "https://registry.yarnpkg.com/@veupathdb/components/-/components-0.19.18.tgz#c1f5ed76783cca6bf910c6b1025c9ad014285619"
+  integrity sha512-fBZBUi1wAEHtR74/lJ95eMhfWuRFgZ0mti/YqEm3omsIXuI5mpX4YyJA3zVlWJtg26B976/Po6hz+kAAWCdTcQ==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^5.46.0"
     "@typescript-eslint/parser" "^5.46.0"


### PR DESCRIPTION
Resolves https://github.com/VEuPathDB/EdaNewIssues/issues/547
Requires https://github.com/VEuPathDB/web-components/pull/446

Do note that the original intent was to only stack marker tooltips for points with identical data, but Plotly does not allow for this to be done easily. Thus, I ultimately leveraged Plotly's built-in `hovermode: 'x'` option as a low-cost alternative. Admittedly, this approach is "busy" when there are multiple overlay vars (see screenshot below).

It's also likely that we'd want to stack marker tooltips for points with _**nearly**_ identical data, as it can be difficult to distinguish between markers. (Note in first screenshot that Year 5 looks like only 5 data points, but Arm 5 and Arm 6 are nearly on top of each other.) This will likely add greater complexity if/when we only want to stack tooltips for points under certain "equality or "near-equality" conditions.

As a note for any follow-up work, I first attempted to leverage [Plotly's `onHover` and `onUnhover` event handlers](https://plotly.com/javascript/plotlyjs-events/#hover-event) to A) determine which data point was hovered over; B) find which other data points are equal to the hovered point, if any; C) try to display stacked markers for equal points. The main sticking point was step C. I zeroed in on the hover container via some methods in the [d3 library](https://github.com/d3/d3/blob/main/API.md#selections-d3-selection), but struggled to find a way to render the desired markers without major issues. Connor suggested [Plotly's Annotations API](https://plotly.com/javascript/reference/layout/annotations/), which may be a more viable option in the future. I briefly looked into `Annotations` in this context and it still seems non-trivial.

Before:
![image](https://user-images.githubusercontent.com/69446567/216158924-a6719751-c49f-4f40-a008-fdfddd0cb1cc.png)

After:
![image](https://user-images.githubusercontent.com/69446567/216158729-1be074ac-dfd6-4f3a-aace-f1d81424acca.png)