### PR TITLE
remove evenness from alpha div

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "3.15.10",
+  "version": "3.15.11",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -106,7 +106,7 @@ function AlphaDivConfigDescriptionComponent({
 }
 
 // Include available methods in this array.
-const ALPHA_DIV_METHODS = ['shannon', 'simpson', 'evenness'];
+const ALPHA_DIV_METHODS = ['shannon', 'simpson'];
 
 export function AlphaDivConfiguration(props: ComputationConfigProps) {
   const {


### PR DESCRIPTION
Resolves #1598 

Removes the 'evenness' method from alpha diversity. Pretty straightforward :) 

Before:
<img width="835" alt="Screen Shot 2023-02-06 at 10 30 09 AM" src="https://user-images.githubusercontent.com/11710234/217013533-190239d3-7faf-47ca-8b1e-9fa03fb3a986.png">

After:
<img width="817" alt="Screen Shot 2023-02-06 at 10 30 32 AM" src="https://user-images.githubusercontent.com/11710234/217013626-b95a0380-c8fa-4f97-9378-cdd929b738e5.png">
