### PR TITLE
Fix/1582/apps grayout emptyplot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.15.11",
+  "version": "3.15.12",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -10,6 +10,7 @@ import {
   Visualization,
   VisualizationOverview,
 } from '../../types/visualization';
+import { JobStatus } from '../computations/ComputeJobStatusHook';
 
 /**
  * Props passed to viz components
@@ -29,6 +30,7 @@ export interface VisualizationProps<Options = undefined> {
   filteredCounts: PromiseHookState<EntityCounts>;
   geoConfigs: GeoConfig[];
   otherVizOverviews: VisualizationOverview[];
+  computeJobStatus?: JobStatus;
 }
 
 export interface IsEnabledInPickerParams {

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -724,43 +724,7 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
               isStepDisabled={computeJobStatus !== 'complete'}
             >
               <div style={{ marginLeft: '3em' }}>
-                {computeJobStatus !== 'complete' ? (
-                  computeJobStatus == null &&
-                  isComputationConfigurationValid ? (
-                    <Loading />
-                  ) : (
-                    <div
-                      style={{
-                        margin: '2em 0',
-                        fontSize: '1.2em',
-                        display: 'flex',
-                        justifyContent: 'flex-start',
-                        gap: '2ex',
-                        flexDirection: 'column',
-                      }}
-                    >
-                      <H5>
-                        {computeJobStatus === 'requesting'
-                          ? 'Requesting computation status.'
-                          : computeJobStatus === 'no-such-job' ||
-                            !computeJobStatus
-                          ? 'Configure and run a computation to use this visualization.'
-                          : computeJobStatus === 'expired'
-                          ? 'Computation has expired. You will need to run it again.'
-                          : computeJobStatus === 'failed'
-                          ? 'Computation has failed. Please contact us for support.'
-                          : 'Computation is in progress. This visualization will be available when it is complete.'}
-                      </H5>
-                      {/* Add image for some compute statuses} */}
-                      {(computeJobStatus == 'no-such-job' ||
-                        !computeJobStatus) && <EmptyPlotSVG />}
-                      {computeJobStatus &&
-                        !isTerminalStatus(computeJobStatus) && (
-                          <RelaxMicrobeSVG />
-                        )}
-                    </div>
-                  )
-                ) : (
+                {computationAppOverview.computeName && (
                   <vizPlugin.fullscreenComponent
                     options={vizPlugin.options}
                     dataElementConstraints={constraints}
@@ -778,6 +742,7 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
                     filteredCounts={filteredCounts}
                     geoConfigs={geoConfigs}
                     otherVizOverviews={overviews.others}
+                    computeJobStatus={computeJobStatus}
                   />
                 )}
               </div>
@@ -800,6 +765,7 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
               filteredCounts={filteredCounts}
               geoConfigs={geoConfigs}
               otherVizOverviews={overviews.others}
+              computeJobStatus={computeJobStatus}
             />
           )}
         </div>

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -724,27 +724,25 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
               isStepDisabled={computeJobStatus !== 'complete'}
             >
               <div style={{ marginLeft: '3em' }}>
-                {computationAppOverview.computeName && (
-                  <vizPlugin.fullscreenComponent
-                    options={vizPlugin.options}
-                    dataElementConstraints={constraints}
-                    dataElementDependencyOrder={dataElementDependencyOrder}
-                    visualization={viz}
-                    computation={computation}
-                    filters={filters}
-                    starredVariables={starredVariables}
-                    toggleStarredVariable={toggleStarredVariable}
-                    updateConfiguration={updateConfiguration}
-                    updateThumbnail={
-                      disableThumbnailCreation ? undefined : updateThumbnail
-                    }
-                    totalCounts={totalCounts}
-                    filteredCounts={filteredCounts}
-                    geoConfigs={geoConfigs}
-                    otherVizOverviews={overviews.others}
-                    computeJobStatus={computeJobStatus}
-                  />
-                )}
+                <vizPlugin.fullscreenComponent
+                  options={vizPlugin.options}
+                  dataElementConstraints={constraints}
+                  dataElementDependencyOrder={dataElementDependencyOrder}
+                  visualization={viz}
+                  computation={computation}
+                  filters={filters}
+                  starredVariables={starredVariables}
+                  toggleStarredVariable={toggleStarredVariable}
+                  updateConfiguration={updateConfiguration}
+                  updateThumbnail={
+                    disableThumbnailCreation ? undefined : updateThumbnail
+                  }
+                  totalCounts={totalCounts}
+                  filteredCounts={filteredCounts}
+                  geoConfigs={geoConfigs}
+                  otherVizOverviews={overviews.others}
+                  computeJobStatus={computeJobStatus}
+                />
               </div>
             </ComputationStepContainer>
           ) : (

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -179,7 +179,6 @@ function BoxplotViz(props: VisualizationProps<Options>) {
   const { id: studyId } = studyMetadata;
   const entities = useStudyEntities();
   const dataClient: DataClient = useDataClient();
-  console.log(computeJobStatus);
 
   const [vizConfig, updateVizConfig] = useVizConfig(
     visualization.descriptor.configuration,
@@ -352,7 +351,9 @@ function BoxplotViz(props: VisualizationProps<Options>) {
       )
         return undefined;
 
-      if (computeJobStatus !== 'complete') return undefined;
+      // If this boxplot has a computed variable and the compute job is anything but complete, do not proceed with getting data.
+      if (computedYAxisDetails && computeJobStatus !== 'complete')
+        return undefined;
 
       if (
         !variablesAreUnique([
@@ -363,8 +364,6 @@ function BoxplotViz(props: VisualizationProps<Options>) {
         ])
       )
         throw new Error(nonUniqueWarning);
-
-      console.log('getting data');
 
       // add visualization.type here. valueSpec too?
       const params = {
@@ -393,8 +392,6 @@ function BoxplotViz(props: VisualizationProps<Options>) {
         params,
         BoxplotResponse
       );
-
-      console.log(response);
 
       const showMissingOverlay =
         vizConfig.showMissingness &&
@@ -453,6 +450,7 @@ function BoxplotViz(props: VisualizationProps<Options>) {
       xAxisVariable,
       computation.descriptor.configuration,
       computation.descriptor.type,
+      computeJobStatus,
       yAxisVariable,
       outputEntity,
       filteredCounts.pending,

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -173,11 +173,13 @@ function BoxplotViz(props: VisualizationProps<Options>) {
     toggleStarredVariable,
     totalCounts,
     filteredCounts,
+    computeJobStatus,
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
   const entities = useStudyEntities();
   const dataClient: DataClient = useDataClient();
+  console.log(computeJobStatus);
 
   const [vizConfig, updateVizConfig] = useVizConfig(
     visualization.descriptor.configuration,
@@ -350,6 +352,8 @@ function BoxplotViz(props: VisualizationProps<Options>) {
       )
         return undefined;
 
+      if (computeJobStatus !== 'complete') return undefined;
+
       if (
         !variablesAreUnique([
           xAxisVariable,
@@ -359,6 +363,8 @@ function BoxplotViz(props: VisualizationProps<Options>) {
         ])
       )
         throw new Error(nonUniqueWarning);
+
+      console.log('getting data');
 
       // add visualization.type here. valueSpec too?
       const params = {
@@ -387,6 +393,8 @@ function BoxplotViz(props: VisualizationProps<Options>) {
         params,
         BoxplotResponse
       );
+
+      console.log(response);
 
       const showMissingOverlay =
         vizConfig.showMissingness &&

--- a/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -245,6 +245,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     toggleStarredVariable,
     totalCounts,
     filteredCounts,
+    computeJobStatus,
   } = props;
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
@@ -520,6 +521,10 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
 
   const data = usePromise(
     useCallback(async (): Promise<ScatterPlotDataWithCoverage | undefined> => {
+      // If this scatterplot has a computed variable and the compute job is anything but complete, do not proceed with getting data.
+      if (computedYAxisDetails && computeJobStatus !== 'complete')
+        return undefined;
+
       if (
         outputEntity == null ||
         filteredCounts.pending ||
@@ -706,6 +711,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
       filteredCounts,
       computation.descriptor.configuration,
       computation.descriptor.type,
+      computeJobStatus,
       providedOverlayVariable,
       showLogScaleBanner,
       // // get data when changing independentAxisRange


### PR DESCRIPTION
Resolves #1582 

First, removed the compute status svgs from rendering following @jernestmyers 's work in https://github.com/VEuPathDB/web-eda/pull/1577.

Second, had viz listen to the `computeJobStatus` and prevented them from asking for data if the compute was not complete. To test this part, create a plot in an app (have to create the whole plot, like in alpha div actually pick an x axis var and everything), then go change config to one that has not yet been run. There should be no error now :)

Tested on all three mbio compute apps, mbio XY Relationships scatter, Distributions box, and clinepi vizs.

Another note - the jobs sometimes autostart when selecting config. So for example i'll select compute params, see that there's no such job, change params, go back to the original and now woah there's a complete result! This was preexisting behavior, and i'll make a new ticket for this.
