### PR TITLE
changing colormap range

### DIFF
--- a/src/lib/core/api/DataClient/types.ts
+++ b/src/lib/core/api/DataClient/types.ts
@@ -293,6 +293,7 @@ export const ScatterplotResponseData = array(
     // changed to string array
     seriesX: array(string),
     seriesY: array(string),
+    seriesGradientColorscale: array(string),
     smoothedMeanX: array(string),
     smoothedMeanY: array(number),
     smoothedMeanSE: array(number),


### PR DESCRIPTION
This PR intends to resolve https://github.com/VEuPathDB/web-components/issues/454. Made a mistake to resolve this in a very complex manner but later much simpler solution was found. Also, it is worth noting that while I was working on the colormap range, I noticed that the decimal points in the colormap's tick labels were often too long, so I have set it up to be 2 decimal points at a web-components PR, https://github.com/VEuPathDB/web-components/pull/464.

Two logics are currently utilized to find out the colormap range: a) no filter case: taking Min/Max between displayMin/Max and rangeMin/Max using the metadata of the overlay variable; b) with filter(s) (subsetted): taking Min/Max between computed data-based Min/Max and displayMin/Max from the metadata of the overlay variable. I saw that there is a work in progress to have a filter-aware metadata by Danielle, but it appeared to me that it is still underway.

Some screenshots are attached in the following (GEMS1 data): BMI-for-age-z-score has displayMin/Max of (-30, 20) and rangeMin/Max of (-15.3, 273.91).

a) No filter is used: in this case, range becomes (-30, 273.91)
![scatter-colormap-withoutFilters](https://user-images.githubusercontent.com/12802305/226765493-d6538fd1-b0ee-407b-84f7-31f3c662a388.png)

b) with filters: data-based Min/Max is (-11.05, 143.33)
![scatter-colormap-withFilters](https://user-images.githubusercontent.com/12802305/226765664-79d2fb70-4670-4023-9687-84433208339d.png)

c) Age, matched case for the overlay variable with filters: Sequential colormap. No displayMin/Max; data-based Min/Max is (33, 56), thus final range becomes the data-based Min/Max
![scatter-colormap-withFilters-sequential](https://user-images.githubusercontent.com/12802305/226766647-1fd31548-541e-4a93-983f-9a100b82abb2.png)
