### PR TITLE
enable interactive mode for mosaic facet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.0.19",
+  "version": "4.0.20",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -477,7 +477,6 @@ function MosaicViz(props: Props<Options>) {
     independentAxisLabel: xAxisLabel ?? 'X-axis',
     dependentAxisLabel: yAxisLabel ?? 'Y-axis',
     displayLegend: false,
-    interactive: !isFaceted(data.value) ? true : false,
     showSpinner: data.pending,
     displayLibraryControls: false,
   };


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1477. Tried to find the reason at other components such as Mosaic, facetedMosaicPlot component (at web-components), etc., but I realized it later that interactive prop was disabled for faceted cases. Thus simply removed it. Actually this happened for both Mosaic RxC as well as 2x2. 

Here is an screenshot showing mouseover tooltip at full screen modal with the same example case at the ticket.
![mosaic rxc faceted interactive 1477](https://user-images.githubusercontent.com/12802305/221686317-271c16bd-977a-420a-9490-a783af962d94.png)
