### PR TITLE
Replace location when compute config changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/computations/Utils.ts
+++ b/src/lib/core/components/computations/Utils.ts
@@ -231,5 +231,5 @@ function handleRouting(
   urlToReplace: string,
   urlToReplaceWith: string
 ) {
-  history.push(baseUrl.replace(urlToReplace, urlToReplaceWith));
+  history.replace(baseUrl.replace(urlToReplace, urlToReplaceWith));
 }


### PR DESCRIPTION
This will prevent "backing" into a non-existent compute config.