### PR TITLE
Enable quadrant A selections when its corresponding table var is selected

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -99,7 +99,7 @@ const modalPlotContainerStyles = {
   margin: 'auto',
 };
 
-const twoBytwoInputStyle: React.CSSProperties = {
+const twoByTwoInputStyle: React.CSSProperties = {
   display: 'grid',
   gridTemplateColumns: '115px auto',
   marginBottom: '0.5em',
@@ -616,22 +616,20 @@ function MosaicViz(props: Props<Options>) {
   const classes = useInputStyles();
 
   /**
-   * Disabled because reference value selection options are based on the variable's vocabulary
-   * */
-  const areQuadrantSelectionsDisabled =
-    !xAxisVariable?.vocabulary || !yAxisVariable?.vocabulary;
-
-  /**
-   * TEMPORARY: would be better to upgrade CoreUI's SingleSelect (and other selectors) to enable disabling
-   * By using pointerEvents: 'none', we lose the ability to convey messages via tooltips and cursors
-   * */
-  const twoByTwoQuadrantStyle: React.CSSProperties | undefined = !isTwoByTwo
-    ? undefined
-    : {
-        ...twoBytwoInputStyle,
-        pointerEvents: areQuadrantSelectionsDisabled ? 'none' : undefined,
-        opacity: areQuadrantSelectionsDisabled ? 0.5 : 1,
-      };
+   * TEMPORARY:
+   * CoreUI's selection components need to be updated to enable disabling them. We lose the ability to convey messages via tooltips
+   * and cursors when we use pointerEvents: 'none'
+   *
+   * In the meantime, these disabled styles are applied when a variable is missing the vocabulary property because a variable's vocabulary
+   * determines the selection options.
+   */
+  const getReferenceValueStyles = (
+    variableHasVocabulary: boolean
+  ): React.CSSProperties => ({
+    ...twoByTwoInputStyle,
+    pointerEvents: variableHasVocabulary ? undefined : 'none',
+    opacity: variableHasVocabulary ? 1 : 0.5,
+  });
 
   const twoByTwoReferenceValueInputs = !isTwoByTwo
     ? undefined
@@ -647,12 +645,12 @@ function MosaicViz(props: Props<Options>) {
           order: 75,
           content: (
             <>
-              <div style={twoByTwoQuadrantStyle}>
+              <div style={getReferenceValueStyles(!!xAxisVariable?.vocabulary)}>
                 <Tooltip css={{}} title={'Required parameter'}>
                   <span
                     className={classes.label}
                     style={
-                      !xAxisReferenceValue && !areQuadrantSelectionsDisabled
+                      !xAxisReferenceValue && xAxisVariable?.vocabulary
                         ? requiredInputLabelStyle
                         : undefined
                     }
@@ -689,12 +687,12 @@ function MosaicViz(props: Props<Options>) {
                   />
                 </div>
               </div>
-              <div style={twoByTwoQuadrantStyle}>
+              <div style={getReferenceValueStyles(!!yAxisVariable?.vocabulary)}>
                 <Tooltip css={{}} title={'Required parameter'}>
                   <span
                     className={classes.label}
                     style={
-                      !yAxisReferenceValue && !areQuadrantSelectionsDisabled
+                      !yAxisReferenceValue && yAxisVariable?.vocabulary
                         ? requiredInputLabelStyle
                         : undefined
                     }
@@ -746,14 +744,14 @@ function MosaicViz(props: Props<Options>) {
               label: isTwoByTwo ? 'Columns (X-axis)' : 'X-axis',
               role: 'axis',
               titleOverride: isTwoByTwo ? '2x2 table variables' : undefined,
-              styleOverride: isTwoByTwo ? twoBytwoInputStyle : undefined,
+              styleOverride: isTwoByTwo ? twoByTwoInputStyle : undefined,
             },
             {
               name: 'yAxisVariable',
               label: isTwoByTwo ? 'Rows (Y-axis)' : 'Y-axis',
               role: 'axis',
               titleOverride: isTwoByTwo ? '2x2 table variables' : undefined,
-              styleOverride: isTwoByTwo ? twoBytwoInputStyle : undefined,
+              styleOverride: isTwoByTwo ? twoByTwoInputStyle : undefined,
             },
             ...(options?.hideFacetInputs
               ? []


### PR DESCRIPTION
Responds to [these comments](https://github.com/VEuPathDB/web-eda/issues/1575#issuecomment-1440471807) in https://github.com/VEuPathDB/web-eda/issues/1575 (comments shown below for ease):
>@jernestmyers - I spoke to the team and we feel that the Quadrant A values should become active immediately after their corresponding x- or y-axis variable has been selected. Sorry this is different from the mock-ups! And thank you for making the update.