### PR TITLE
fixing mosaic tooltip for no facet variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/eda",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "dependencies": {
     "debounce-promise": "^3.1.2",
     "fp-ts": "^2.9.3",

--- a/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -483,6 +483,7 @@ function MosaicViz(props: Props<Options>) {
     independentAxisLabel: xAxisLabel ?? 'X-axis',
     dependentAxisLabel: yAxisLabel ?? 'Y-axis',
     displayLegend: false,
+    interactive: true,
     showSpinner: data.pending,
     displayLibraryControls: false,
   };


### PR DESCRIPTION
This will resolve https://github.com/VEuPathDB/web-eda/issues/1681. 

As Dave thought, I was looking into web-components' components, however, I just found that plot interaction was simply not to be activated (didn't pass the prop when no facet variable was selected). I confirmed that this would work for both Mosaic 2x2 and RxC, including with or without facet variable.

Here is a screenshot:
![mosaic-no-facet-tooltip1](https://user-images.githubusercontent.com/12802305/223200397-42babf2f-7a1e-4524-820a-d9a319ecceeb.png)
  