### PR TITLE
Add warning banner for download table preview for entities with lots of vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
@@ -284,6 +284,7 @@ export default function SubsetDownloadModal({
       analysisState.analysis?.descriptor.subset.descriptor,
       currentEntity,
       mergeKeys,
+      canLoadTablePreview,
     ]
   );
 

--- a/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
@@ -417,7 +417,7 @@ export default function SubsetDownloadModal({
             banner={{
               type: 'warning',
               message:
-                'A table preview is not available for this entity. You can still select variables and download a tabular file.',
+                'Preview is not available. You can still configure and download a tabular file of the filtered dataset.',
             }}
           />
         )}

--- a/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
@@ -365,6 +365,8 @@ export default function SubsetDownloadModal({
 
   const headerMarginBottom = 15;
 
+  const showPreviewTableWarning = currentEntity.variables.length >= 1000;
+
   // Render the table data or instructions on how to get started.
   const renderDataGridArea = () => {
     return (
@@ -406,6 +408,15 @@ export default function SubsetDownloadModal({
             />
           )}
         </div>
+        {showPreviewTableWarning && (
+          <Banner
+            banner={{
+              type: 'warning',
+              message:
+                'A table preview is not available for this entity. You can still select variables and download a tabular file.',
+            }}
+          />
+        )}
         {apiError && (
           <Banner
             banner={{

--- a/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
+++ b/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
@@ -123,6 +123,12 @@ export default function SubsetDownloadModal({
   const theme = useUITheme();
   const primaryColor = theme?.palette.primary.hue[theme.palette.primary.level];
 
+  // In order to show a sortable preview we need a wide table of data.
+  // Wide tables can only be up to 1000 columns. So if there are at least 1000
+  // vars, (1) do not ask for the wide table and (2) tell the user that we can't
+  // show a preview but everything is okay.
+  const canLoadTablePreview = currentEntity.variables.length < 1000;
+
   //   Various Custom Hooks
   const studyRecord = useStudyRecord();
   const studyMetadata = useStudyMetadata();
@@ -223,7 +229,7 @@ export default function SubsetDownloadModal({
   >['serverSidePagination']['fetchPaginatedData'] = useCallback(
     ({ pageSize, pageIndex, sortBy }) => {
       if (!currentEntity) return;
-      if (selectedVariableDescriptors.length === 0) {
+      if (selectedVariableDescriptors.length === 0 || !canLoadTablePreview) {
         setGridData(null);
         return;
       }
@@ -365,8 +371,6 @@ export default function SubsetDownloadModal({
 
   const headerMarginBottom = 15;
 
-  const showPreviewTableWarning = currentEntity.variables.length >= 1000;
-
   // Render the table data or instructions on how to get started.
   const renderDataGridArea = () => {
     return (
@@ -408,7 +412,7 @@ export default function SubsetDownloadModal({
             />
           )}
         </div>
-        {showPreviewTableWarning && (
+        {!canLoadTablePreview && (
           <Banner
             banner={{
               type: 'warning',
@@ -567,7 +571,7 @@ export default function SubsetDownloadModal({
             </button>
             {dataLoading && <LoadingOverlay />}
           </div>
-        ) : selectedVariableDescriptors.length === 0 ? (
+        ) : selectedVariableDescriptors.length === 0 || !canLoadTablePreview ? (
           <div
             style={{
               width: '100%',


### PR DESCRIPTION
Resolves #1652 

Current behavior
<img width="1782" alt="Screen Shot 2023-03-03 at 10 58 13 AM" src="https://user-images.githubusercontent.com/11710234/222766988-37610a8c-a666-44eb-a753-014bdc3c0dd4.png">


Now it looks like:
<img width="1744" alt="Screen Shot 2023-03-03 at 10 58 38 AM" src="https://user-images.githubusercontent.com/11710234/222767081-e193ec8d-402c-4c6f-b667-166a0868e55e.png">

That error banner only comes up once i've clicked at least one var.

Is it weird to have both banners? I thought about removing the server-error banner, but i dont want to hide errors that might be useful to us to see later...