### PR TITLE
Add viz-specific compute config

### DIFF
--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -156,15 +156,19 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
   assertComputationWithConfig<AbundanceConfig>(computation, Computation);
 
   // Add visualization type specific computation configuration with plugin.additionalComputeConfig
-  // (for example, here scatterplot has as additional parameter that the boxplot does not need)
+  // (for example, here scatterplot and boxplot differ on the numberVariablesReturned param)
   // Only need to add this extra config when the config is empty.
-  const visualizationType = computation.visualizations.find(
+  const visualizationType: string = computation.visualizations.find(
     (viz) => viz.visualizationId === visualizationId
-  )?.descriptor.type;
+  )
+    ? computation.visualizations.find(
+        (viz) => viz.visualizationId === visualizationId
+      )!.descriptor.type
+    : '';
 
   if (!computation.descriptor.configuration) {
     computation.descriptor.configuration = {
-      ...plugin.visualizationPlugins[visualizationType as string]?.options
+      ...plugin.visualizationPlugins[visualizationType]?.options
         .additionalComputeConfig,
     };
   }

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -162,11 +162,14 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
   const visualizationType = computation.visualizations.find(
     (viz) => viz.visualizationId === visualizationId
   )?.descriptor.type;
-  computation.descriptor.configuration = {
-    ...computation.descriptor.configuration,
-    ...plugin.visualizationPlugins[visualizationType as string]?.options
-      .additionalComputeConfig,
-  };
+
+  if (!computation.descriptor.configuration) {
+    computation.descriptor.configuration = {
+      ...plugin.visualizationPlugins[visualizationType as string]?.options
+        .additionalComputeConfig,
+    };
+  }
+
   const configuration = computation.descriptor.configuration;
   console.log(configuration);
 

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -153,12 +153,11 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
   if (collections.length === 0)
     throw new Error('Could not find any collections for this app.');
 
-  console.log(computation.descriptor.configuration);
-
   assertComputationWithConfig<AbundanceConfig>(computation, Computation);
 
   // Add visualization type specific computation configuration with plugin.additionalComputeConfig
   // (for example, here scatterplot has as additional parameter that the boxplot does not need)
+  // Only need to add this extra config when the config is empty.
   const visualizationType = computation.visualizations.find(
     (viz) => viz.visualizationId === visualizationId
   )?.descriptor.type;
@@ -171,7 +170,6 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
   }
 
   const configuration = computation.descriptor.configuration;
-  console.log(configuration);
 
   const changeConfigHandler = useConfigChangeHandler<AbundanceConfig>(
     analysisState,

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -125,6 +125,7 @@ interface Options
   getComputedYAxisDetails?: (
     computeConfig: unknown
   ) => ComputedVariableDetails | undefined;
+  additionalComputeConfig?: unknown;
 }
 
 export const boxplotVisualization = createVisualizationPlugin({

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -566,8 +566,6 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
         valueSpecValue = 'bestFitLineWithRaw';
       }
 
-      console.log(computation.descriptor.configuration);
-
       // request params
       const params = {
         studyId,
@@ -583,10 +581,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
             : undefined,
           showMissingness: vizConfig.showMissingness ? 'TRUE' : 'FALSE',
         },
-        computeConfig: {
-          ...(computation.descriptor.configuration as object),
-          ...(options?.additionalComputeConfig as object),
-        },
+        computeConfig: computation.descriptor.configuration,
       };
 
       const response = await dataClient.getVisualizationData(

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -229,6 +229,7 @@ interface Options extends LayoutOptions, TitleOptions, OverlayOptions {
   getComputedOverlayVariable?(config: unknown): VariableDescriptor | undefined;
   hideTrendlines?: boolean;
   hideLogScale?: boolean;
+  additionalComputeConfig?: unknown;
 }
 
 function ScatterplotViz(props: VisualizationProps<Options>) {
@@ -565,6 +566,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
         valueSpecValue = 'bestFitLineWithRaw';
       }
 
+      console.log(computation.descriptor.configuration);
+
       // request params
       const params = {
         studyId,
@@ -580,7 +583,10 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
             : undefined,
           showMissingness: vizConfig.showMissingness ? 'TRUE' : 'FALSE',
         },
-        computeConfig: computation.descriptor.configuration,
+        computeConfig: {
+          ...(computation.descriptor.configuration as object),
+          ...(options?.additionalComputeConfig as object),
+        },
       };
 
       const response = await dataClient.getVisualizationData(
@@ -1372,8 +1378,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
   const [showBanner, setShowBanner] = useState(true);
 
   //DKDK
-  console.log('data =', data);
-  console.log('!showLogScaleBanner =', !showLogScaleBanner);
+  // console.log('data =', data);
+  // console.log('!showLogScaleBanner =', !showLogScaleBanner);
 
   const controlsNode = (
     <>


### PR DESCRIPTION
Resolves #1548 

## Important
This PR requires the `add-numbervarsreturned-abundance` branch from service-eda-compute.

In rare cases, the viz type affects what configuration the computation should use. Our first example is for ranked abundance. The computation returns 10 variables by default. The boxplot can handle 10 variables, since those vars are mapped to x axis values, but the scatterplot can only handle 8 variables because those vars are going to the overlay. 

History on the topic: This viz-specific configuration was handled in the data service before the compute service was wired up.

This PR adds `additionalComputeConfig` to a viz's options in the ranked abundance app. This way, the app plugin can control which config goes to which visualization. 

One issue i ran into while making this change was adding this extra bit to the compute config without making it think it's "updating", and thus re-requesting the compute, every 10 seconds. To fix this i added the conditional on the compute config being empty.