### PR TITLE
use placeholderDisplayName if no variableId for y label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.15.7",
+  "version": "3.15.8",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/src/lib/core/components/computations/plugins/abundance.tsx
@@ -44,7 +44,7 @@ export const plugin: ComputationPlugin = {
         if (AbundanceConfig.is(config)) {
           return {
             entityId: config.collectionVariable.entityId,
-            placeholderDisplayName: 'Relative abundance',
+            placeholderDisplayName: 'Abundance',
           };
         }
       },
@@ -60,7 +60,7 @@ export const plugin: ComputationPlugin = {
         if (AbundanceConfig.is(config)) {
           return {
             entityId: config.collectionVariable.entityId,
-            placeholderDisplayName: 'Relative abundance',
+            placeholderDisplayName: 'Abundance',
           };
         }
       },

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1052,12 +1052,19 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     'X-axis'
   );
 
-  const dependentAxisLabel = getVariableLabel(
-    'yAxis',
-    data.value?.computedVariableMetadata,
-    entities,
-    'Y-axis'
-  );
+  // If we're to use a computed variable but no variableId is given for the computed variable,
+  // simply use the placeholder display name given by the app.
+  // Otherwise, create the dependend axis label as usual.
+  const dependentAxisLabel =
+    computedYAxisDetails?.placeholderDisplayName &&
+    !computedYAxisDetails?.variableId
+      ? computedYAxisDetails.placeholderDisplayName
+      : getVariableLabel(
+          'yAxis',
+          data.value?.computedVariableMetadata,
+          entities,
+          'Y-axis'
+        );
 
   // dataWithoutSmoothedMean returns array of data that does not have smoothed mean
   // Thus, if dataWithoutSmoothedMean.length > 0, then there is at least one data without smoothed mean
@@ -1372,8 +1379,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
   const [showBanner, setShowBanner] = useState(true);
 
   //DKDK
-  console.log('data =', data);
-  console.log('!showLogScaleBanner =', !showLogScaleBanner);
+  // console.log('data =', data);
+  // console.log('!showLogScaleBanner =', !showLogScaleBanner);
 
   const controlsNode = (
     <>


### PR DESCRIPTION
Resolves #1585 

Previously the scatterplot was showing a value returned by the compute. This PR tells the scatterplot to use the placeholder name given by the abundance app instead of the variable display name returned by the compute, when a true variable isn't actually going to be returned.

I saw two options for solving this issue. The first is what i've done here, and the second is to update [this line](https://github.com/VEuPathDB/microbiomeComputations/blob/1516c3e626d58c5cf06a757bd1c32029c513e5c6/R/method-rankedAbundance.R#L85) with a nicer display name. 

I chose this route of updating the frontend because eventually this display name should be driven by collection variable metadata (that doesn't exist yet). The compute, however, does not know about collection metadata. It's called "Ranked Abundance" but really it could rank any type of data (for example, it also currently can be used to rank pathway coverage data. Anyways, once the collection variable metadata with display name does exist, we would plug that into the relevant part of the plugin Options.

Tested on mbio and clinepi