### PR TITLE
Skip job status polling if compute config is invalid or undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/src/lib/core/components/computations/ComputationInstance.tsx
@@ -63,7 +63,11 @@ export function ComputationInstance(props: Props) {
 
   const { url } = useRouteMatch();
 
-  const { jobStatus, createJob } = useComputeJobStatus(analysis, computation);
+  const { jobStatus, createJob } = useComputeJobStatus(
+    analysis,
+    computation,
+    computationAppOverview.computeName
+  );
 
   if (analysis == null || computation == null) return null;
 

--- a/src/lib/core/components/computations/ComputeJobStatusHook.ts
+++ b/src/lib/core/components/computations/ComputeJobStatusHook.ts
@@ -14,7 +14,8 @@ export type JobStatus = JobStatusReponse['status'] | 'requesting';
  */
 export function useComputeJobStatus(
   analysis: Analysis | NewAnalysis,
-  computation: Computation
+  computation: Computation,
+  computeName: string,
 ) {
   const computeClient = useComputeClient();
   const studyMetadata = useStudyMetadata();
@@ -39,7 +40,7 @@ export function useComputeJobStatus(
     derivedVariables: analysis.descriptor.derivedVariables,
     filters: analysis.descriptor.subset.descriptor,
     studyId: studyMetadata.id,
-    computeType: computation.descriptor.type,
+    computeName,
   };
 
   // Use a state variable to track current dependencies
@@ -81,8 +82,8 @@ export function useComputeJobStatus(
     // Fetch the job status and update state
     async function updateJobStatus() {
       const { status } = await computeClient.getJobStatus(
-        jobStatusDeps.computeType,
-        omit(jobStatusDeps, 'computeType')
+        jobStatusDeps.computeName,
+        omit(jobStatusDeps, 'computeName')
       );
       if (!cancelled) setJobStatus(status);
     }
@@ -105,8 +106,8 @@ export function useComputeJobStatus(
     if (!computePlugin.isConfigurationValid(jobStatusDeps.config)) return;
     setJobStatus('requesting');
     const { status } = await computeClient.createJob(
-      jobStatusDeps.computeType,
-      omit(jobStatusDeps, 'computeType')
+      jobStatusDeps.computeName,
+      omit(jobStatusDeps, 'computeName')
     );
     setJobStatus(status);
   }, [computePlugin, computeClient, jobStatusDeps]);

--- a/src/lib/core/components/computations/ComputeJobStatusHook.ts
+++ b/src/lib/core/components/computations/ComputeJobStatusHook.ts
@@ -15,7 +15,7 @@ export type JobStatus = JobStatusReponse['status'] | 'requesting';
 export function useComputeJobStatus(
   analysis: Analysis | NewAnalysis,
   computation: Computation,
-  computeName: string,
+  computeName?: string,
 ) {
   const computeClient = useComputeClient();
   const studyMetadata = useStudyMetadata();
@@ -66,7 +66,7 @@ export function useComputeJobStatus(
   // `jobStatus` variable does not need to be included as a dependency.
   useEffect(() => {
     if (
-      jobStatusDeps.config == null ||
+      !jobStatusDeps.computeName ||
       !computePlugin.isConfigurationValid(jobStatusDeps.config)
     )
       return;
@@ -81,6 +81,7 @@ export function useComputeJobStatus(
 
     // Fetch the job status and update state
     async function updateJobStatus() {
+      if (jobStatusDeps.computeName == null) return;
       const { status } = await computeClient.getJobStatus(
         jobStatusDeps.computeName,
         omit(jobStatusDeps, 'computeName')
@@ -105,6 +106,7 @@ export function useComputeJobStatus(
   const createJob = useCallback(async () => {
     if (!computePlugin.isConfigurationValid(jobStatusDeps.config)) return;
     setJobStatus('requesting');
+    if (jobStatusDeps.computeName == null) return;
     const { status } = await computeClient.createJob(
       jobStatusDeps.computeName,
       omit(jobStatusDeps, 'computeName')

--- a/src/lib/core/components/computations/ComputeJobStatusHook.ts
+++ b/src/lib/core/components/computations/ComputeJobStatusHook.ts
@@ -64,6 +64,11 @@ export function useComputeJobStatus(
   // A mutable ref is used for checking the job status so that the `useState`
   // `jobStatus` variable does not need to be included as a dependency.
   useEffect(() => {
+    if (
+      jobStatusDeps.config == null ||
+      !computePlugin.isConfigurationValid(jobStatusDeps.config)
+    )
+      return;
     // Track if effect has been "cancelled"
     let cancelled = false;
     // start the loop
@@ -75,7 +80,6 @@ export function useComputeJobStatus(
 
     // Fetch the job status and update state
     async function updateJobStatus() {
-      if (!computePlugin.isConfigurationValid(jobStatusDeps.config)) return;
       const { status } = await computeClient.getJobStatus(
         jobStatusDeps.computeType,
         omit(jobStatusDeps, 'computeType')


### PR DESCRIPTION
This PR introduces the following changes:
1. Fixes requesting a job status for apps without a compute (such as the `pass` app).
2. Fixes using an app name, instead of a compute name, to request a job status.