### PR TITLE
fix: hide My Subset downloads if assay entity present

### DIFF
--- a/src/lib/workspace/DownloadTab/index.tsx
+++ b/src/lib/workspace/DownloadTab/index.tsx
@@ -249,15 +249,26 @@ export default function DownloadTab({
     );
   }, [WDKStudyReleases, downloadServiceStudyReleases]);
 
+  // We can't show (or sometimes even create!) my subset tables for entities with many vars. Assays in mbio often
+  // have >1000 vars. Until we can handle these cases, hide the whole My Subset section if any entites
+  // are 'assay' entities.
+  const showMySubset =
+    enhancedEntityData.filter((entity) => entity.displayName.includes('assay'))
+      .length === 0;
+
   return (
     <div style={{ display: 'flex', paddingTop: 10 }}>
       <div key="Column One" style={{ marginRight: 75 }}>
         {dataAccessDeclaration ?? ''}
-        <MySubset
-          datasetId={datasetId}
-          entities={enhancedEntityData}
-          analysisState={analysisState}
-        />
+        {showMySubset ? (
+          <MySubset
+            datasetId={datasetId}
+            entities={enhancedEntityData}
+            analysisState={analysisState}
+          />
+        ) : (
+          <br></br>
+        )}
         {mergedReleaseData.map((release, index) =>
           index === 0 ? (
             <CurrentRelease


### PR DESCRIPTION
Resolves #1652 

The assay entities were giving us such a headache that we just decided to remove the whole My Subset part of the downloads tab. See slack thread in mbio channel for more details. 

I thought about using the entity ids, but then we'd have a hardcoded list of entity ids in the code which didn't seem good either. As long as clinepi doesn't have any assay entities (they don't yet!) then this fix will be okay. Still, this is a temporary fix for a problem that requires a harder solution (allowing tables with >1000 vars). 