### PR TITLE
improve dependent axis label display name logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -49,6 +49,7 @@ import {
   vocabularyWithMissingData,
   fixVarIdLabels,
   fixVarIdLabel,
+  getVariableLabel,
 } from '../../../utils/visualization';
 import { VariablesByInputName } from '../../../utils/data-element-constraints';
 import { StudyEntity, Variable } from '../../../types/study';
@@ -557,10 +558,19 @@ function BoxplotViz(props: VisualizationProps<Options>) {
     variableDisplayWithUnit(xAxisVariable) ??
     'X-axis';
 
+  // If we're to use a computed variable but no variableId is given for the computed variable,
+  // use the placeholder display name given by the app.
+  // Otherwise, create the dependent axis label as usual.
   const dependentAxisLabel =
-    computedYAxisDetails?.placeholderDisplayName ??
-    variableDisplayWithUnit(yAxisVariable) ??
-    'Y-axis';
+    computedYAxisDetails?.placeholderDisplayName &&
+    !computedYAxisDetails?.variableId
+      ? computedYAxisDetails.placeholderDisplayName
+      : getVariableLabel(
+          'yAxis',
+          data.value?.computedVariableMetadata,
+          entities,
+          'Y-axis'
+        );
 
   const overlayLabel = variableDisplayWithUnit(overlayVariable);
   const neutralPaletteProps = useNeutralPaletteProps(


### PR DESCRIPTION
Resolves #1626 

Adds logic to the boxplot that shows the alpha div metric on the y axis instead of the generic "Alpha diversity" label. 

Nothing too exciting!