### PR TITLE
Mosaic 2x2 banners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -66,6 +66,7 @@ import { useInputStyles } from '../inputStyles';
 import { ClearSelectionButton } from '../../variableTrees/VariableTreeDropdown';
 import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 import { MEDIUM_GRAY } from '@veupathdb/components/lib/constants/colors';
+import Banner from '@veupathdb/coreui/dist/components/banners/Banner';
 
 const plotContainerStyles = {
   width: 750,
@@ -540,40 +541,74 @@ function MosaicViz(props: Props<Options>) {
             ? vizConfig.showMissingness
               ? 'Statistics are not calculated when the "include no data" option is selected'
               : facetVariable != null && (
-                  <div
-                    style={{
-                      ...facetedStatsTableContainerStyles,
-                      margin: '15px 0',
-                    }}
-                  >
-                    {data.value.facets.map(({ label, data }, index) => (
-                      <table key={index}>
-                        <tbody>
-                          <tr style={{ marginLeft: '0.9em' }}>
-                            <th
-                              style={{
-                                border: 'none' /* cancel WDK style! */,
-                              }}
-                            >
-                              {facetVariable.displayName}: {label}
-                            </th>
-                          </tr>
-                          <tr>
-                            <td>
-                              {/* {' '} */}
-                              {isTwoByTwo
-                                ? TwoByTwoStats(
-                                    data as TwoByTwoData | undefined
-                                  )
-                                : ContTableStats(
-                                    data as ContTableData | undefined
-                                  )}
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    ))}
-                  </div>
+                  <>
+                    {/* 2x2 stats table banner for facet variable */}
+                    {isTwoByTwo && (
+                      <div
+                        style={{
+                          width: '750px',
+                        }}
+                      >
+                        {/* 2x2 stats collapsible banner */}
+                        <Banner
+                          banner={{
+                            type: 'info',
+                            // message is used as a basic text
+                            message:
+                              'Learn about appropriate statistics for each study design.',
+                            pinned: true,
+                            intense: false,
+                            additionalMessage: undefined,
+                            // text for showMore link
+                            showMoreLinkText: 'Read more...',
+                            // text for showless link
+                            showLessLinkText: 'Read less...',
+                            // color for show more links
+                            showMoreLinkColor: '#000000',
+                            // is showMoreLink bold?
+                            isShowMoreLinkBold: true,
+                          }}
+                          onClose={() => null}
+                          // collapsible content: React.FC
+                          CollapsibleContent={StatsCollapsibleBannerContent}
+                        />
+                      </div>
+                    )}
+                    <div
+                      style={{
+                        ...facetedStatsTableContainerStyles,
+                        margin: '15px 0',
+                      }}
+                    >
+                      {data.value.facets.map(({ label, data }, index) => (
+                        <table key={index}>
+                          <tbody>
+                            <tr style={{ marginLeft: '0.9em' }}>
+                              <th
+                                style={{
+                                  border: 'none' /* cancel WDK style! */,
+                                }}
+                              >
+                                {facetVariable.displayName}: {label}
+                              </th>
+                            </tr>
+                            <tr>
+                              <td>
+                                {/* {' '} */}
+                                {isTwoByTwo
+                                  ? TwoByTwoStats(
+                                      data as TwoByTwoData | undefined
+                                    )
+                                  : ContTableStats(
+                                      data as ContTableData | undefined
+                                    )}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      ))}
+                    </div>
+                  </>
                 )
             : isTwoByTwo
             ? TwoByTwoStats(data.value as TwoByTwoData | undefined)
@@ -736,80 +771,494 @@ function MosaicViz(props: Props<Options>) {
         },
       ];
 
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
-        <InputVariables
-          inputs={[
-            {
-              name: 'xAxisVariable',
-              label: isTwoByTwo ? 'Columns (X-axis)' : 'X-axis',
-              role: 'axis',
-              titleOverride: isTwoByTwo ? '2x2 table variables' : undefined,
-              styleOverride: isTwoByTwo ? twoBytwoInputStyle : undefined,
-            },
-            {
-              name: 'yAxisVariable',
-              label: isTwoByTwo ? 'Rows (Y-axis)' : 'Y-axis',
-              role: 'axis',
-              titleOverride: isTwoByTwo ? '2x2 table variables' : undefined,
-              styleOverride: isTwoByTwo ? twoBytwoInputStyle : undefined,
-            },
-            ...(options?.hideFacetInputs
-              ? []
-              : [
-                  {
-                    name: 'facetVariable',
-                    label: 'Facet',
-                    role: 'stratification',
-                  } as const,
-                ]),
-          ]}
-          customSections={isTwoByTwo ? twoByTwoReferenceValueInputs : undefined}
-          entities={entities}
-          selectedVariables={{
-            xAxisVariable: vizConfig.xAxisVariable,
-            yAxisVariable: vizConfig.yAxisVariable,
-            facetVariable: vizConfig.facetVariable,
+  // 2x2 more information box banner content
+  const MoreInfoBoxBanner = () => {
+    const tableCellStyle = {
+      border: '1px solid black',
+      borderSpacing: '0px',
+      width: '7em',
+    };
+
+    return (
+      <>
+        The shorthand "A, B, C, D" is used to refer to specific quadrants in the
+        2x2 table:
+        <table
+          style={{
+            borderCollapse: 'collapse',
+            marginTop: '1em',
+            textAlign: 'center',
           }}
-          onChange={handleInputVariableChange}
-          constraints={dataElementConstraints}
-          dataElementDependencyOrder={dataElementDependencyOrder}
-          starredVariables={starredVariables}
-          toggleStarredVariable={toggleStarredVariable}
-          enableShowMissingnessToggle={
-            facetVariable != null &&
-            data.value?.completeCasesAllVars !==
-              data.value?.completeCasesAxesVars
+        >
+          <tr>
+            <td style={{ width: '10em' }}>&nbsp;</td>
+            <td colSpan={3}>
+              <b>
+                Columns (X-axis):
+                <br />
+              </b>{' '}
+              outcome/disease status;
+              <br />
+              gold standard/reference test result
+            </td>
+          </tr>
+          <tr>
+            <td rowSpan={3}>
+              <b>Rows (Y-axis):</b>
+              <br />
+              exposure/risk factor; <br />
+              diagnostic test result
+            </td>
+            <td style={tableCellStyle}>&nbsp;</td>
+            <td style={tableCellStyle}>
+              <b>+</b>
+            </td>
+            <td style={tableCellStyle}>
+              <b>-</b>
+            </td>
+          </tr>
+          <tr>
+            <td style={tableCellStyle}>
+              <b>+</b>
+            </td>
+            <td style={tableCellStyle}>
+              <b>A</b>
+            </td>
+            <td style={tableCellStyle}>
+              <b>B</b>
+            </td>
+          </tr>
+          <tr>
+            <td style={tableCellStyle}>
+              <b>-</b>
+            </td>
+            <td style={tableCellStyle}>
+              <b>C</b>
+            </td>
+            <td style={tableCellStyle}>
+              <b>D</b>
+            </td>
+          </tr>
+        </table>
+        <br />
+        <b>
+          <i>If you want to investigate a measure of association:</i>
+        </b>
+        <ul>
+          <li>
+            Columns (X-axis): select a value for Quadrant A representing the
+            outcome or disease status of interest.
+          </li>
+          <li>
+            Rows (Y-axis): select a value for Quadrant A representing the
+            exposure or risk factor of interest.
+          </li>
+        </ul>
+        <br />
+        <b>
+          <i>If you want to investigate diagnostic test performance:</i>
+        </b>
+        <ul>
+          <li>
+            Columns (X-axis): select a value for Quadrant A representing a
+            positive result for the reference (gold standard) diagnostic test.
+          </li>
+          <li>
+            Rows (Y-axis): select values for Quadrant A representing a positive
+            result for the diagnostic test being evaluated.
+          </li>
+        </ul>
+      </>
+    );
+  };
+
+  return (
+    <>
+      {/* 2x2 more information box banner */}
+      {isTwoByTwo && (
+        <div>
+          <Banner
+            banner={{
+              type: 'info',
+              // message is used as a basic text
+              message:
+                'Learn how to set up a 2x2 table in order for statistics to be calculated correctly.',
+              pinned: true,
+              intense: false,
+              additionalMessage: undefined,
+              // text for showMore link
+              showMoreLinkText: 'Read more...',
+              // text for showless link
+              showLessLinkText: 'Read less...',
+              // color for show more links
+              showMoreLinkColor: '#000000',
+              // is showMoreLink bold?
+              isShowMoreLinkBold: true,
+            }}
+            onClose={() => null}
+            // collapsible content: React.FC
+            CollapsibleContent={MoreInfoBoxBanner}
+          />
+        </div>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
+          <InputVariables
+            inputs={[
+              {
+                name: 'xAxisVariable',
+                label: isTwoByTwo ? 'Columns (X-axis)' : 'X-axis',
+                role: 'axis',
+                titleOverride: isTwoByTwo ? '2x2 table variables' : undefined,
+                styleOverride: isTwoByTwo ? twoBytwoInputStyle : undefined,
+              },
+              {
+                name: 'yAxisVariable',
+                label: isTwoByTwo ? 'Rows (Y-axis)' : 'Y-axis',
+                role: 'axis',
+                titleOverride: isTwoByTwo ? '2x2 table variables' : undefined,
+                styleOverride: isTwoByTwo ? twoBytwoInputStyle : undefined,
+              },
+              ...(options?.hideFacetInputs
+                ? []
+                : [
+                    {
+                      name: 'facetVariable',
+                      label: 'Facet',
+                      role: 'stratification',
+                    } as const,
+                  ]),
+            ]}
+            customSections={
+              isTwoByTwo ? twoByTwoReferenceValueInputs : undefined
+            }
+            entities={entities}
+            selectedVariables={{
+              xAxisVariable: vizConfig.xAxisVariable,
+              yAxisVariable: vizConfig.yAxisVariable,
+              facetVariable: vizConfig.facetVariable,
+            }}
+            onChange={handleInputVariableChange}
+            constraints={dataElementConstraints}
+            dataElementDependencyOrder={dataElementDependencyOrder}
+            starredVariables={starredVariables}
+            toggleStarredVariable={toggleStarredVariable}
+            enableShowMissingnessToggle={
+              facetVariable != null &&
+              data.value?.completeCasesAllVars !==
+                data.value?.completeCasesAxesVars
+            }
+            showMissingness={vizConfig.showMissingness}
+            // this can be used to show and hide no data control
+            onShowMissingnessChange={
+              computation.descriptor.type === 'pass'
+                ? onShowMissingnessChange
+                : undefined
+            }
+            outputEntity={outputEntity}
+          />
+        </div>
+
+        <PluginError error={data.error} outputSize={outputSize} />
+        <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
+        <LayoutComponent
+          isFaceted={isFaceted(data.value)}
+          plotNode={plotNode}
+          controlsNode={controlsNode}
+          tableGroupNode={tableGroupNode}
+          // statistics tab is disabled in 2x2, so no need to prompt for required inputs
+          showRequiredInputsPrompt={
+            !areRequiredInputsSelected &&
+            !(isTwoByTwo && activeTab === 'Statistics')
           }
-          showMissingness={vizConfig.showMissingness}
-          // this can be used to show and hide no data control
-          onShowMissingnessChange={
-            computation.descriptor.type === 'pass'
-              ? onShowMissingnessChange
-              : undefined
-          }
-          outputEntity={outputEntity}
+          isMosaicPlot={true}
         />
       </div>
-
-      <PluginError error={data.error} outputSize={outputSize} />
-      <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
-      <LayoutComponent
-        isFaceted={isFaceted(data.value)}
-        plotNode={plotNode}
-        controlsNode={controlsNode}
-        tableGroupNode={tableGroupNode}
-        // statistics tab is disabled in 2x2, so no need to prompt for required inputs
-        showRequiredInputsPrompt={
-          !areRequiredInputsSelected &&
-          !(isTwoByTwo && activeTab === 'Statistics')
-        }
-        isMosaicPlot={true}
-      />
-    </div>
+    </>
   );
 }
+
+// 2x2 stats table content
+const StatsCollapsibleBannerContent = () => {
+  const tableCellStyleNormal = {
+    border: '1px solid black',
+    borderSpacing: '0px',
+    width: '7em',
+  };
+
+  const tableCellStyleMoreWidth = {
+    border: '1px solid black',
+    borderSpacing: '0px',
+    width: '8em',
+  };
+
+  const tableCellStyleBold = {
+    border: '1px solid black',
+    borderSpacing: '0px',
+    width: '7em',
+  };
+
+  return (
+    <div>
+      The appropriate measure of association or diagnostic test performance
+      depends on the study design. The shorthand "A, B, C, D" is used to refer
+      to specific quadrants in the 2x2 contingency table:
+      <table
+        style={{
+          borderCollapse: 'collapse',
+          marginTop: '1em',
+          textAlign: 'center',
+        }}
+      >
+        <tr>
+          <td style={{ width: '10em' }}>&nbsp;</td>
+          <td colSpan={4}>
+            <b>
+              Columns (X-axis):
+              <br />
+            </b>{' '}
+            outcome/disease status;
+            <br />
+            gold standard/reference test result
+          </td>
+        </tr>
+        <tr>
+          <td rowSpan={4}>
+            <b>Rows (Y-axis):</b>
+            <br />
+            exposure/risk factor; <br />
+            diagnostic test result
+          </td>
+          <td style={tableCellStyleBold}>&nbsp;</td>
+          <td style={tableCellStyleBold}>
+            <b>+</b>
+          </td>
+          <td style={tableCellStyleBold}>
+            <b>-</b>
+          </td>
+          <td style={tableCellStyleMoreWidth}>
+            <i>Row Totals</i>
+          </td>
+        </tr>
+        <tr>
+          <td style={tableCellStyleBold}>
+            <b>+</b>
+          </td>
+          <td style={tableCellStyleBold}>
+            <b>A</b>
+          </td>
+          <td style={tableCellStyleBold}>
+            <b>B</b>
+          </td>
+          <td style={tableCellStyleMoreWidth}>
+            <i>A + B</i>
+          </td>
+        </tr>
+        <tr>
+          <td style={tableCellStyleBold}>
+            <b>-</b>
+          </td>
+          <td style={tableCellStyleBold}>
+            <b>C</b>
+          </td>
+          <td style={tableCellStyleBold}>
+            <b>D</b>
+          </td>
+          <td style={tableCellStyleMoreWidth}>
+            <i>C + D</i>
+          </td>
+        </tr>
+        <tr>
+          <td style={tableCellStyleNormal}>
+            <i>Column Totals</i>
+          </td>
+          <td style={tableCellStyleNormal}>
+            <i>A + C</i>
+          </td>
+          <td style={tableCellStyleNormal}>
+            <i>B + D</i>
+          </td>
+          <td style={tableCellStyleMoreWidth}>
+            <i>n = A + B + C + D</i>
+          </td>
+        </tr>
+      </table>
+      <br />
+      <b>All studies:</b>
+      <ul>
+        <li>
+          <b>
+            <i>
+              Chi-squared Statistic (&chi;<sup>2</sup>)
+            </i>
+          </b>
+          : &Sigma; (O<sub>i</sub> - EO<sub>i</sub>)<sup>2</sup> / EO
+          <sub>i</sub>
+          <ul>
+            <li>
+              Tests whether there is an association between the two 2x2 table
+              variables.
+            </li>
+            <li>If sample sizes are small, use Fisher’s Exact Test.</li>
+            <li>
+              For more information, see:{' '}
+              <a
+                href="https://www.bmj.com/about-bmj/resources-readers/publications/statistics-square-one/8-chi-squared-tests"
+                target="_blank"
+              >
+                https://www.bmj.com/about-bmj/resources-readers/publications/statistics-square-one/8-chi-squared-tests
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <b>
+            <i>Fisher’s Exact Test</i>
+          </b>
+          : [ (A + B)! (C + D)! (A + C)! (B + D)! ] / ( A! B! C! D! n! )
+          <ul>
+            <li>
+              Tests whether there is an association between the two 2x2 table
+              variables.
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <br />
+      <b>Studies that use prevalence data:</b>
+      <br />
+      <u>Cross-sectional Studies:</u>
+      <ul>
+        <li>
+          <b>
+            <i>Prevalence</i>
+          </b>
+          : (A + C) / (A + B + C + D)
+        </li>
+        <ul>
+          <li>
+            The proportion of the population who have the disease specified in
+            the columns (X-axis) at the examined point in time was [
+            <i>Prevalence</i>].
+          </li>
+        </ul>
+        <li>
+          <b>
+            <i>Odds Ratio</i>
+          </b>
+          : (A / B) / (C / D)
+        </li>
+        <ul>
+          <li>
+            The odds of having the disease specified in the columns (X-axis) was
+            [<i>Odds Ratio</i>] times as high in those exposed to the potential
+            risk factor indicated in the rows (Y-axis), as compared to those
+            unexposed.
+          </li>
+        </ul>
+      </ul>
+      <u>Case-Control Studies:</u>
+      <ul>
+        <li>
+          <b>
+            <i>Odds Ratio</i>
+          </b>
+          : (A / B) / (C / D)
+        </li>
+        <ul>
+          <li>
+            The odds of having the disease specified in the columns (X-axis) was
+            [<i>Odds Ratio</i>] times as high in those exposed to the potential
+            risk factor indicated in the rows (Y-axis) in the time period of
+            interest, as compared to those unexposed.
+          </li>
+        </ul>
+      </ul>
+      <br />
+      <b>Studies that use incidence data:</b>
+      <br />
+      <u>Cohort Studies and Randomized Controlled Trials:</u>
+      <ul>
+        <li>
+          <b>
+            <i>Risk Ratio</i>
+          </b>{' '}
+          (for studies using a population at risk approach): [A / (A + B)] / [C
+          / (C + D)]
+        </li>
+        <ul>
+          <li>
+            The risk of having the disease specified in the columns (X-axis)
+            over the follow-up period was [<i>Risk Ratio</i>] times as high in
+            those exposed to the potential risk factor indicated in the rows
+            (Y-axis), as compared to those unexposed.
+          </li>
+        </ul>
+      </ul>
+      <br />
+      <b>Studies that investigate diagnostic test performance:</b>
+      <ul>
+        <li>
+          <b>
+            <i>Sensitivity</i>
+          </b>
+          : A / (A + C)
+        </li>
+        <ul>
+          <li>
+            The probability of being positive by the diagnostic test indicated
+            in the rows (Y-axis) when the disease specified in the columns
+            (X-axis) is present is [<i>Sensitivity</i>].
+          </li>
+        </ul>
+
+        <li>
+          <b>
+            <i>Specificity</i>
+          </b>
+          : D / (B + D)
+        </li>
+        <ul>
+          <li>
+            The probability of being negative by the diagnostic test indicated
+            in the rows (Y-axis) when the disease specified in the columns
+            (X-axis) is absent is [<i>Specificity</i>].
+          </li>
+        </ul>
+
+        <li>
+          <b>
+            <i>Positive Predictive Value</i>
+          </b>
+          : A / (A + B)
+        </li>
+        <ul>
+          <li>
+            The probability that a person testing positive by the diagnostic
+            test indicated in the rows (Y-axis) actually has the disease
+            specified in the columns (X-axis) is [
+            <i>Positive Predictive Value</i>].
+          </li>
+        </ul>
+
+        <li>
+          <b>
+            <i>Negative Predictive Value</i>
+          </b>
+          : D / (C + D)
+        </li>
+        <ul>
+          <li>
+            The probability that a person testing negative by the diagnostic
+            test indicated in the rows (Y-axis) does NOT actually have the
+            disease specified in the columns (X-axis) is [
+            <i>Negative Predictive Value</i>].
+          </li>
+        </ul>
+      </ul>
+    </div>
+  );
+};
 
 function TwoByTwoStats(props?: {
   // reflecting 2x2 stats table content
@@ -825,183 +1274,219 @@ function TwoByTwoStats(props?: {
   facetVariableDetails?: facetVariableDetailsType;
 }) {
   return props != null ? (
-    <div
-      className="stats-table"
-      style={
-        props.facetVariableDetails != null
-          ? { width: '750px' }
-          : { margin: '15px 0', marginLeft: '0.9em', width: '750px' }
-      }
-    >
-      <table>
-        {' '}
-        <tbody>
-          <tr>
-            {/* <th></th> */}
-            <td className="stats-table_top-empty-cell"></td>
-            <td className="stats-table_top-empty-cell"></td>
-            <th
-              className="stats-table_top-left-cell"
-              style={{ background: MEDIUM_GRAY, textAlign: 'right' }}
-            >
-              Value
-            </th>
-            <th
-              className="stats-table_top-cell"
-              style={{ background: MEDIUM_GRAY, textAlign: 'center' }}
-            >
-              95% CI
-            </th>
-            <th
-              className="stats-table_top-right-cell"
-              style={{ background: MEDIUM_GRAY, textAlign: 'right' }}
-            >
-              P-value
-            </th>
-          </tr>
-          <tr>
-            <td className="stats-table_leftmost-cell">
-              Association between 2 categorical variables
-            </td>
-            <td className="stats-table_middle-cell">
-              <b>Chi-squared (df=1)</b>
-            </td>
-            <td>{props.chiSq?.value ?? 'n/a'}</td>
-            <td style={{ textAlign: 'center' }}>
-              {props.chiSq?.confidenceInterval ?? 'n/a'}
-            </td>
-            <td className="stats-table_rightmost-cell">
-              {props.chiSq?.pvalue ?? 'n/a'}
-            </td>
-          </tr>
-          <tr>
-            <td className="stats-table_leftmost-cell">
-              Association between 2 categorical variables
-            </td>
-            <td className="stats-table_middle-cell">
-              <b>Fisher's Exact Test</b>
-            </td>
-            <td>{props.fisher?.value ?? 'n/a'}</td>
-            <td style={{ textAlign: 'center' }}>
-              {props.fisher?.confidenceInterval ?? 'n/a'}
-            </td>
-            <td className="stats-table_rightmost-cell">
-              {props.fisher?.pvalue ?? 'n/a'}
-            </td>
-          </tr>
-          <tr>
-            <td className="stats-table_leftmost-cell">
-              Cross-sectional studies
-            </td>
-            <td className="stats-table_middle-cell">
-              <b>Prevalence</b>
-            </td>
-            <td>{props.prevalence?.value ?? 'n/a'}</td>
-            <td style={{ textAlign: 'center' }}>
-              {props.prevalence?.confidenceInterval ?? 'n/a'}
-            </td>
-            <td className="stats-table_rightmost-cell">
-              {props.prevalence?.pvalue ?? 'n/a'}
-            </td>
-          </tr>
-          <tr>
-            <td className="stats-table_leftmost-cell">
-              Case control or Cross-sectional: Risk ratio
-            </td>
-            <td className="stats-table_middle-cell">
-              <b>Odds ratio</b>
-            </td>
-            <td>{props.oddsRatio?.value ?? 'n/a'}</td>
-            <td style={{ textAlign: 'center' }}>
-              {props.oddsRatio?.confidenceInterval ?? 'n/a'}
-            </td>
-            <td className="stats-table_rightmost-cell">
-              {props.oddsRatio?.pvalue ?? 'n/a'}
-            </td>
-          </tr>
-          <tr>
-            <td className="stats-table_leftmost-cell">
-              Cohort studies & randomized controlled trials
-            </td>
-            <td className="stats-table_middle-cell">
-              <b>Risk Ratio</b>
-            </td>
-            <td>{props.relativeRisk?.value ?? 'n/a'}</td>
-            <td style={{ textAlign: 'center' }}>
-              {props.relativeRisk?.confidenceInterval ?? 'n/a'}
-            </td>
-            <td className="stats-table_rightmost-cell">
-              {props.relativeRisk?.pvalue ?? 'n/a'}
-            </td>
-          </tr>
-          <tr>
-            <td className="stats-table_leftmost-cell">
-              Diagnostic test performance
-            </td>
-            <td className="stats-table_middle-cell">
-              <b>Sensitivity</b>
-            </td>
-            <td>{props.sensitivity?.value ?? 'n/a'}</td>
-            <td style={{ textAlign: 'center' }}>
-              {props.sensitivity?.confidenceInterval ?? 'n/a'}
-            </td>
-            <td className="stats-table_rightmost-cell">
-              {props.sensitivity?.pvalue ?? 'n/a'}
-            </td>
-          </tr>
-          <tr>
-            <td className="stats-table_leftmost-cell">
-              Diagnostic test performance
-            </td>
-            <td className="stats-table_middle-cell">
-              <b>Specificity</b>
-            </td>
-            <td>{props.specificity?.value ?? 'n/a'}</td>
-            <td style={{ textAlign: 'center' }}>
-              {props.specificity?.confidenceInterval ?? 'n/a'}
-            </td>
-            <td className="stats-table_rightmost-cell">
-              {props.specificity?.pvalue ?? 'n/a'}
-            </td>
-          </tr>
-          <tr>
-            <td className="stats-table_leftmost-cell">
-              Diagnostic test performance
-            </td>
-            <td className="stats-table_middle-cell">
-              <b>Positive Predictive Value</b>
-            </td>
-            <td>{props.posPredictiveValue?.value ?? 'n/a'}</td>
-            <td style={{ textAlign: 'center' }}>
-              {props.posPredictiveValue?.confidenceInterval ?? 'n/a'}
-            </td>
-            <td className="stats-table_rightmost-cell">
-              {props.posPredictiveValue?.pvalue ?? 'n/a'}
-            </td>
-          </tr>
-          <tr>
-            <td className="stats-table_bottom-left-cell">
-              Diagnostic test performance
-            </td>
-            <td className="stats-table_bottom-middle-cell">
-              <b>Negative Predictive Value</b>
-            </td>
-            <td className="stats-table_bottom-cell">
-              {props.negPredictiveValue?.value ?? 'n/a'}
-            </td>
-            <td
-              className="stats-table_bottom-cell"
-              style={{ textAlign: 'center' }}
-            >
-              {props.negPredictiveValue?.confidenceInterval ?? 'n/a'}
-            </td>
-            <td className="stats-table_bottom-right-cell">
-              {props.negPredictiveValue?.pvalue ?? 'n/a'}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <>
+      {props.facetVariableDetails != null ? (
+        ''
+      ) : (
+        <div
+          style={{
+            marginLeft: '0.9em',
+            width: '750px',
+          }}
+        >
+          {/* 2x2 stats table collapsible banner */}
+          <Banner
+            banner={{
+              type: 'info',
+              // message is used as a basic text
+              message:
+                'Learn about appropriate statistics for each study design.',
+              pinned: true,
+              intense: false,
+              additionalMessage: undefined,
+              // text for showMore link
+              showMoreLinkText: 'Read more...',
+              // text for showless link
+              showLessLinkText: 'Read less...',
+              // color for show more links
+              showMoreLinkColor: '#000000',
+              // is showMoreLink bold?
+              isShowMoreLinkBold: true,
+            }}
+            onClose={() => null}
+            // collapsible content: React.FC
+            CollapsibleContent={StatsCollapsibleBannerContent}
+          />
+        </div>
+      )}
+      <div
+        className="stats-table"
+        style={
+          props.facetVariableDetails != null
+            ? { width: '750px' }
+            : { margin: '15px 0', marginLeft: '0.9em', width: '750px' }
+        }
+      >
+        <table>
+          {' '}
+          <tbody>
+            <tr>
+              {/* <th></th> */}
+              <td className="stats-table_top-empty-cell"></td>
+              <td className="stats-table_top-empty-cell"></td>
+              <th
+                className="stats-table_top-left-cell"
+                style={{ background: MEDIUM_GRAY, textAlign: 'right' }}
+              >
+                Value
+              </th>
+              <th
+                className="stats-table_top-cell"
+                style={{ background: MEDIUM_GRAY, textAlign: 'center' }}
+              >
+                95% CI
+              </th>
+              <th
+                className="stats-table_top-right-cell"
+                style={{ background: MEDIUM_GRAY, textAlign: 'right' }}
+              >
+                P-value
+              </th>
+            </tr>
+            <tr>
+              <td className="stats-table_leftmost-cell">
+                Association between 2 categorical variables
+              </td>
+              <td className="stats-table_middle-cell">
+                <b>Chi-squared (df=1)</b>
+              </td>
+              <td>{props.chiSq?.value ?? 'n/a'}</td>
+              <td style={{ textAlign: 'center' }}>
+                {props.chiSq?.confidenceInterval ?? 'n/a'}
+              </td>
+              <td className="stats-table_rightmost-cell">
+                {props.chiSq?.pvalue ?? 'n/a'}
+              </td>
+            </tr>
+            <tr>
+              <td className="stats-table_leftmost-cell">
+                Association between 2 categorical variables
+              </td>
+              <td className="stats-table_middle-cell">
+                <b>Fisher's Exact Test</b>
+              </td>
+              <td>{props.fisher?.value ?? 'n/a'}</td>
+              <td style={{ textAlign: 'center' }}>
+                {props.fisher?.confidenceInterval ?? 'n/a'}
+              </td>
+              <td className="stats-table_rightmost-cell">
+                {props.fisher?.pvalue ?? 'n/a'}
+              </td>
+            </tr>
+            <tr>
+              <td className="stats-table_leftmost-cell">
+                Cross-sectional studies
+              </td>
+              <td className="stats-table_middle-cell">
+                <b>Prevalence</b>
+              </td>
+              <td>{props.prevalence?.value ?? 'n/a'}</td>
+              <td style={{ textAlign: 'center' }}>
+                {props.prevalence?.confidenceInterval ?? 'n/a'}
+              </td>
+              <td className="stats-table_rightmost-cell">
+                {props.prevalence?.pvalue ?? 'n/a'}
+              </td>
+            </tr>
+            <tr>
+              <td className="stats-table_leftmost-cell">
+                Case control or Cross-sectional: Risk ratio
+              </td>
+              <td className="stats-table_middle-cell">
+                <b>Odds ratio</b>
+              </td>
+              <td>{props.oddsRatio?.value ?? 'n/a'}</td>
+              <td style={{ textAlign: 'center' }}>
+                {props.oddsRatio?.confidenceInterval ?? 'n/a'}
+              </td>
+              <td className="stats-table_rightmost-cell">
+                {props.oddsRatio?.pvalue ?? 'n/a'}
+              </td>
+            </tr>
+            <tr>
+              <td className="stats-table_leftmost-cell">
+                Cohort studies & randomized controlled trials
+              </td>
+              <td className="stats-table_middle-cell">
+                <b>Risk Ratio</b>
+              </td>
+              <td>{props.relativeRisk?.value ?? 'n/a'}</td>
+              <td style={{ textAlign: 'center' }}>
+                {props.relativeRisk?.confidenceInterval ?? 'n/a'}
+              </td>
+              <td className="stats-table_rightmost-cell">
+                {props.relativeRisk?.pvalue ?? 'n/a'}
+              </td>
+            </tr>
+            <tr>
+              <td className="stats-table_leftmost-cell">
+                Diagnostic test performance
+              </td>
+              <td className="stats-table_middle-cell">
+                <b>Sensitivity</b>
+              </td>
+              <td>{props.sensitivity?.value ?? 'n/a'}</td>
+              <td style={{ textAlign: 'center' }}>
+                {props.sensitivity?.confidenceInterval ?? 'n/a'}
+              </td>
+              <td className="stats-table_rightmost-cell">
+                {props.sensitivity?.pvalue ?? 'n/a'}
+              </td>
+            </tr>
+            <tr>
+              <td className="stats-table_leftmost-cell">
+                Diagnostic test performance
+              </td>
+              <td className="stats-table_middle-cell">
+                <b>Specificity</b>
+              </td>
+              <td>{props.specificity?.value ?? 'n/a'}</td>
+              <td style={{ textAlign: 'center' }}>
+                {props.specificity?.confidenceInterval ?? 'n/a'}
+              </td>
+              <td className="stats-table_rightmost-cell">
+                {props.specificity?.pvalue ?? 'n/a'}
+              </td>
+            </tr>
+            <tr>
+              <td className="stats-table_leftmost-cell">
+                Diagnostic test performance
+              </td>
+              <td className="stats-table_middle-cell">
+                <b>Positive Predictive Value</b>
+              </td>
+              <td>{props.posPredictiveValue?.value ?? 'n/a'}</td>
+              <td style={{ textAlign: 'center' }}>
+                {props.posPredictiveValue?.confidenceInterval ?? 'n/a'}
+              </td>
+              <td className="stats-table_rightmost-cell">
+                {props.posPredictiveValue?.pvalue ?? 'n/a'}
+              </td>
+            </tr>
+            <tr>
+              <td className="stats-table_bottom-left-cell">
+                Diagnostic test performance
+              </td>
+              <td className="stats-table_bottom-middle-cell">
+                <b>Negative Predictive Value</b>
+              </td>
+              <td className="stats-table_bottom-cell">
+                {props.negPredictiveValue?.value ?? 'n/a'}
+              </td>
+              <td
+                className="stats-table_bottom-cell"
+                style={{ textAlign: 'center' }}
+              >
+                {props.negPredictiveValue?.confidenceInterval ?? 'n/a'}
+              </td>
+              <td className="stats-table_bottom-right-cell">
+                {props.negPredictiveValue?.pvalue ?? 'n/a'}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </>
   ) : (
     <div
       style={{

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -544,11 +544,7 @@ function MosaicViz(props: Props<Options>) {
                   <>
                     {/* 2x2 stats table banner for facet variable */}
                     {isTwoByTwo && (
-                      <div
-                        style={{
-                          width: '750px',
-                        }}
-                      >
+                      <div>
                         {/* 2x2 stats collapsible banner */}
                         <Banner
                           banner={{


### PR DESCRIPTION
This will resolve https://github.com/VEuPathDB/web-eda/issues/1383 and https://github.com/VEuPathDB/web-eda/issues/1574. Screenshots are attached in the following:

a) showing top and stats table banners at once (unfolded)
![mosaic-2x2-banner00](https://user-images.githubusercontent.com/12802305/220507804-d7b819bc-18a3-4c39-bc50-2bb35e191a73.png)

b) showing top banner content after folded
![mosaic-2x2-banner01](https://user-images.githubusercontent.com/12802305/220507906-8db6f3b9-7e39-4b64-bb4b-12f6c0cffe26.png)

c) showing stats table banner content after folded: no facet variable
![mosaic-2x2-banner02](https://user-images.githubusercontent.com/12802305/220507980-7adde987-721b-4f35-be42-88f2bac5e446.png)

d) a case with a facet variable (unfolded)
![mosaic-2x2-banner03](https://user-images.githubusercontent.com/12802305/220508045-32b12ebe-64c5-448b-a9ab-659dc4864683.png)

