### PR TITLE
Prevent job deps and status from becoming out-of-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -7,7 +7,6 @@ import { ComputationProps } from './Types';
 import { plugins } from './plugins';
 import { VisualizationPlugin } from '../visualizations/VisualizationPlugin';
 import { AnalysisState } from '../../hooks/analysis';
-import { useStudyMetadata } from '../../hooks/workspace';
 import { useComputeJobStatus } from './ComputeJobStatusHook';
 
 export interface Props extends ComputationProps {
@@ -64,11 +63,7 @@ export function ComputationInstance(props: Props) {
 
   const { url } = useRouteMatch();
 
-  const { jobStatus, createJob } = useComputeJobStatus(
-    analysis,
-    computation,
-    computationAppOverview.computeName
-  );
+  const { jobStatus, createJob } = useComputeJobStatus(analysis, computation);
 
   if (analysis == null || computation == null) return null;
 
@@ -153,7 +148,6 @@ function useComputation(
   analysis: AnalysisState['analysis'],
   computationId: string
 ) {
-  const studyMetadata = useStudyMetadata();
   return useMemo(() => {
     const computation = analysis?.descriptor.computations.find(
       (computation) => computation.computationId === computationId
@@ -166,9 +160,5 @@ function useComputation(
       );
     }
     return computation;
-  }, [
-    analysis?.descriptor.computations,
-    computationId,
-    studyMetadata.rootEntity,
-  ]);
+  }, [analysis?.descriptor.computations, computationId]);
 }


### PR DESCRIPTION
fixes #1600

This PR employs a technique described in https://beta.reactjs.org/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes.

The previous implementation had the job status, which is tracked with a `useState` hook, being set to `undefined` inside of a `useEffect` hook callback function. Callback functions passed to a `useEffect` hook are scheduled to be called after the current render phase is complete. This means that the component would render once with new compute job dependencies, but an old job status.

The implementation in this PR moves that logic to outside of the `useEffect` callback, which ensures that the component will render with both the new compute job dependencies, and a job status of `undefined`, rather than the old job status.