### PR TITLE
let expired jobs be run again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/RunComputeButton.tsx
+++ b/src/lib/core/components/computations/RunComputeButton.tsx
@@ -30,7 +30,7 @@ export function RunComputeButton(props: Props) {
         text={`Generate ${computationAppOverview.displayName} results`}
         textTransform="none"
         onPress={createJob}
-        disabled={status !== 'no-such-job'}
+        disabled={!status || !['no-such-job', 'expired'].includes(status)}
       />
       <div
         style={{
@@ -58,7 +58,7 @@ const colorMap: Record<JobStatus, string> = {
   queued: 'orange',
   'in-progress': 'orange',
   complete: 'green',
-  expired: 'red',
+  expired: 'gray',
   failed: 'red',
 };
 
@@ -70,7 +70,8 @@ const jobStatusDisplay = {
   'in-progress':
     'In progress. You may return later to use results in the visualization.',
   complete: 'Complete. Results saved in the system.',
-  expired: 'Results expired.',
+  expired:
+    'Results expired. Please regenerate results to use this visualization.',
   failed: 'Failed. Contact the VEuPathDB team for support.',
 } as const;
 

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -801,6 +801,11 @@ function ConfiguredVisualizationGrayOut({
               primary: 'Computation failed',
               secondary: 'Please contact us for support.',
             }
+          : computeJobStatus === 'expired'
+          ? {
+              primary: 'Computation expired',
+              secondary: 'Please regenerate results to use this visualization.',
+            }
           : computeJobStatus === 'no-such-job' ||
             !isComputationConfigurationValid
           ? {


### PR DESCRIPTION
Resolves #1637 

Could use some ux feedback on the exact verbiage before merging.

As of right now, the button is active for expired jobs, but when i click the button i see "Requesting" for a moment and then the same expired status. My guess is that when we send that job request to the cs, it's not rerunning. But maybe there's something else going on!

Also i've only found the one expired job so far, so if i successfully get it to restart, we will have 0 known expired jobs that we can use to test :) So i took some screenshots of what things look like:


<img width="1462" alt="Screen Shot 2023-02-22 at 3 03 18 PM" src="https://user-images.githubusercontent.com/11710234/220751792-5e84d9a1-def6-4b18-8522-66b9a67c2b09.png">

<img width="1064" alt="Screen Shot 2023-02-22 at 3 03 34 PM" src="https://user-images.githubusercontent.com/11710234/220751985-35790399-027b-47b6-a3ec-055955423b01.png">
