### PR TITLE
fix: remove warning banner for longitudinal study downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/DownloadTab/index.tsx
+++ b/src/lib/workspace/DownloadTab/index.tsx
@@ -78,43 +78,6 @@ export default function DownloadTab({
     [datasetId, history, user, dispatch]
   );
 
-  // Longitudinal studies on beta.microbiome are not formatted correctly (missing repeated measures) which affects the download files. This will be fixed for b60.
-  // For now, warn the user about improperly formatted download files.
-  const SHOULD_SHOW_DOWNLOAD_WARNING_KEY = `shouldShowDownloadWarning-${datasetId}`;
-  const [
-    shouldShowWarning,
-    setShouldShowWarning,
-  ] = useLocalBackedState<boolean>(
-    true,
-    SHOULD_SHOW_DOWNLOAD_WARNING_KEY,
-    (boolean) => String(boolean),
-    (string) => string !== 'false'
-  );
-  const studiesForDownloadWarning = [
-    'DS_b3b3ae9838', // BONUS
-    'DS_1102462e80', // Bangladesh
-    'DS_a2f8877e68', // DIABIMMUNE
-    'DS_5a4f8a1791', // DailyBaby
-    'DS_accd1b80f6', // ECAM
-    'DS_d20b9c4094', // Eco-CF
-    'DS_570856e10e', // HMP V1-V3
-    'DS_ca4404e155', // HMP V3-V5
-    'DS_72c94486c6', // MAL-ED 2yr
-    'DS_2e56313a65', // MAL-ED diarrhea
-    'DS_84fcb69f4e', // NICU NEC
-    'DS_d1b9f788dc', // Preterm Resistome I
-    'DS_b9dc726b20', // Preterm Resistome II
-  ];
-  const handleCloseWarning = () => {
-    setShouldShowWarning(false);
-  };
-  const downloadWarningMessage = [
-    'Download files for this dataset may be formatted improperly. Instead, please download files for this study from ',
-    <a href="https://microbiomedb.org">https://microbiomedb.org</a>,
-    '. We appreciate your patience as we transfer to the new system.',
-  ];
-  // End of this section of the temporary solution for funky download files
-
   const dataAccessDeclaration = useMemo(() => {
     if (
       !user ||
@@ -146,19 +109,6 @@ export default function DownloadTab({
           fontSize: '1.4em',
         }}
       >
-        {/* The following is part of the temporary solution for funky mbio download files */}
-        {studiesForDownloadWarning.includes(datasetId) && shouldShowWarning && (
-          <Banner
-            banner={{
-              type: 'warning',
-              message: downloadWarningMessage,
-              pinned: false,
-              intense: false,
-            }}
-            onClose={handleCloseWarning}
-          ></Banner>
-        )}
-        {/* End temporary solution section */}
         {getDataAccessDeclaration(
           studyAccess,
           user.isGuest,
@@ -167,14 +117,7 @@ export default function DownloadTab({
         )}
       </span>
     );
-  }, [
-    user,
-    permission,
-    studyRecord,
-    handleClick,
-    datasetId,
-    shouldShowWarning,
-  ]);
+  }, [user, permission, studyRecord, handleClick, datasetId]);
 
   /**
    * Ok, this is confusing, but there are two places where we need


### PR DESCRIPTION
Resolves #1665 

The banner has been removed!!

<img width="1749" alt="Screen Shot 2023-03-01 at 4 16 50 PM" src="https://user-images.githubusercontent.com/11710234/222266876-39f1caea-ca12-44c2-8a3c-2365ca78a3d2.png">
