### PR TITLE
Display error messaging in download modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.15.9",
+  "version": "3.15.10",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
@@ -43,7 +43,7 @@ import {
   SortBy,
 } from '@veupathdb/coreui/dist/components/grids/DataGrid';
 import { stripHTML } from '@veupathdb/wdk-client/lib/Utils/DomUtils';
-import Error from '@veupathdb/wdk-client/lib/Components/PageStatus/Error';
+import Banner from '@veupathdb/coreui/dist/components/banners/Banner';
 
 type SubsetDownloadModalProps = {
   /** Should the modal currently be visible? */
@@ -257,11 +257,15 @@ export default function SubsetDownloadModal({
         })
         .catch((error: Error) => {
           const splitErrorMessage = error.message.split('\n');
-          setApiError({
-            status: splitErrorMessage[0],
-            message: splitErrorMessage[1],
-            requestID: '',
-          });
+          try {
+            setApiError(JSON.parse(splitErrorMessage[1]));
+          } catch (/* ignore JSON.parse error */ _) {
+            setApiError({
+              status: splitErrorMessage[0],
+              message: splitErrorMessage[1],
+              requestID: '',
+            });
+          }
         })
         .finally(() => {
           setDataLoading(false);
@@ -402,6 +406,14 @@ export default function SubsetDownloadModal({
             />
           )}
         </div>
+        {apiError && (
+          <Banner
+            banner={{
+              type: 'error',
+              message: apiError.status,
+            }}
+          />
+        )}
         {gridData ? (
           <div
             css={{
@@ -842,24 +854,7 @@ export default function SubsetDownloadModal({
           }}
         >
           {renderVariableSelectionArea()}
-          {apiError ? (
-            <Error>
-              <h2>Please try again later.</h2>
-              <br />
-              <span>
-                <strong>Error status: </strong> <br />
-                {apiError.status}
-              </span>
-              <br />
-              <br />
-              <span>
-                <strong>Error message:</strong> <br />
-                {apiError.message}
-              </span>
-            </Error>
-          ) : (
-            renderDataGridArea()
-          )}
+          {renderDataGridArea()}
         </div>
       </div>
     </Modal>

--- a/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
@@ -43,6 +43,7 @@ import {
   SortBy,
 } from '@veupathdb/coreui/dist/components/grids/DataGrid';
 import { stripHTML } from '@veupathdb/wdk-client/lib/Utils/DomUtils';
+import Error from '@veupathdb/wdk-client/lib/Components/PageStatus/Error';
 
 type SubsetDownloadModalProps = {
   /** Should the modal currently be visible? */
@@ -255,7 +256,12 @@ export default function SubsetDownloadModal({
           setGridData(data);
         })
         .catch((error: Error) => {
-          setApiError(JSON.parse(error.message.split('\n')[1]));
+          const splitErrorMessage = error.message.split('\n');
+          setApiError({
+            status: splitErrorMessage[0],
+            message: splitErrorMessage[1],
+            requestID: '',
+          });
         })
         .finally(() => {
           setDataLoading(false);
@@ -836,7 +842,24 @@ export default function SubsetDownloadModal({
           }}
         >
           {renderVariableSelectionArea()}
-          {renderDataGridArea()}
+          {apiError ? (
+            <Error>
+              <h2>Please try again later.</h2>
+              <br />
+              <span>
+                <strong>Error status: </strong> <br />
+                {apiError.status}
+              </span>
+              <br />
+              <br />
+              <span>
+                <strong>Error message:</strong> <br />
+                {apiError.message}
+              </span>
+            </Error>
+          ) : (
+            renderDataGridArea()
+          )}
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
Resolves #1522 

Displays a rudimentary message informing user of data fetching error. The error response expected in this component differed from what is currently being received. An error modal is being rendered as a result of this mismatch, but it appears behind the download modal. Instead, I've rendered the error in the download modal itself though it may be preferred to render it differently in terms of location, styling, and/or messaging.

**Before** (image 1 shows blank space where data grid is expected and one can faintly see the error modal behind the download modal; image 2 shows the error modal when the download modal is closed):
![image](https://user-images.githubusercontent.com/69446567/216402386-7b299576-b589-46a2-a831-f2788a431e6c.png)
![image](https://user-images.githubusercontent.com/69446567/216403362-bdabaa78-2400-469f-b577-1af544db2c2d.png)

**After** (notice there's no more error modal resulting from the `JSON.parse()` syntax error):
![image](https://user-images.githubusercontent.com/69446567/216402941-e07ac638-5d2d-4722-ae94-724de4e9f526.png)