### PR TITLE
hiding map-related Viz icons under FSM

### DIFF
--- a/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
+++ b/src/lib/core/components/fullScreenApps/fullScreenMap.tsx
@@ -369,6 +369,8 @@ function FullScreenMap(props: FullScreenComponentProps) {
               visualizationsOverview={app.visualizations}
               geoConfigs={[geoConfig]}
               onVisualizationCreated={onVisualizationCreated}
+              // declare that this is from FSM
+              isFullScreenMap={true}
             />
           );
         }}

--- a/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -211,7 +211,7 @@ function ConfiguredVisualizations(props: Props) {
                                 (v) => v.visualizationId !== viz.visualizationId
                               )
                             );
-                            /* 
+                            /*
                               Here we're deleting the computation in the event we delete
                               the computation's last remaining visualization.
                             */
@@ -321,6 +321,8 @@ interface NewVisualizationPickerProps
     computationId: string
   ) => void;
   includeHeader?: boolean;
+  // add this prop to clarify whether the parent component is from FSM or not
+  isFullScreenMap?: boolean;
 }
 
 export function NewVisualizationPicker(props: NewVisualizationPickerProps) {
@@ -334,6 +336,7 @@ export function NewVisualizationPicker(props: NewVisualizationPickerProps) {
       history.replace(`../${computationId}/${visualizationId}`);
     },
     includeHeader = true,
+    isFullScreenMap = false,
   } = props;
   const colors = useVizIconColors();
   const history = useHistory();
@@ -359,6 +362,15 @@ export function NewVisualizationPicker(props: NewVisualizationPickerProps) {
           ['desc']
         ).map((vizOverview, index) => {
           const vizPlugin = visualizationPlugins[vizOverview.name!];
+
+          // hiding map-related icons under FSM
+          if (
+            isFullScreenMap &&
+            (vizOverview.name === 'map-markers' ||
+              vizOverview.name === 'map-markers-overlay')
+          )
+            return;
+
           const disabled =
             vizPlugin == null ||
             (vizPlugin.isEnabledInPicker != null &&
@@ -588,7 +600,7 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
                     updateVisualizations((visualizations) =>
                       visualizations.filter((v) => v.visualizationId !== id)
                     );
-                    /* 
+                    /*
                       Here we're deleting the computation in the event we delete
                       the computation's last remaining visualization.
                     */


### PR DESCRIPTION
This will resolve https://github.com/VEuPathDB/web-eda/issues/1664.
What is done is to add a prop to let the child component (NewVisualizationPicker) know whether the parent component is FSM or not. If it is from FSM, then map-related Viz icons is hidden in the Select Visualization.

Here is a screenshot under FSM, which two map-related Viz icons such as map-markers and map-markers-overlay are not shown. Certainly, in a normal mode, the New Visualization shows all Viz icons.

![fsm-geomap-icons](https://user-images.githubusercontent.com/12802305/222537682-621850f7-4c41-4c90-9bbd-80e39b758932.png)


