### PR TITLE
resolve scroll issue of entity diagram

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.0.18",
+  "version": "4.0.19",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/EDAWorkspace.scss
+++ b/src/lib/workspace/EDAWorkspace.scss
@@ -160,7 +160,13 @@
     overflow-x: auto;
     max-width: 97vw;
     align-items: center;
-    justify-content: space-evenly;
+    justify-content: space-between;
+  }
+
+  // introducing pseudo element
+  .Entities::before,
+  .Entities::after {
+    content: '';
   }
 
   .expanded-diagram {


### PR DESCRIPTION
This will resolve https://github.com/VEuPathDB/web-eda/issues/1567.

Here are example screenshots based on the example in the original ticket.

a) sufficient horizontal width of one's browser: entity diagram is still centered as designed
![entitydiagram01](https://user-images.githubusercontent.com/12802305/222287186-7b3791d8-03d2-47d9-b05b-6cb43891741d.png)


b) intentionally narrowed down the horizontal width of one's browser: the leftmost entity, Clusters, is now shown without cut-off
![entitydiagram02](https://user-images.githubusercontent.com/12802305/222287364-ab5ff0be-3018-448b-8a76-5494c12857e9.png)

